### PR TITLE
fix: rename Postgres access SG to avoid duplicate URN with RDS SG

### DIFF
--- a/provider/defangaws/postgres.go
+++ b/provider/defangaws/postgres.go
@@ -50,7 +50,7 @@ func (*Postgres) Construct(
 
 	configProvider := provideraws.NewConfigProvider(inputs.ProjectName)
 
-	sg, err := awssdk.NewSecurityGroup(ctx, name, &awssdk.SecurityGroupArgs{
+	sg, err := awssdk.NewSecurityGroup(ctx, name+"-access", &awssdk.SecurityGroupArgs{
 		VpcId:       inputs.Infra.VpcID,
 		Description: pulumi.String("Security group for Postgres"),
 		Egress: awssdk.SecurityGroupEgressArray{

--- a/tests/aws/postgres_test.go
+++ b/tests/aws/postgres_test.go
@@ -1,14 +1,49 @@
 package aws
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 
 	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	defangaws "github.com/DefangLabs/pulumi-defang/provider/defangaws"
 	"github.com/DefangLabs/pulumi-defang/tests/testutil"
 )
+
+func TestConstructAwsPostgresHasNoDuplicateResourceNames(t *testing.T) {
+	var mu sync.Mutex
+	seen := map[string]bool{}
+	mock := &integration.MockResourceMonitor{
+		NewResourceF: func(args integration.MockResourceArgs) (string, property.Map, error) {
+			key := fmt.Sprintf("%s::%s", args.TypeToken, args.Name)
+			mu.Lock()
+			defer mu.Unlock()
+			assert.False(t, seen[key], "duplicate resource %s", key)
+			seen[key] = true
+			return args.Name, args.Inputs, nil
+		},
+	}
+	server := testutil.MustNewServer(defangaws.Name, defangaws.Provider(), integration.WithMocks(mock))
+
+	_, err := server.Construct(p.ConstructRequest{
+		Urn: testutil.AwsURN("Postgres"),
+		Inputs: property.NewMap(map[string]property.Value{
+			"project_name": property.New("myproject"),
+			"image":        property.New("postgres:16"),
+			"postgres":     property.New(property.NewMap(map[string]property.Value{})),
+			"aws": property.New(property.NewMap(map[string]property.Value{
+				"vpcID": property.New("vpc-12345"),
+			})),
+		}),
+	})
+
+	require.NoError(t, err)
+}
 
 func TestConstructAwsPostgres(t *testing.T) {
 	server := testutil.MakeTestServer()


### PR DESCRIPTION
## Summary

Fixes a duplicate resource URN error when using the `Postgres` component standalone (not via `Project`):

```
aws:ec2:SecurityGroup (db):
  error: Duplicate resource URN 'urn:pulumi:jordan::ecs::defang-aws:index:Postgres$aws:ec2/securityGroup:SecurityGroup::db'; try giving it a unique name
```

### Why two security groups are needed

The Postgres component creates two security groups with distinct responsibilities:

1. **Access SG** (`name-access`) — created in `Postgres.Construct` (`postgres.go`). This represents the caller/application side. It is passed as `privateSgID` into `CreateRDS` and used as an ingress *source* rule on the RDS SG, meaning: "allow traffic from whatever holds this SG into the database."

2. **RDS SG** (`name`) — created inside `CreateRDS` (`aws/rds.go`). This is attached directly to the RDS instance and has an ingress rule allowing TCP on the Postgres port from the access SG above.

This two-SG pattern is necessary so that other resources (e.g. ECS tasks) can be granted access to the RDS instance simply by being associated with the access SG, without opening the RDS to arbitrary CIDRs.

### The bug

When using the `Postgres` component directly, both SGs were children of the same component resource and both used the component's name (e.g. `"db"`) as their Pulumi resource name — producing a duplicate URN. The fix renames the access SG to `name+"-access"` to make the names distinct.

When `newPostgresComponent` (used by `Project`) calls `CreateRDS`, the `privateSgID` is sourced from the shared infra (`infra.PrivateSgID`) rather than created locally, so only the RDS SG is created as a child — no duplicate.

## Test plan

- [x] Added `TestConstructAwsPostgresHasNoDuplicateResourceNames` — uses `MockResourceMonitor` to assert every `(type, name)` pair is unique across all resources created by the component; this test fails on the buggy code and passes after the fix
- [ ] Deploy a stack using `defangAws.Postgres` directly and confirm no duplicate URN error
- [ ] Confirm existing `Project`-based postgres services are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)