### PR TITLE
fix(ci): add pull-requests write permission for regenerate-examples job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ permissions:
   contents: write # Allows writing releases
   packages: write # Allows publishing packages
   id-token: write # Required for requesting the JWT before publishing to Pypi and NPM
+  pull-requests: write # Allows creating PRs for regenerated examples
 
 env:
   PROVIDER: "defang"


### PR DESCRIPTION
## Summary

- The `regenerate_examples` job calls `gh pr create` to open a PR with regenerated examples after each release
- The workflow's top-level `permissions` block was missing `pull-requests: write`, causing the step to fail with `GraphQL: Resource not accessible by integration`
- Adds the missing permission

## Root cause

Observed in run [#24576450886](https://github.com/DefangLabs/pulumi-defang/actions/runs/24576450886/job/71866987029):
```
pull request create failed: GraphQL: Resource not accessible by integration (createPullRequest)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)