### PR TITLE
Added pycache to default ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,9 @@ typings/
 # parcel-bundler cache (https://parceljs.org/)
 .cache
 
+# Python cache
+**/__pycache__/
+
 # Next.js build output
 .next
 

--- a/upload.ts
+++ b/upload.ts
@@ -15,7 +15,7 @@ const defaultDockerIgnore = `# Default .dockerignore file for Defang
 **/.idea
 **/.next
 **/.vscode
-**/__pycache__
+**/__pycache__/
 **/compose.yaml
 **/compose.yml
 **/defang.exe


### PR DESCRIPTION
Fixes DefangLabs/defang#781 for `pulumi-defang` repo

- added `**/__pycache__/ ` to top-level `.gitignore` 
- added a trailing slash `/` (for consistency, done also in `samples` repo) to the `**/__pycache__` in `upload.ts`