### PR TITLE
avoid building multi-cloud image for now

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,7 +172,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        clouds: [aws, gcp, azure, all]
+        clouds: [aws, gcp, azure]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
This job is currently timing out after 50+ minutes. it's not critical at the moment, so i'm going to remove it for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker image publishing workflow for cloud provider deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->