### PR TITLE
perf: remove redundant go_sdk hook from goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,8 +5,7 @@ archives:
     name_template: '{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}'
 
 before:
-  hooks:
-    - make go_sdk
+  hooks: []
 
 builds:
   - id: pulumi-resource-defang-aws


### PR DESCRIPTION
## Summary
- Removes redundant `make go_sdk` hook from goreleaser before hooks that was regenerating the Go SDK before each of the 18 binary builds (3 providers × 3 OSes × 2 architectures), adding ~5-10 minutes of overhead during release
- SDK generation is already handled by the separate `publish_sdk` job after binaries are built