### PR TITLE
Ignore Dockerfile/Compose files by default

### DIFF
--- a/tests/test1/ignored.Dockerfile
+++ b/tests/test1/ignored.Dockerfile
@@ -1,0 +1,2 @@
+# This file should not be included in the build context
+FROM scratch

--- a/upload.ts
+++ b/upload.ts
@@ -6,6 +6,8 @@ import { promises as stream } from "stream";
 import * as tar from "tar";
 
 const SOURCE_DATE_EPOCH = process.env["SOURCE_DATE_EPOCH"] ?? "315532800"; // defaults to 1980-01-01, same as nix-shell
+
+// The default .dockerignore for projects that don't have one. Keep in sync with pkg/cli/context.go in CLI repo.
 const defaultDockerIgnore = `# Default .dockerignore file for Defang
 **/.DS_Store
 **/.direnv
@@ -18,13 +20,15 @@ const defaultDockerIgnore = `# Default .dockerignore file for Defang
 **/__pycache__
 **/compose.yaml
 **/compose.yml
-**/defang.exe
 **/docker-compose.yaml
 **/docker-compose.yml
 **/node_modules
 **/Thumbs.db
+Dockerfile
+*.Dockerfile
 # Ignore our own binary, but only in the root to avoid ignoring subfolders
 defang
+defang.exe
 # Ignore our project-level state
 .defang`;
 

--- a/upload.ts
+++ b/upload.ts
@@ -9,17 +9,21 @@ const SOURCE_DATE_EPOCH = process.env["SOURCE_DATE_EPOCH"] ?? "315532800"; // de
 
 // The default .dockerignore for projects that don't have one. Keep in sync with pkg/cli/context.go in CLI repo.
 const defaultDockerIgnore = `# Default .dockerignore file for Defang
-**/.DS_Store
+**/__pycache__
 **/.direnv
+**/.DS_Store
 **/.envrc
 **/.git
 **/.github
 **/.idea
 **/.next
 **/.vscode
-**/__pycache__
+**/compose.*.yaml
+**/compose.*.yml
 **/compose.yaml
 **/compose.yml
+**/docker-compose.*.yaml
+**/docker-compose.*.yml
 **/docker-compose.yaml
 **/docker-compose.yml
 **/node_modules


### PR DESCRIPTION
The `Dockerfile` and `compose.*.yaml` is not needed inside the build, so we should ignore it by default. Ideally the runtime images only have runtime files in them, so no build-only artifacts. If these do get included, there are a couple of unwanted side-effects:
- Changing `compose.yaml` for one service would cause all services to get rebuilt if the `compose.yaml` is in their build contexts, even though only one service config got changed.
- Sometimes (lazy) devs add secrets into the `compose.yaml` and these could end up being copied into the runtime container image because of a `COPY . .` statement.
- A change to a `Dockerfile` doesn't always result in a new image, because the resulting image might be the same, but if the `Dockerfile` ends up being copied into the image, that it will by definition always change the image and cause a service replacement.

Should we include the `.dockerignore` in the build context? This way, Kaniko will use it when it evaluates `COPY . .` etc. But a bit tricky to be including files that weren't there to begin with. We'd have to ignore `.dockerignore` itself, for one.

