### PR TITLE
fix(ci): install setuptools before building Python SDK

### DIFF
--- a/.github/actions/build-sdk/action.yml
+++ b/.github/actions/build-sdk/action.yml
@@ -43,6 +43,11 @@ runs:
       with:
         python-version: "3.12" # should match the version in shell.nix
 
+    - if: ${{ inputs.language == 'python' }}
+      name: Install Python build dependencies
+      shell: bash
+      run: pip install setuptools
+
     - name: Build SDK
       shell: bash
       run: make ${{ inputs.language }}_sdk_${{ inputs.provider }}


### PR DESCRIPTION
## Summary

- `actions/setup-python@v6` no longer bundles `setuptools` by default (following PEP 517)
- This caused `python3 setup.py build sdist` to fail with `ModuleNotFoundError: No module named 'setuptools'` in all three Python SDK publish jobs
- Fix: add an explicit `pip install setuptools` step after Python setup in the `build-sdk` action

Fixes the failures seen in https://github.com/DefangLabs/pulumi-defang/actions/runs/24576450886

## Test plan

- [ ] Trigger a release and verify Python SDK jobs (`Publish SDKs (python, aws/gcp/azure)`) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)