### PR TITLE
fix(gcp): add explicit Build→BucketIAMMember dependency to prevent IAM 403 on first deploy

### DIFF
--- a/provider/defanggcp/gcp/artifact_registry.go
+++ b/provider/defanggcp/gcp/artifact_registry.go
@@ -16,12 +16,13 @@ import (
 // BuildInfra holds GCP infrastructure shared across all services with build configs.
 // Created once per project when at least one service defines a build context.
 type BuildInfra struct {
-	Repository     *artifactregistry.Repository
-	ServiceAccount *serviceaccount.Account
-	BuildBucket    *storage.Bucket     // GCS bucket for uploading local build contexts
-	RepositoryURL  pulumi.StringOutput // e.g. "us-central1-docker.pkg.dev/project/repo"
-	Region         string
-	GcpProject     string
+	Repository      *artifactregistry.Repository
+	ServiceAccount  *serviceaccount.Account
+	BuildBucket     *storage.Bucket       // GCS bucket for uploading local build contexts
+	BucketIAMMember *storage.BucketIAMMember // grants build SA objectViewer on BuildBucket
+	RepositoryURL   pulumi.StringOutput   // e.g. "us-central1-docker.pkg.dev/project/repo"
+	Region          string
+	GcpProject      string
 }
 
 // hasBuildConfig reports whether any service in the map defines a build context.
@@ -145,11 +146,12 @@ func createBuildInfra(
 		return nil, fmt.Errorf("binding artifact registry admin role: %w", err)
 	}
 
-	if _, err := storage.NewBucketIAMMember(ctx, projectName+"-artifacts-viewer", &storage.BucketIAMMemberArgs{
+	artifactsViewer, err := storage.NewBucketIAMMember(ctx, projectName+"-artifacts-viewer", &storage.BucketIAMMemberArgs{
 		Bucket: bucket.Name,
 		Role:   pulumi.String("roles/storage.objectViewer"),
 		Member: pulumi.Sprintf("serviceAccount:%v", bsa.Email),
-	}, saOpts...); err != nil {
+	}, saOpts...)
+	if err != nil {
 		return nil, fmt.Errorf("binding storage.objectViewer role: %w", err)
 	}
 
@@ -172,11 +174,12 @@ func createBuildInfra(
 	repoURL := pulumi.Sprintf("%s-docker.pkg.dev/%s/%s", region, gcpProject, ar.Name)
 
 	return &BuildInfra{
-		Repository:     ar,
-		ServiceAccount: bsa,
-		BuildBucket:    bucket,
-		RepositoryURL:  repoURL,
-		Region:         region,
-		GcpProject:     gcpProject,
+		Repository:      ar,
+		ServiceAccount:  bsa,
+		BuildBucket:     bucket,
+		BucketIAMMember: artifactsViewer,
+		RepositoryURL:   repoURL,
+		Region:          region,
+		GcpProject:      gcpProject,
 	}, nil
 }

--- a/provider/defanggcp/gcp/image.go
+++ b/provider/defanggcp/gcp/image.go
@@ -224,6 +224,17 @@ func buildServiceImage(
 		return nil, err
 	}
 
+	// The Build resource must depend on the BucketIAMMember so Pulumi waits for
+	// the IAM binding before submitting the Cloud Build job. GCP IAM changes can
+	// take ~60 s to propagate globally; without this explicit edge the build SA
+	// may not yet have objectViewer access when Cloud Build attempts to read the
+	// source archive, causing a 403 on first deploy.
+	buildOpts := make([]pulumi.ResourceOption, 0, len(opts)+1)
+	buildOpts = append(buildOpts, opts...)
+	if infra.BucketIAMMember != nil {
+		buildOpts = append(buildOpts, pulumi.DependsOn([]pulumi.Resource{infra.BucketIAMMember}))
+	}
+
 	var buildRes gcpBuildResource
 	if err := ctx.RegisterResource(
 		"defang-gcp:defanggcp:Build",
@@ -240,7 +251,7 @@ func buildServiceImage(
 			"diskSizeGb":     pulumi.Int(cloudBuildDiskSizeGb(shmBytes)),
 		},
 		&buildRes,
-		opts...,
+		buildOpts...,
 	); err != nil {
 		return nil, fmt.Errorf("creating Build resource for %s: %w", serviceName, err)
 	}

--- a/provider/defanggcp/gcp/image_test.go
+++ b/provider/defanggcp/gcp/image_test.go
@@ -1,9 +1,12 @@
 package gcp
 
 import (
+	"strings"
 	"sync"
 	"testing"
 
+	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/serviceaccount"
+	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/storage"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/assert"
@@ -22,6 +25,25 @@ func (testMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.Pro
 }
 
 func (testMocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
+	return args.Args, nil
+}
+
+// buildDepsSpy records the Pulumi dependency URNs of the Build custom resource.
+type buildDepsSpy struct {
+	mu        sync.Mutex
+	buildDeps []string
+}
+
+func (m *buildDepsSpy) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+	if args.TypeToken == "defang-gcp:defanggcp:Build" && args.RegisterRPC != nil {
+		m.mu.Lock()
+		m.buildDeps = args.RegisterRPC.GetDependencies()
+		m.mu.Unlock()
+	}
+	return args.Name + "_id", args.Inputs, nil
+}
+
+func (m *buildDepsSpy) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
 	return args.Args, nil
 }
 
@@ -322,4 +344,64 @@ func TestBuildSourceDigest(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestBuildServiceImageDependsOnBucketIAMMember verifies that the Build custom
+// resource has an explicit Pulumi dependency on the BucketIAMMember that grants
+// the build service account read access to the artifacts bucket. Without this
+// dependency Cloud Build can be submitted before GCP IAM has propagated the
+// binding (~60 s window), causing a 403 on first deploy.
+func TestBuildServiceImageDependsOnBucketIAMMember(t *testing.T) {
+	spy := &buildDepsSpy{}
+
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		iamMember, err := storage.NewBucketIAMMember(ctx, "artifacts-viewer", &storage.BucketIAMMemberArgs{
+			Bucket: pulumi.String("my-artifacts-bucket"),
+			Role:   pulumi.String("roles/storage.objectViewer"),
+			Member: pulumi.String("serviceAccount:build@proj.iam.gserviceaccount.com"),
+		})
+		if err != nil {
+			return err
+		}
+
+		sa, err := serviceaccount.NewAccount(ctx, "build-sa", &serviceaccount.AccountArgs{
+			AccountId: pulumi.String("build-sa"),
+		})
+		if err != nil {
+			return err
+		}
+
+		infra := &BuildInfra{
+			ServiceAccount:  sa,
+			BucketIAMMember: iamMember,
+			RepositoryURL:   pulumi.String("us-central1-docker.pkg.dev/proj/repo").ToStringOutput(),
+			Region:          "us-central1",
+			GcpProject:      "proj",
+		}
+
+		svc := compose.ServiceConfig{
+			Build: &compose.BuildConfig{
+				// Use a gs:// URI so resolveSourceURI skips the BucketObject creation
+				// and we don't need a real BuildBucket in infra.
+				Context: pulumi.String("gs://my-artifacts-bucket/context.zip"),
+			},
+		}
+
+		_, err = buildServiceImage(ctx, "my-svc", svc, infra)
+		return err
+	}, pulumi.WithMocks("proj", "stack", spy))
+
+	require.NoError(t, err)
+
+	// The Build resource must list the BucketIAMMember as a dependency so that
+	// Pulumi waits for the IAM binding before submitting the Cloud Build job.
+	var hasBucketIAMDep bool
+	for _, dep := range spy.buildDeps {
+		if strings.Contains(dep, "BucketIAMMember") {
+			hasBucketIAMDep = true
+			break
+		}
+	}
+	assert.True(t, hasBucketIAMDep,
+		"Build resource must depend on BucketIAMMember (got deps: %v)", spy.buildDeps)
 }


### PR DESCRIPTION
## Summary

Fixes #115.

- Added `BucketIAMMember *storage.BucketIAMMember` field to `BuildInfra` and populated it in `createBuildInfra`
- In `buildServiceImage`, appended `pulumi.DependsOn([]pulumi.Resource{infra.BucketIAMMember})` to the Build resource options so Pulumi waits for the IAM binding before submitting the Cloud Build job
- Added `TestBuildServiceImageDependsOnBucketIAMMember`: a spy mock that captures `RegisterRPC.GetDependencies()` on the Build resource and asserts the `BucketIAMMember` URN is present

## Test plan

- [ ] New unit test `TestBuildServiceImageDependsOnBucketIAMMember` passes (confirmed locally)
- [ ] All existing unit tests pass (confirmed via pre-push hook)
- [ ] Deploy a project with a `build.context` service to GCP and verify `pulumi up` succeeds on first run without a 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)