### PR TITLE
Config set cd image refs in Fabric

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,3 +274,14 @@ jobs:
             done
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # Pin the Azure CD image ref (digest) in the Defang Fabric so deployments use this exact build.
+      - name: Set cd_image_azure config in Defang
+        if: matrix.clouds == 'azure'
+        uses: DefangLabs/defang-github-action@v2
+        with:
+          project: ecs
+          stack: awsprod1
+          command: "config set -e cd_image_azure"
+        env:
+          cd_image_azure: defang.azurecr.io/cd@${{ steps.build-push.outputs.digest }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -278,7 +278,7 @@ jobs:
       # Pin the Azure CD image ref (digest) in the Defang Fabric so deployments use this exact build.
       - name: Set cd_image_azure config in Defang
         if: matrix.clouds == 'azure'
-        uses: DefangLabs/defang-github-action@v2
+        uses: DefangLabs/defang-github-action@2298c7cafed90f258a6b9d2fdfff4821b0382c89 # v2.2.0
         with:
           project: ecs
           stack: awsprod1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -278,10 +278,10 @@ jobs:
       # Pin the Azure CD image ref (digest) in the Defang Fabric so deployments use this exact build.
       - name: Set cd_image_azure config in Defang
         if: matrix.clouds == 'azure'
-        uses: DefangLabs/defang-github-action@2298c7cafed90f258a6b9d2fdfff4821b0382c89 # v2.2.0
+        uses: DefangLabs/defang-github-action@482e8e65caf00bc48ad2044d0e41cde178b3e2b6 # v2.3.0
         with:
           project: ecs
-          stack: awsprod1
+          stack: awsprod1oidc
           command: "config set -e cd_image_azure"
         env:
           cd_image_azure: defang.azurecr.io/cd@${{ steps.build-push.outputs.digest }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,7 +111,9 @@ jobs:
     needs:
       - build_sdks
     permissions:
+      contents: read
       packages: write
+      id-token: write # for defang OIDC login
     steps:
       - name: Checkout Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -139,6 +141,7 @@ jobs:
           fi
 
       - name: Build and push image to GHCR
+        id: build-push
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: . # build context must be repo root to include generated Go SDK
@@ -147,3 +150,17 @@ jobs:
           tags: ${{ env.IMAGE_REPO }}:${{ env.IMAGE_TAG }}
           cache-from: type=gha,scope=${{ github.workflow }}
           cache-to: type=gha,scope=${{ github.workflow }},mode=max
+
+      # Pin the staging Azure CD image ref (digest) in the Defang Fabric. Only on main-branch
+      # pushes — PR runs would otherwise have every contributor overwrite the staging config.
+      - name: Set cd_image_ configs in Defang
+        if: github.event_name == 'push'
+        uses: DefangLabs/defang-github-action@v2
+        with:
+          project: ecs
+          stack: awsstaging
+          command: "config set -e cd_image_azure cd_image_aws cd_image_gcp"
+        env:
+          cd_image_azure: ${{ env.IMAGE_REPO }}@${{ steps.build-push.outputs.digest }}
+          cd_image_aws: ${{ env.IMAGE_REPO }}@${{ steps.build-push.outputs.digest }}
+          cd_image_gcp: ${{ env.IMAGE_REPO }}@${{ steps.build-push.outputs.digest }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,7 +155,7 @@ jobs:
       # Pin the staging Azure CD image ref (digest) in the Defang Fabric. Only on main-branch
       # pushes — PR runs would otherwise have every contributor overwrite the staging config.
       - name: Set cd_image_ configs in Defang
-        if: github.event_name == 'push'
+        # if: github.event_name == 'push'
         uses: DefangLabs/defang-github-action@2298c7cafed90f258a6b9d2fdfff4821b0382c89 # v2.2.0
         with:
           project: ecs
@@ -165,3 +165,4 @@ jobs:
           cd_image_azure: ${{ env.IMAGE_REPO }}@${{ steps.build-push.outputs.digest }}
           cd_image_aws: ${{ env.IMAGE_REPO }}@${{ steps.build-push.outputs.digest }}
           cd_image_gcp: ${{ env.IMAGE_REPO }}@${{ steps.build-push.outputs.digest }}
+          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,7 +155,7 @@ jobs:
       # Pin the staging Azure CD image ref (digest) in the Defang Fabric. Only on main-branch
       # pushes — PR runs would otherwise have every contributor overwrite the staging config.
       - name: Set cd_image_ configs in Defang
-        # if: github.event_name == 'push'
+        if: github.event_name == 'push'
         uses: DefangLabs/defang-github-action@482e8e65caf00bc48ad2044d0e41cde178b3e2b6 # v2.3.0
         with:
           project: ecs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,6 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build_sdks
+    environment: defang-staging
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,7 +160,7 @@ jobs:
         with:
           project: ecs
           stack: awsstagingoidc
-          command: "config set -e cd_image_azure cd_image_aws cd_image_gcp"
+          command: config set -e cd_image_azure # cd_image_cb cd_image_gcp"
         env:
           cd_image_azure: ${{ env.IMAGE_REPO }}@${{ steps.build-push.outputs.digest }}
           # cd_image_cb: ${{ env.IMAGE_REPO }}@${{ steps.build-push.outputs.digest }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,7 +159,7 @@ jobs:
         uses: DefangLabs/defang-github-action@2298c7cafed90f258a6b9d2fdfff4821b0382c89 # v2.2.0
         with:
           project: ecs
-          stack: awsstaging
+          stack: awsstagingoidc
           command: "config set -e cd_image_azure cd_image_aws cd_image_gcp"
         env:
           cd_image_azure: ${{ env.IMAGE_REPO }}@${{ steps.build-push.outputs.digest }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,7 +155,7 @@ jobs:
       # pushes — PR runs would otherwise have every contributor overwrite the staging config.
       - name: Set cd_image_ configs in Defang
         if: github.event_name == 'push'
-        uses: DefangLabs/defang-github-action@v2
+        uses: DefangLabs/defang-github-action@2298c7cafed90f258a6b9d2fdfff4821b0382c89 # v2.2.0
         with:
           project: ecs
           stack: awsstaging

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,7 +156,7 @@ jobs:
       # pushes — PR runs would otherwise have every contributor overwrite the staging config.
       - name: Set cd_image_ configs in Defang
         # if: github.event_name == 'push'
-        uses: DefangLabs/defang-github-action@2298c7cafed90f258a6b9d2fdfff4821b0382c89 # v2.2.0
+        uses: DefangLabs/defang-github-action@482e8e65caf00bc48ad2044d0e41cde178b3e2b6 # v2.3.0
         with:
           project: ecs
           stack: awsstagingoidc
@@ -165,4 +165,3 @@ jobs:
           cd_image_azure: ${{ env.IMAGE_REPO }}@${{ steps.build-push.outputs.digest }}
           cd_image_aws: ${{ env.IMAGE_REPO }}@${{ steps.build-push.outputs.digest }}
           cd_image_gcp: ${{ env.IMAGE_REPO }}@${{ steps.build-push.outputs.digest }}
-          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,5 +163,5 @@ jobs:
           command: "config set -e cd_image_azure cd_image_aws cd_image_gcp"
         env:
           cd_image_azure: ${{ env.IMAGE_REPO }}@${{ steps.build-push.outputs.digest }}
-          cd_image_aws: ${{ env.IMAGE_REPO }}@${{ steps.build-push.outputs.digest }}
-          cd_image_gcp: ${{ env.IMAGE_REPO }}@${{ steps.build-push.outputs.digest }}
+          # cd_image_cb: ${{ env.IMAGE_REPO }}@${{ steps.build-push.outputs.digest }}
+          # cd_image_gcp: ${{ env.IMAGE_REPO }}@${{ steps.build-push.outputs.digest }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Azure deployment so releases use the exact built Docker image digest, preventing mismatched deployments.
  * Strengthened staging workflow with proper authentication and explicit image tracking to ensure staging deployments use the intended build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->