### PR TITLE
feat(postgres): expose InstanceIdentifier for CloudWatch MetricAlarms

### DIFF
--- a/provider/defangaws/postgres.go
+++ b/provider/defangaws/postgres.go
@@ -28,6 +28,10 @@ type PostgresInputs struct {
 type PostgresOutputs struct {
 	pulumi.ResourceState
 	Endpoint pulumi.StringOutput `pulumi:"endpoint"`
+	// InstanceIdentifier is the RDS DBInstanceIdentifier — exposed so consumers
+	// can attach their own CloudWatch MetricAlarms (e.g. CPUUtilization,
+	// FreeStorageSpace) without Defang owning the notification destination.
+	InstanceIdentifier pulumi.StringOutput `pulumi:"instance_identifier"`
 	// Dependency is an internal-only handle (CNAME record or RDS instance) used by
 	// downstream services for ordering. Untagged — not part of the SDK schema.
 	Dependency pulumi.Resource
@@ -106,8 +110,12 @@ func createPostgres(
 		pulumix.Output[string](rdsResult.Instance.Address), func(addr string) string {
 			return fmt.Sprintf("%s:%d", addr, 5432)
 		}))
+	comp.InstanceIdentifier = rdsResult.Instance.Identifier
 
-	if err := ctx.RegisterResourceOutputs(comp, pulumi.Map{"endpoint": comp.Endpoint}); err != nil {
+	if err := ctx.RegisterResourceOutputs(comp, pulumi.Map{
+		"endpoint":            comp.Endpoint,
+		"instance_identifier": comp.InstanceIdentifier,
+	}); err != nil {
 		return fmt.Errorf("registering outputs for %s: %w", serviceName, err)
 	}
 	return nil

--- a/provider/defangaws/postgres.go
+++ b/provider/defangaws/postgres.go
@@ -16,7 +16,7 @@ type Postgres struct{}
 
 // PostgresInputs defines the inputs for a standalone AWS RDS Postgres instance.
 type PostgresInputs struct {
-	ProjectName string                   `pulumi:"project_name"`
+	ProjectName string                   `pulumi:"projectName"`
 	Postgres    *compose.PostgresConfig  `pulumi:"postgres,optional"`
 	Image       *string                  `pulumi:"image,optional"`
 	Deploy      *compose.DeployConfig    `pulumi:"deploy,optional"`
@@ -31,7 +31,7 @@ type PostgresOutputs struct {
 	// InstanceIdentifier is the RDS DBInstanceIdentifier — exposed so consumers
 	// can attach their own CloudWatch MetricAlarms (e.g. CPUUtilization,
 	// FreeStorageSpace) without Defang owning the notification destination.
-	InstanceIdentifier pulumi.StringOutput `pulumi:"instance_identifier"`
+	InstanceIdentifier pulumi.StringOutput `pulumi:"instanceIdentifier"`
 	// Dependency is an internal-only handle (CNAME record or RDS instance) used by
 	// downstream services for ordering. Untagged — not part of the SDK schema.
 	Dependency pulumi.Resource
@@ -113,8 +113,8 @@ func createPostgres(
 	comp.InstanceIdentifier = rdsResult.Instance.Identifier
 
 	if err := ctx.RegisterResourceOutputs(comp, pulumi.Map{
-		"endpoint":            comp.Endpoint,
-		"instance_identifier": comp.InstanceIdentifier,
+		"endpoint":           comp.Endpoint,
+		"instanceIdentifier": comp.InstanceIdentifier,
 	}); err != nil {
 		return fmt.Errorf("registering outputs for %s: %w", serviceName, err)
 	}

--- a/provider/defangaws/redis.go
+++ b/provider/defangaws/redis.go
@@ -16,7 +16,7 @@ type Redis struct{}
 
 // RedisInputs defines the inputs for a standalone AWS ElastiCache Redis instance.
 type RedisInputs struct {
-	ProjectName string                      `pulumi:"project_name"`
+	ProjectName string                      `pulumi:"projectName"`
 	Redis       *compose.RedisConfig        `pulumi:"redis,optional"`
 	Image       *string                     `pulumi:"image,optional"`
 	Ports       []compose.ServicePortConfig `pulumi:"ports,optional"`

--- a/provider/defangaws/service.go
+++ b/provider/defangaws/service.go
@@ -19,7 +19,7 @@ type Service struct{}
 type ServiceInputs struct {
 	Image       string                      `pulumi:"image"`
 	Platform    *string                     `pulumi:"platform,optional"`
-	ProjectName string                      `pulumi:"project_name"`
+	ProjectName string                      `pulumi:"projectName"`
 	Ports       []compose.ServicePortConfig `pulumi:"ports,optional"`
 	Deploy      *compose.DeployConfig       `pulumi:"deploy,optional"`
 	Environment map[string]*string          `pulumi:"environment,optional"`

--- a/provider/defangazure/postgres.go
+++ b/provider/defangazure/postgres.go
@@ -14,7 +14,7 @@ type Postgres struct{}
 
 // AzurePostgresInputs defines the inputs for a standalone Azure PostgreSQL Flexible Server.
 type AzurePostgresInputs struct {
-	ProjectName string                  `pulumi:"project_name"`
+	ProjectName string                  `pulumi:"projectName"`
 	Image       *string                 `pulumi:"image,optional"`
 	Postgres    *compose.PostgresConfig `pulumi:"postgres,optional"`
 	Deploy      *compose.DeployConfig   `pulumi:"deploy,optional"`

--- a/provider/defangazure/redis.go
+++ b/provider/defangazure/redis.go
@@ -14,7 +14,7 @@ type Redis struct{}
 
 // AzureRedisInputs defines the inputs for a standalone Azure Cache for Redis instance.
 type AzureRedisInputs struct {
-	ProjectName string                `pulumi:"project_name"`
+	ProjectName string                `pulumi:"projectName"`
 	Image       *string               `pulumi:"image,optional"`
 	Redis       *compose.RedisConfig  `pulumi:"redis,optional"`
 	Deploy      *compose.DeployConfig `pulumi:"deploy,optional"`

--- a/provider/defanggcp/postgres.go
+++ b/provider/defanggcp/postgres.go
@@ -14,7 +14,7 @@ type Postgres struct{}
 
 // PostgresInputs defines the inputs for a standalone GCP Cloud SQL Postgres instance.
 type PostgresInputs struct {
-	ProjectName string                      `pulumi:"project_name"`
+	ProjectName string                      `pulumi:"projectName"`
 	Postgres    *compose.PostgresConfig     `pulumi:"postgres,optional"`
 	Image       *string                     `pulumi:"image,optional"`
 	Deploy      *compose.DeployConfig       `pulumi:"deploy,optional"`

--- a/provider/defanggcp/service.go
+++ b/provider/defanggcp/service.go
@@ -19,7 +19,7 @@ type Service struct{}
 type ServiceInputs struct {
 	Image       string                      `pulumi:"image"`
 	Platform    *string                     `pulumi:"platform,optional"`
-	ProjectName string                      `pulumi:"project_name"`
+	ProjectName string                      `pulumi:"projectName"`
 	Ports       []compose.ServicePortConfig `pulumi:"ports,optional"`
 	Deploy      *compose.DeployConfig       `pulumi:"deploy,optional"`
 	Environment map[string]*string          `pulumi:"environment,optional"`

--- a/sdk/v2/go/defang-aws/postgres.go
+++ b/sdk/v2/go/defang-aws/postgres.go
@@ -17,8 +17,8 @@ import (
 type Postgres struct {
 	pulumi.ResourceState
 
-	Endpoint            pulumi.StringOutput `pulumi:"endpoint"`
-	Instance_identifier pulumi.StringOutput `pulumi:"instance_identifier"`
+	Endpoint           pulumi.StringOutput `pulumi:"endpoint"`
+	InstanceIdentifier pulumi.StringOutput `pulumi:"instanceIdentifier"`
 }
 
 // NewPostgres registers a new resource with the given unique name, arguments, and options.
@@ -38,22 +38,22 @@ func NewPostgres(ctx *pulumi.Context,
 }
 
 type postgresArgs struct {
-	Aws          *aws.SharedInfra        `pulumi:"aws"`
-	Deploy       *compose.DeployConfig   `pulumi:"deploy"`
-	Environment  map[string]string       `pulumi:"environment"`
-	Image        *string                 `pulumi:"image"`
-	Postgres     *compose.PostgresConfig `pulumi:"postgres"`
-	Project_name string                  `pulumi:"project_name"`
+	Aws         *aws.SharedInfra        `pulumi:"aws"`
+	Deploy      *compose.DeployConfig   `pulumi:"deploy"`
+	Environment map[string]string       `pulumi:"environment"`
+	Image       *string                 `pulumi:"image"`
+	Postgres    *compose.PostgresConfig `pulumi:"postgres"`
+	ProjectName string                  `pulumi:"projectName"`
 }
 
 // The set of arguments for constructing a Postgres resource.
 type PostgresArgs struct {
-	Aws          aws.SharedInfraPtrInput
-	Deploy       compose.DeployConfigPtrInput
-	Environment  pulumi.StringMapInput
-	Image        *string
-	Postgres     compose.PostgresConfigPtrInput
-	Project_name string
+	Aws         aws.SharedInfraPtrInput
+	Deploy      compose.DeployConfigPtrInput
+	Environment pulumi.StringMapInput
+	Image       *string
+	Postgres    compose.PostgresConfigPtrInput
+	ProjectName string
 }
 
 func (PostgresArgs) ElementType() reflect.Type {
@@ -97,8 +97,8 @@ func (o PostgresOutput) Endpoint() pulumi.StringOutput {
 	return o.ApplyT(func(v *Postgres) pulumi.StringOutput { return v.Endpoint }).(pulumi.StringOutput)
 }
 
-func (o PostgresOutput) Instance_identifier() pulumi.StringOutput {
-	return o.ApplyT(func(v *Postgres) pulumi.StringOutput { return v.Instance_identifier }).(pulumi.StringOutput)
+func (o PostgresOutput) InstanceIdentifier() pulumi.StringOutput {
+	return o.ApplyT(func(v *Postgres) pulumi.StringOutput { return v.InstanceIdentifier }).(pulumi.StringOutput)
 }
 
 func init() {

--- a/sdk/v2/go/defang-aws/postgres.go
+++ b/sdk/v2/go/defang-aws/postgres.go
@@ -17,7 +17,8 @@ import (
 type Postgres struct {
 	pulumi.ResourceState
 
-	Endpoint pulumi.StringOutput `pulumi:"endpoint"`
+	Endpoint            pulumi.StringOutput `pulumi:"endpoint"`
+	Instance_identifier pulumi.StringOutput `pulumi:"instance_identifier"`
 }
 
 // NewPostgres registers a new resource with the given unique name, arguments, and options.
@@ -94,6 +95,10 @@ func (o PostgresOutput) ToPostgresOutputWithContext(ctx context.Context) Postgre
 
 func (o PostgresOutput) Endpoint() pulumi.StringOutput {
 	return o.ApplyT(func(v *Postgres) pulumi.StringOutput { return v.Endpoint }).(pulumi.StringOutput)
+}
+
+func (o PostgresOutput) Instance_identifier() pulumi.StringOutput {
+	return o.ApplyT(func(v *Postgres) pulumi.StringOutput { return v.Instance_identifier }).(pulumi.StringOutput)
 }
 
 func init() {

--- a/sdk/v2/go/defang-aws/redis.go
+++ b/sdk/v2/go/defang-aws/redis.go
@@ -37,24 +37,24 @@ func NewRedis(ctx *pulumi.Context,
 }
 
 type redisArgs struct {
-	Aws          *aws.SharedInfra            `pulumi:"aws"`
-	Deploy       *compose.DeployConfig       `pulumi:"deploy"`
-	Environment  map[string]string           `pulumi:"environment"`
-	Image        *string                     `pulumi:"image"`
-	Ports        []compose.ServicePortConfig `pulumi:"ports"`
-	Project_name string                      `pulumi:"project_name"`
-	Redis        *compose.RedisConfig        `pulumi:"redis"`
+	Aws         *aws.SharedInfra            `pulumi:"aws"`
+	Deploy      *compose.DeployConfig       `pulumi:"deploy"`
+	Environment map[string]string           `pulumi:"environment"`
+	Image       *string                     `pulumi:"image"`
+	Ports       []compose.ServicePortConfig `pulumi:"ports"`
+	ProjectName string                      `pulumi:"projectName"`
+	Redis       *compose.RedisConfig        `pulumi:"redis"`
 }
 
 // The set of arguments for constructing a Redis resource.
 type RedisArgs struct {
-	Aws          aws.SharedInfraPtrInput
-	Deploy       compose.DeployConfigPtrInput
-	Environment  pulumi.StringMapInput
-	Image        *string
-	Ports        compose.ServicePortConfigArrayInput
-	Project_name string
-	Redis        compose.RedisConfigPtrInput
+	Aws         aws.SharedInfraPtrInput
+	Deploy      compose.DeployConfigPtrInput
+	Environment pulumi.StringMapInput
+	Image       *string
+	Ports       compose.ServicePortConfigArrayInput
+	ProjectName string
+	Redis       compose.RedisConfigPtrInput
 }
 
 func (RedisArgs) ElementType() reflect.Type {

--- a/sdk/v2/go/defang-aws/service.go
+++ b/sdk/v2/go/defang-aws/service.go
@@ -37,32 +37,32 @@ func NewService(ctx *pulumi.Context,
 }
 
 type serviceArgs struct {
-	Aws          *aws.SharedInfra            `pulumi:"aws"`
-	Command      []string                    `pulumi:"command"`
-	Deploy       *compose.DeployConfig       `pulumi:"deploy"`
-	DomainName   *string                     `pulumi:"domainName"`
-	Entrypoint   []string                    `pulumi:"entrypoint"`
-	Environment  map[string]string           `pulumi:"environment"`
-	HealthCheck  *compose.HealthCheckConfig  `pulumi:"healthCheck"`
-	Image        string                      `pulumi:"image"`
-	Platform     *string                     `pulumi:"platform"`
-	Ports        []compose.ServicePortConfig `pulumi:"ports"`
-	Project_name string                      `pulumi:"project_name"`
+	Aws         *aws.SharedInfra            `pulumi:"aws"`
+	Command     []string                    `pulumi:"command"`
+	Deploy      *compose.DeployConfig       `pulumi:"deploy"`
+	DomainName  *string                     `pulumi:"domainName"`
+	Entrypoint  []string                    `pulumi:"entrypoint"`
+	Environment map[string]string           `pulumi:"environment"`
+	HealthCheck *compose.HealthCheckConfig  `pulumi:"healthCheck"`
+	Image       string                      `pulumi:"image"`
+	Platform    *string                     `pulumi:"platform"`
+	Ports       []compose.ServicePortConfig `pulumi:"ports"`
+	ProjectName string                      `pulumi:"projectName"`
 }
 
 // The set of arguments for constructing a Service resource.
 type ServiceArgs struct {
-	Aws          aws.SharedInfraPtrInput
-	Command      pulumi.StringArrayInput
-	Deploy       compose.DeployConfigPtrInput
-	DomainName   *string
-	Entrypoint   pulumi.StringArrayInput
-	Environment  pulumi.StringMapInput
-	HealthCheck  compose.HealthCheckConfigPtrInput
-	Image        string
-	Platform     *string
-	Ports        compose.ServicePortConfigArrayInput
-	Project_name string
+	Aws         aws.SharedInfraPtrInput
+	Command     pulumi.StringArrayInput
+	Deploy      compose.DeployConfigPtrInput
+	DomainName  *string
+	Entrypoint  pulumi.StringArrayInput
+	Environment pulumi.StringMapInput
+	HealthCheck compose.HealthCheckConfigPtrInput
+	Image       string
+	Platform    *string
+	Ports       compose.ServicePortConfigArrayInput
+	ProjectName string
 }
 
 func (ServiceArgs) ElementType() reflect.Type {

--- a/sdk/v2/go/defang-azure/postgres.go
+++ b/sdk/v2/go/defang-azure/postgres.go
@@ -36,20 +36,20 @@ func NewPostgres(ctx *pulumi.Context,
 }
 
 type postgresArgs struct {
-	Deploy       *compose.DeployConfig   `pulumi:"deploy"`
-	Environment  map[string]string       `pulumi:"environment"`
-	Image        *string                 `pulumi:"image"`
-	Postgres     *compose.PostgresConfig `pulumi:"postgres"`
-	Project_name string                  `pulumi:"project_name"`
+	Deploy      *compose.DeployConfig   `pulumi:"deploy"`
+	Environment map[string]string       `pulumi:"environment"`
+	Image       *string                 `pulumi:"image"`
+	Postgres    *compose.PostgresConfig `pulumi:"postgres"`
+	ProjectName string                  `pulumi:"projectName"`
 }
 
 // The set of arguments for constructing a Postgres resource.
 type PostgresArgs struct {
-	Deploy       compose.DeployConfigPtrInput
-	Environment  pulumi.StringMapInput
-	Image        *string
-	Postgres     compose.PostgresConfigPtrInput
-	Project_name string
+	Deploy      compose.DeployConfigPtrInput
+	Environment pulumi.StringMapInput
+	Image       *string
+	Postgres    compose.PostgresConfigPtrInput
+	ProjectName string
 }
 
 func (PostgresArgs) ElementType() reflect.Type {

--- a/sdk/v2/go/defang-azure/redis.go
+++ b/sdk/v2/go/defang-azure/redis.go
@@ -36,20 +36,20 @@ func NewRedis(ctx *pulumi.Context,
 }
 
 type redisArgs struct {
-	Deploy       *compose.DeployConfig `pulumi:"deploy"`
-	Environment  map[string]string     `pulumi:"environment"`
-	Image        *string               `pulumi:"image"`
-	Project_name string                `pulumi:"project_name"`
-	Redis        *compose.RedisConfig  `pulumi:"redis"`
+	Deploy      *compose.DeployConfig `pulumi:"deploy"`
+	Environment map[string]string     `pulumi:"environment"`
+	Image       *string               `pulumi:"image"`
+	ProjectName string                `pulumi:"projectName"`
+	Redis       *compose.RedisConfig  `pulumi:"redis"`
 }
 
 // The set of arguments for constructing a Redis resource.
 type RedisArgs struct {
-	Deploy       compose.DeployConfigPtrInput
-	Environment  pulumi.StringMapInput
-	Image        *string
-	Project_name string
-	Redis        compose.RedisConfigPtrInput
+	Deploy      compose.DeployConfigPtrInput
+	Environment pulumi.StringMapInput
+	Image       *string
+	ProjectName string
+	Redis       compose.RedisConfigPtrInput
 }
 
 func (RedisArgs) ElementType() reflect.Type {

--- a/sdk/v2/go/defang-gcp/postgres.go
+++ b/sdk/v2/go/defang-gcp/postgres.go
@@ -36,22 +36,22 @@ func NewPostgres(ctx *pulumi.Context,
 }
 
 type postgresArgs struct {
-	Deploy       *compose.DeployConfig       `pulumi:"deploy"`
-	Environment  map[string]string           `pulumi:"environment"`
-	Image        *string                     `pulumi:"image"`
-	Ports        []compose.ServicePortConfig `pulumi:"ports"`
-	Postgres     *compose.PostgresConfig     `pulumi:"postgres"`
-	Project_name string                      `pulumi:"project_name"`
+	Deploy      *compose.DeployConfig       `pulumi:"deploy"`
+	Environment map[string]string           `pulumi:"environment"`
+	Image       *string                     `pulumi:"image"`
+	Ports       []compose.ServicePortConfig `pulumi:"ports"`
+	Postgres    *compose.PostgresConfig     `pulumi:"postgres"`
+	ProjectName string                      `pulumi:"projectName"`
 }
 
 // The set of arguments for constructing a Postgres resource.
 type PostgresArgs struct {
-	Deploy       compose.DeployConfigPtrInput
-	Environment  pulumi.StringMapInput
-	Image        *string
-	Ports        compose.ServicePortConfigArrayInput
-	Postgres     compose.PostgresConfigPtrInput
-	Project_name string
+	Deploy      compose.DeployConfigPtrInput
+	Environment pulumi.StringMapInput
+	Image       *string
+	Ports       compose.ServicePortConfigArrayInput
+	Postgres    compose.PostgresConfigPtrInput
+	ProjectName string
 }
 
 func (PostgresArgs) ElementType() reflect.Type {

--- a/sdk/v2/go/defang-gcp/service.go
+++ b/sdk/v2/go/defang-gcp/service.go
@@ -36,32 +36,32 @@ func NewService(ctx *pulumi.Context,
 }
 
 type serviceArgs struct {
-	Command      []string                    `pulumi:"command"`
-	Deploy       *compose.DeployConfig       `pulumi:"deploy"`
-	DomainName   *string                     `pulumi:"domainName"`
-	Entrypoint   []string                    `pulumi:"entrypoint"`
-	Environment  map[string]string           `pulumi:"environment"`
-	HealthCheck  *compose.HealthCheckConfig  `pulumi:"healthCheck"`
-	Image        string                      `pulumi:"image"`
-	Llm          *compose.LlmConfig          `pulumi:"llm"`
-	Platform     *string                     `pulumi:"platform"`
-	Ports        []compose.ServicePortConfig `pulumi:"ports"`
-	Project_name string                      `pulumi:"project_name"`
+	Command     []string                    `pulumi:"command"`
+	Deploy      *compose.DeployConfig       `pulumi:"deploy"`
+	DomainName  *string                     `pulumi:"domainName"`
+	Entrypoint  []string                    `pulumi:"entrypoint"`
+	Environment map[string]string           `pulumi:"environment"`
+	HealthCheck *compose.HealthCheckConfig  `pulumi:"healthCheck"`
+	Image       string                      `pulumi:"image"`
+	Llm         *compose.LlmConfig          `pulumi:"llm"`
+	Platform    *string                     `pulumi:"platform"`
+	Ports       []compose.ServicePortConfig `pulumi:"ports"`
+	ProjectName string                      `pulumi:"projectName"`
 }
 
 // The set of arguments for constructing a Service resource.
 type ServiceArgs struct {
-	Command      pulumi.StringArrayInput
-	Deploy       compose.DeployConfigPtrInput
-	DomainName   *string
-	Entrypoint   pulumi.StringArrayInput
-	Environment  pulumi.StringMapInput
-	HealthCheck  compose.HealthCheckConfigPtrInput
-	Image        string
-	Llm          compose.LlmConfigPtrInput
-	Platform     *string
-	Ports        compose.ServicePortConfigArrayInput
-	Project_name string
+	Command     pulumi.StringArrayInput
+	Deploy      compose.DeployConfigPtrInput
+	DomainName  *string
+	Entrypoint  pulumi.StringArrayInput
+	Environment pulumi.StringMapInput
+	HealthCheck compose.HealthCheckConfigPtrInput
+	Image       string
+	Llm         compose.LlmConfigPtrInput
+	Platform    *string
+	Ports       compose.ServicePortConfigArrayInput
+	ProjectName string
 }
 
 func (ServiceArgs) ElementType() reflect.Type {

--- a/tests/aws/ecs_service_test.go
+++ b/tests/aws/ecs_service_test.go
@@ -25,8 +25,8 @@ func TestConstructAwsEcsServiceWithImage(t *testing.T) {
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.AwsURN("Service"),
 		Inputs: property.NewMap(map[string]property.Value{
-			"project_name": property.New("myproject"),
-			"image":        property.New("nginx:latest"),
+			"projectName": property.New("myproject"),
+			"image":       property.New("nginx:latest"),
 		}),
 	})
 
@@ -39,8 +39,8 @@ func TestConstructAwsEcsServiceWithIngressPort(t *testing.T) {
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.AwsURN("Service"),
 		Inputs: property.NewMap(map[string]property.Value{
-			"project_name": property.New("myproject"),
-			"image":        property.New("nginx:latest"),
+			"projectName": property.New("myproject"),
+			"image":       property.New("nginx:latest"),
 			"ports": property.New(property.NewArray([]property.Value{
 				testutil.IngressPort(8080),
 			})),
@@ -56,8 +56,8 @@ func TestConstructAwsEcsServiceWithMultiplePorts(t *testing.T) {
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.AwsURN("Service"),
 		Inputs: property.NewMap(map[string]property.Value{
-			"project_name": property.New("myproject"),
-			"image":        property.New("myapp:latest"),
+			"projectName": property.New("myproject"),
+			"image":       property.New("myapp:latest"),
 			"ports": property.New(property.NewArray([]property.Value{
 				testutil.IngressPort(8080),
 				property.New(property.NewMap(map[string]property.Value{
@@ -78,8 +78,8 @@ func TestConstructAwsEcsServiceWithBuild(t *testing.T) {
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.AwsURN("Service"),
 		Inputs: property.NewMap(map[string]property.Value{
-			"project_name": property.New("myproject"),
-			"image":        property.New("myapp:latest"),
+			"projectName": property.New("myproject"),
+			"image":       property.New("myapp:latest"),
 			"build": property.New(property.NewMap(map[string]property.Value{
 				"context": property.New("./app"),
 			})),
@@ -95,8 +95,8 @@ func TestConstructAwsEcsServiceWithBuildAndDockerfile(t *testing.T) {
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.AwsURN("Service"),
 		Inputs: property.NewMap(map[string]property.Value{
-			"project_name": property.New("myproject"),
-			"image":        property.New("myapp:latest"),
+			"projectName": property.New("myproject"),
+			"image":       property.New("myapp:latest"),
 			"build": property.New(property.NewMap(map[string]property.Value{
 				"context":    property.New("./app"),
 				"dockerfile": property.New("docker/Dockerfile.prod"),
@@ -114,8 +114,8 @@ func TestConstructAwsEcsServiceWithVPC(t *testing.T) {
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.AwsURN("Service"),
 		Inputs: property.NewMap(map[string]property.Value{
-			"project_name": property.New("myproject"),
-			"image":        property.New("nginx:latest"),
+			"projectName": property.New("myproject"),
+			"image":       property.New("nginx:latest"),
 			"aws": property.New(property.NewMap(map[string]property.Value{
 				"vpcId": property.New("vpc-0123456789abcdef0"),
 				"subnetIds": property.New(property.NewArray([]property.Value{
@@ -139,8 +139,8 @@ func TestConstructAwsEcsServiceWithHealthCheck(t *testing.T) {
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.AwsURN("Service"),
 		Inputs: property.NewMap(map[string]property.Value{
-			"project_name": property.New("myproject"),
-			"image":        property.New("nginx:latest"),
+			"projectName": property.New("myproject"),
+			"image":       property.New("nginx:latest"),
 			"ports": property.New(property.NewArray([]property.Value{
 				testutil.IngressPort(80),
 			})),
@@ -167,8 +167,8 @@ func TestConstructAwsEcsServiceWithEnvironment(t *testing.T) {
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.AwsURN("Service"),
 		Inputs: property.NewMap(map[string]property.Value{
-			"project_name": property.New("myproject"),
-			"image":        property.New("myapp:latest"),
+			"projectName": property.New("myproject"),
+			"image":       property.New("myapp:latest"),
 			"environment": property.New(property.NewMap(map[string]property.Value{
 				"APP_ENV": property.New("production"),
 				"PORT":    property.New("8080"),
@@ -185,8 +185,8 @@ func TestConstructAwsEcsServiceWithDeploy(t *testing.T) {
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.AwsURN("Service"),
 		Inputs: property.NewMap(map[string]property.Value{
-			"project_name": property.New("myproject"),
-			"image":        property.New("myapp:latest"),
+			"projectName": property.New("myproject"),
+			"image":       property.New("myapp:latest"),
 			"deploy": property.New(property.NewMap(map[string]property.Value{
 				"replicas": property.New(float64(2)),
 				"resources": property.New(property.NewMap(map[string]property.Value{
@@ -209,8 +209,8 @@ func TestConstructAwsEcsServiceWithDeploy(t *testing.T) {
 func constructAwsServiceContainerDef(t *testing.T, env map[string]property.Value) awsprov.ContainerDefinition {
 	t.Helper()
 	inputs := map[string]property.Value{
-		"project_name": property.New("myproject"),
-		"image":        property.New("myapp:latest"),
+		"projectName": property.New("myproject"),
+		"image":       property.New("myapp:latest"),
 	}
 	if env != nil {
 		inputs["environment"] = property.New(property.NewMap(env))

--- a/tests/aws/postgres_test.go
+++ b/tests/aws/postgres_test.go
@@ -16,7 +16,7 @@ func TestConstructAwsPostgres(t *testing.T) {
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.AwsURN("Postgres"),
 		Inputs: property.NewMap(map[string]property.Value{
-			"project_name": property.New("myproject"),
+			"projectName": property.New("myproject"),
 			"image":        property.New("postgres:16"),
 			"postgres":     property.New(property.NewMap(map[string]property.Value{})),
 			"aws": property.New(property.NewMap(map[string]property.Value{
@@ -34,7 +34,7 @@ func TestConstructAwsPostgresWithAllowDowntime(t *testing.T) {
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.AwsURN("Postgres"),
 		Inputs: property.NewMap(map[string]property.Value{
-			"project_name": property.New("myproject"),
+			"projectName": property.New("myproject"),
 			"image":        property.New("postgres:15"),
 			"postgres": property.New(property.NewMap(map[string]property.Value{
 				"allowDowntime": property.New(true),
@@ -54,7 +54,7 @@ func TestConstructAwsPostgresWithSnapshot(t *testing.T) {
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.AwsURN("Postgres"),
 		Inputs: property.NewMap(map[string]property.Value{
-			"project_name": property.New("myproject"),
+			"projectName": property.New("myproject"),
 			"image":        property.New("postgres:16"),
 			"postgres": property.New(property.NewMap(map[string]property.Value{
 				"fromSnapshot": property.New("rds:myproject-db-2024-01-01"),
@@ -74,7 +74,7 @@ func TestConstructAwsPostgresWithEnvironment(t *testing.T) {
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.AwsURN("Postgres"),
 		Inputs: property.NewMap(map[string]property.Value{
-			"project_name": property.New("myproject"),
+			"projectName": property.New("myproject"),
 			"image":        property.New("postgres:16"),
 			"postgres":     property.New(property.NewMap(map[string]property.Value{})),
 			"environment": property.New(property.NewMap(map[string]property.Value{
@@ -97,7 +97,7 @@ func TestConstructAwsPostgresWithVPC(t *testing.T) {
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.AwsURN("Postgres"),
 		Inputs: property.NewMap(map[string]property.Value{
-			"project_name": property.New("myproject"),
+			"projectName": property.New("myproject"),
 			"image":        property.New("postgres:16"),
 			"postgres":     property.New(property.NewMap(map[string]property.Value{})),
 			"aws": property.New(property.NewMap(map[string]property.Value{

--- a/tests/aws/redis_test.go
+++ b/tests/aws/redis_test.go
@@ -24,7 +24,7 @@ func TestConstructAwsRedis(t *testing.T) {
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.AwsURN("Redis"),
 		Inputs: property.NewMap(map[string]property.Value{
-			"project_name": property.New("myproject"),
+			"projectName": property.New("myproject"),
 			"aws":          awsConfig,
 		}),
 	})
@@ -38,7 +38,7 @@ func TestConstructAwsRedisWithImage(t *testing.T) {
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.AwsURN("Redis"),
 		Inputs: property.NewMap(map[string]property.Value{
-			"project_name": property.New("myproject"),
+			"projectName": property.New("myproject"),
 			"image":        property.New("redis:7.2"),
 			"aws":          awsConfig,
 		}),
@@ -53,7 +53,7 @@ func TestConstructAwsRedisWithValkey(t *testing.T) {
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.AwsURN("Redis"),
 		Inputs: property.NewMap(map[string]property.Value{
-			"project_name": property.New("myproject"),
+			"projectName": property.New("myproject"),
 			"image":        property.New("valkey/valkey:8"),
 			"aws":          awsConfig,
 		}),
@@ -68,7 +68,7 @@ func TestConstructAwsRedisWithCustomPort(t *testing.T) {
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.AwsURN("Redis"),
 		Inputs: property.NewMap(map[string]property.Value{
-			"project_name": property.New("myproject"),
+			"projectName": property.New("myproject"),
 			"image":        property.New("redis:7.2"),
 			"ports": property.New(property.NewArray([]property.Value{
 				property.New(property.NewMap(map[string]property.Value{
@@ -89,7 +89,7 @@ func TestConstructAwsRedisWithAllowDowntime(t *testing.T) {
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.AwsURN("Redis"),
 		Inputs: property.NewMap(map[string]property.Value{
-			"project_name": property.New("myproject"),
+			"projectName": property.New("myproject"),
 			"image":        property.New("redis:7.2"),
 			"redis": property.New(property.NewMap(map[string]property.Value{
 				"allowDowntime": property.New(true),
@@ -107,7 +107,7 @@ func TestConstructAwsRedisWithVPC(t *testing.T) {
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.AwsURN("Redis"),
 		Inputs: property.NewMap(map[string]property.Value{
-			"project_name": property.New("myproject"),
+			"projectName": property.New("myproject"),
 			"image":        property.New("redis:7.2"),
 			"aws": property.New(property.NewMap(map[string]property.Value{
 				"vpcID": property.New("vpc-0123456789abcdef0"),

--- a/tests/azure/postgres_test.go
+++ b/tests/azure/postgres_test.go
@@ -16,7 +16,7 @@ func TestConstructAzurePostgres(t *testing.T) {
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.AzureURN("Postgres"),
 		Inputs: property.NewMap(map[string]property.Value{
-			"project_name": property.New("myproject"),
+			"projectName": property.New("myproject"),
 			"image":        property.New("postgres:16"),
 			"postgres":     property.New(property.NewMap(map[string]property.Value{})),
 			"environment": property.New(property.NewMap(map[string]property.Value{
@@ -34,7 +34,7 @@ func TestConstructAzurePostgresWithAllowDowntime(t *testing.T) {
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.AzureURN("Postgres"),
 		Inputs: property.NewMap(map[string]property.Value{
-			"project_name": property.New("myproject"),
+			"projectName": property.New("myproject"),
 			"image":        property.New("postgres:15"),
 			"postgres": property.New(property.NewMap(map[string]property.Value{
 				"allowDowntime": property.New(true),
@@ -57,7 +57,7 @@ func TestConstructAzurePostgresWithEnvironment(t *testing.T) {
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.AzureURN("Postgres"),
 		Inputs: property.NewMap(map[string]property.Value{
-			"project_name": property.New("myproject"),
+			"projectName": property.New("myproject"),
 			"image":        property.New("postgres:16"),
 			"postgres":     property.New(property.NewMap(map[string]property.Value{})),
 			"environment": property.New(property.NewMap(map[string]property.Value{

--- a/tests/gcp/postgres_test.go
+++ b/tests/gcp/postgres_test.go
@@ -18,7 +18,7 @@ func TestConstructGcpCloudSql(t *testing.T) {
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.GcpURN("Postgres"),
 		Inputs: property.NewMap(map[string]property.Value{
-			"project_name": property.New("myproject"),
+			"projectName": property.New("myproject"),
 			"image":        property.New("postgres:15"),
 			"postgres":     property.New(property.NewMap(map[string]property.Value{})),
 		}),
@@ -33,7 +33,7 @@ func TestConstructGcpCloudSqlWithAllowDowntime(t *testing.T) {
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.GcpURN("Postgres"),
 		Inputs: property.NewMap(map[string]property.Value{
-			"project_name": property.New("myproject"),
+			"projectName": property.New("myproject"),
 			"image":        property.New("postgres:16"),
 			"postgres": property.New(property.NewMap(map[string]property.Value{
 				"allowDowntime": property.New(true),
@@ -50,7 +50,7 @@ func TestConstructGcpCloudSqlWithEnvironment(t *testing.T) {
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.GcpURN("Postgres"),
 		Inputs: property.NewMap(map[string]property.Value{
-			"project_name": property.New("myproject"),
+			"projectName": property.New("myproject"),
 			"image":        property.New("postgres:16"),
 			"postgres":     property.New(property.NewMap(map[string]property.Value{})),
 			"environment": property.New(property.NewMap(map[string]property.Value{
@@ -70,7 +70,7 @@ func TestConstructGcpCloudSqlNoUserOrDatabaseByDefault(t *testing.T) {
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.GcpURN("Postgres"),
 		Inputs: property.NewMap(map[string]property.Value{
-			"project_name": property.New("myproject"),
+			"projectName": property.New("myproject"),
 			"image":        property.New("postgres:17"),
 			"postgres":     property.New(property.NewMap(map[string]property.Value{})),
 		}),
@@ -90,7 +90,7 @@ func TestConstructGcpCloudSqlCreatesUserAndDatabaseWhenSet(t *testing.T) {
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.GcpURN("Postgres"),
 		Inputs: property.NewMap(map[string]property.Value{
-			"project_name": property.New("myproject"),
+			"projectName": property.New("myproject"),
 			"image":        property.New("postgres:17"),
 			"postgres":     property.New(property.NewMap(map[string]property.Value{})),
 			"environment": property.New(property.NewMap(map[string]property.Value{
@@ -114,7 +114,7 @@ func TestConstructGcpCloudSqlDefaultDbNameSkipsDatabase(t *testing.T) {
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.GcpURN("Postgres"),
 		Inputs: property.NewMap(map[string]property.Value{
-			"project_name": property.New("myproject"),
+			"projectName": property.New("myproject"),
 			"image":        property.New("postgres:17"),
 			"postgres":     property.New(property.NewMap(map[string]property.Value{})),
 			"environment": property.New(property.NewMap(map[string]property.Value{
@@ -138,7 +138,7 @@ func TestConstructGcpCloudSqlStandaloneNoVPCPeering(t *testing.T) {
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.GcpURN("Postgres"),
 		Inputs: property.NewMap(map[string]property.Value{
-			"project_name": property.New("myproject"),
+			"projectName": property.New("myproject"),
 			"image":        property.New("postgres:17"),
 			"postgres":     property.New(property.NewMap(map[string]property.Value{})),
 		}),


### PR DESCRIPTION
Add the RDS instance identifier to the Postgres component outputs, so the user can set up alerts themselves. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PostgreSQL components now expose the database instance identifier as a public output and publish both endpoint and instance identifier.

* **Chores**
  * Standardized input property naming across providers and SDKs: renamed project inputs from snake_case to camelCase (project_name → projectName) for consistent configuration keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->