### PR TITLE
upgrade CI to Node 24 to fix broken npm in Node 22.22.2 tool cache

### DIFF
--- a/.github/actions/build-sdk/action.yml
+++ b/.github/actions/build-sdk/action.yml
@@ -36,13 +36,14 @@ runs:
       name: Setup Node
       uses: actions/setup-node@v6
       with:
-        node-version: 22.x
+        # Node 24 ships with npm 11, which supports OIDC Trusted Publishers natively.
+        # We upgraded from Node 22 because the Node 22.22.2 tool cache on the ubuntu-24.04
+        # runner image ships with a broken npm 10.9.7 (promise-retry missing from its module
+        # tree), which causes `npm install -g` to fail. Node 24 avoids this entirely.
+        # See: https://github.com/actions/runner-images/issues/13883
+        #      https://github.com/nodejs/node/pull/62463
+        node-version: 24.x
         registry-url: https://registry.npmjs.org
-
-    - if: ${{ inputs.language == 'nodejs' }}
-      name: Upgrade npm for Trusted Publishers support
-      shell: bash
-      run: npm install -g npm@11.12.1
 
     - if: ${{ inputs.language == 'dotnet' }}
       name: Setup DotNet


### PR DESCRIPTION
## Summary

- Upgrades the nodejs SDK build job from Node 22 to Node 24
- Drops the `npm install -g` upgrade step entirely — Node 24 ships with npm 11 natively, which already supports OIDC Trusted Publishers

## Background

The ubuntu-24.04 runner image `20260329.72.1` ships with a corrupted Node 22.22.2 tool cache: npm 10.9.7 is missing `promise-retry` from its own module tree, causing any `npm install -g` to fail with `MODULE_NOT_FOUND`. This broke all nodejs SDK build jobs.

Previous attempts to work around this by pinning `npm@11.12.1` also failed because the underlying npm is too broken to upgrade itself.

See:
- https://github.com/actions/runner-images/issues/13883
- https://github.com/nodejs/node/pull/62463

## Test plan

- [ ] All three nodejs SDK build jobs (aws, gcp, azure) pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)