### PR TITLE
expose privateSgID through aws infra

### DIFF
--- a/provider/defangaws/aws/ecs.go
+++ b/provider/defangaws/aws/ecs.go
@@ -40,11 +40,11 @@ type SharedInfra struct {
 	ProjectDomain    string
 	ZoneId           pulumi.StringPtrInput // Route53 zone ID for public DNS records (empty if no public DNS)
 	// shared "private SG" — attached to all services, no ingress rules
-	PrivateSgID    pulumi.IDPtrInput  `pulumi:"privateSgID,optional"`
-	AlbSG          *ec2.SecurityGroup // nil if no ALB
-	HttpListener   *lb.Listener       // nil if no ALB
-	HttpsListener  *lb.Listener       // nil if no ALB
-	Alb            *lb.LoadBalancer   // nil if no ALB
+	PrivateSgID    pulumi.StringPtrInput `pulumi:"privateSgID,optional"`
+	AlbSG          *ec2.SecurityGroup    // nil if no ALB
+	HttpListener   *lb.Listener          // nil if no ALB
+	HttpsListener  *lb.Listener          // nil if no ALB
+	Alb            *lb.LoadBalancer      // nil if no ALB
 	Region         string
 	BuildInfra     *BuildInfra       // nil if no builds needed
 	PublicEcrCache *PullThroughCache // ECR public pull-through cache
@@ -197,7 +197,7 @@ func createServiceSG(
 			rule.SecurityGroups = pulumi.StringArray{infra.AlbSG.ID()}
 		case isPrivate && infra.PrivateSgID != nil:
 			// Private port: allow from privateSG as source SG
-			rule.SecurityGroups = pulumi.StringArray{infra.PrivateSgID.ToIDPtrOutput().Elem()}
+			rule.SecurityGroups = pulumi.StringArray{infra.PrivateSgID.ToStringPtrOutput().Elem()}
 		default:
 			// Public port: allow from anywhere
 			rule.CidrBlocks = pulumi.StringArray{pulumi.String("0.0.0.0/0")}
@@ -215,7 +215,7 @@ func createServiceSG(
 			Protocol:    pulumi.String("icmp"),
 		}
 		if isPrivate && infra.PrivateSgID != nil {
-			icmpRule.SecurityGroups = pulumi.StringArray{infra.PrivateSgID.ToIDPtrOutput().Elem()}
+			icmpRule.SecurityGroups = pulumi.StringArray{infra.PrivateSgID.ToStringPtrOutput().Elem()}
 		} else {
 			icmpRule.CidrBlocks = pulumi.StringArray{pulumi.String("0.0.0.0/0")}
 		}
@@ -529,7 +529,7 @@ func CreateECSService(
 	// Attach both per-service SG and shared privateSG (matches TS: [privateSg])
 	securityGroups := pulumi.StringArray{serviceSG.ID()}
 	if infra.PrivateSgID != nil {
-		securityGroups = append(securityGroups, infra.PrivateSgID.ToIDPtrOutput().Elem())
+		securityGroups = append(securityGroups, infra.PrivateSgID.ToStringPtrOutput().Elem())
 	}
 	ecsServiceArgs := &ecs.ServiceArgs{
 		Cluster:        clusterArn,

--- a/provider/defangaws/aws/ecs.go
+++ b/provider/defangaws/aws/ecs.go
@@ -39,15 +39,16 @@ type SharedInfra struct {
 	PrivateDomain    string
 	ProjectDomain    string
 	ZoneId           pulumi.StringPtrInput // Route53 zone ID for public DNS records (empty if no public DNS)
-	PrivateSgID      pulumi.IDPtrInput     // shared "private SG" — attached to all services, no ingress rules
-	AlbSG            *ec2.SecurityGroup    // nil if no ALB
-	HttpListener     *lb.Listener          // nil if no ALB
-	HttpsListener    *lb.Listener          // nil if no ALB
-	Alb              *lb.LoadBalancer      // nil if no ALB
-	Region           string
-	BuildInfra       *BuildInfra       // nil if no builds needed
-	PublicEcrCache   *PullThroughCache // ECR public pull-through cache
-	SkipNatGW        bool
+	// shared "private SG" — attached to all services, no ingress rules
+	PrivateSgID    pulumi.IDPtrInput  `pulumi:"privateSgID,optional"`
+	AlbSG          *ec2.SecurityGroup // nil if no ALB
+	HttpListener   *lb.Listener       // nil if no ALB
+	HttpsListener  *lb.Listener       // nil if no ALB
+	Alb            *lb.LoadBalancer   // nil if no ALB
+	Region         string
+	BuildInfra     *BuildInfra       // nil if no builds needed
+	PublicEcrCache *PullThroughCache // ECR public pull-through cache
+	SkipNatGW      bool
 	Policies
 }
 

--- a/provider/defangaws/aws/elasticache.go
+++ b/provider/defangaws/aws/elasticache.go
@@ -187,7 +187,7 @@ func CreateElasticache(
 	svc compose.ServiceConfig,
 	vpcID pulumi.StringInput,
 	privateSubnetIDs pulumi.StringArrayInput,
-	privateSgID pulumi.IDPtrInput,
+	privateSgID pulumi.StringPtrInput,
 	deps []pulumi.Resource,
 	opts ...pulumi.ResourceOption,
 ) (*ElasticacheResult, error) {
@@ -247,7 +247,7 @@ func CreateElasticache(
 	// callers (e.g. unit tests) may omit it.
 	var ingressSGs pulumi.StringArray
 	if privateSgID != nil {
-		ingressSGs = pulumi.StringArray{privateSgID.ToIDPtrOutput().Elem()}
+		ingressSGs = pulumi.StringArray{privateSgID.ToStringPtrOutput().Elem()}
 	}
 	cacheSG, err := ec2.NewSecurityGroup(ctx, serviceName, &ec2.SecurityGroupArgs{
 		VpcId:       vpcID.ToStringOutput(),

--- a/provider/defangaws/aws/rds.go
+++ b/provider/defangaws/aws/rds.go
@@ -170,7 +170,7 @@ func CreateRDS(
 	svc compose.ServiceConfig,
 	vpcID pulumi.StringInput,
 	privateSubnetIDs pulumi.StringArrayInput,
-	privateSgID pulumi.IDPtrInput,
+	privateSgID pulumi.StringPtrInput,
 	deps []pulumi.Resource,
 	opts ...pulumi.ResourceOption,
 ) (*RDSResult, error) {
@@ -206,7 +206,7 @@ func CreateRDS(
 	// callers (e.g. unit tests) may omit it.
 	var ingressSGs pulumi.StringArray
 	if privateSgID != nil {
-		ingressSGs = pulumi.StringArray{privateSgID.ToIDPtrOutput().Elem()}
+		ingressSGs = pulumi.StringArray{privateSgID.ToStringPtrOutput().Elem()}
 	}
 	rdsSG, err := ec2.NewSecurityGroup(ctx, serviceName, &ec2.SecurityGroupArgs{
 		VpcId:       vpcID.ToStringOutput(),

--- a/sdk/v2/go/defang-aws/aws/pulumiTypes.go
+++ b/sdk/v2/go/defang-aws/aws/pulumiTypes.go
@@ -14,6 +14,7 @@ import (
 var _ = internal.GetEnvOrDefault
 
 type SharedInfra struct {
+	PrivateSgID      *string  `pulumi:"privateSgID"`
 	PrivateSubnetIDs []string `pulumi:"privateSubnetIDs"`
 	PrivateZoneID    *string  `pulumi:"privateZoneID"`
 	PublicSubnetIDs  []string `pulumi:"publicSubnetIDs"`
@@ -32,6 +33,7 @@ type SharedInfraInput interface {
 }
 
 type SharedInfraArgs struct {
+	PrivateSgID      pulumi.StringPtrInput   `pulumi:"privateSgID"`
 	PrivateSubnetIDs pulumi.StringArrayInput `pulumi:"privateSubnetIDs"`
 	PrivateZoneID    pulumi.StringPtrInput   `pulumi:"privateZoneID"`
 	PublicSubnetIDs  pulumi.StringArrayInput `pulumi:"publicSubnetIDs"`
@@ -115,6 +117,10 @@ func (o SharedInfraOutput) ToSharedInfraPtrOutputWithContext(ctx context.Context
 	}).(SharedInfraPtrOutput)
 }
 
+func (o SharedInfraOutput) PrivateSgID() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v SharedInfra) *string { return v.PrivateSgID }).(pulumi.StringPtrOutput)
+}
+
 func (o SharedInfraOutput) PrivateSubnetIDs() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v SharedInfra) []string { return v.PrivateSubnetIDs }).(pulumi.StringArrayOutput)
 }
@@ -153,6 +159,15 @@ func (o SharedInfraPtrOutput) Elem() SharedInfraOutput {
 		var ret SharedInfra
 		return ret
 	}).(SharedInfraOutput)
+}
+
+func (o SharedInfraPtrOutput) PrivateSgID() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *SharedInfra) *string {
+		if v == nil {
+			return nil
+		}
+		return v.PrivateSgID
+	}).(pulumi.StringPtrOutput)
 }
 
 func (o SharedInfraPtrOutput) PrivateSubnetIDs() pulumi.StringArrayOutput {


### PR DESCRIPTION
## Summary

- Changes `PrivateSgID` in `SharedInfra` from `pulumi.IDPtrInput` to `pulumi.StringPtrInput` so it can be passed in from external callers via the Pulumi input type system
- Adds `pulumi:"privateSgID,optional"` struct tag to expose it as a typed field in the SDK
- Updates `SharedInfraArgs` and `SharedInfraOutput` in the generated Go SDK to include `PrivateSgID` as an optional `pulumi.StringPtrInput`
- Updates all internal usages in `ecs.go`, `elasticache.go`, and `rds.go` to use `.ToStringPtrOutput().Elem()` instead of `.ToIDPtrOutput().Elem()`

## Test plan

- [ ] Unit tests pass (`make test_unit`)
- [ ] Provider tests pass (`make test_provider`)
- [ ] Callers can pass `privateSgID` through `SharedInfraArgs` without manual type wrapping