### PR TITLE
restore goreleaser parallelism to 3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
         with:
           distribution: goreleaser # either 'goreleaser' (default) or 'goreleaser-pro'
-          args: -p 4 release
+          args: -p 3 release
           version: v2
 
   publish_sdk:


### PR DESCRIPTION
release workflows are failing with this annotation

> The hosted runner lost communication with the server. Anything in your workflow that terminates the runner process, starves it for CPU/Memory, or blocks its network access can cause this error.

https://github.com/DefangLabs/pulumi-defang/actions/runs/24680216198