### PR TITLE
fix: set storageEncrypted to true

### DIFF
--- a/provider/defangaws/aws/rds.go
+++ b/provider/defangaws/aws/rds.go
@@ -267,7 +267,7 @@ func CreateRDS(
 		FinalSnapshotIdentifier:  finalSnapshotIdentifier,
 		PubliclyAccessible:       pulumi.Bool(false),
 		DeletionProtection:       pulumi.Bool(deletionProtection),
-		StorageEncrypted:         pulumi.Bool(StorageEncrypted.Get(ctx)),
+		StorageEncrypted:         pulumi.Bool(true),
 		AutoMinorVersionUpgrade:  pulumi.Bool(true),
 		BackupRetentionPeriod:    pulumi.Int(backupRetentionDays),
 		Tags:                     tags,
@@ -279,6 +279,10 @@ func CreateRDS(
 		rdsArgs.SnapshotIdentifier = pulumi.String(pg.FromSnapshot)
 	}
 
+	// IgnoreChanges on storageEncrypted: pre-existing instances created when the
+	// (now-removed) `storage-encrypted` recipe defaulted to false would otherwise
+	// force-replace on next up. RDS can't toggle encryption in-place, so we
+	// preserve the existing instance and leave migration to the operator.
 	rdsOpts := append(append([]pulumi.ResourceOption{}, opts...), pulumi.IgnoreChanges([]string{"storageEncrypted"}))
 	if len(deps) > 0 {
 		rdsOpts = append(rdsOpts, pulumi.DependsOn(deps))

--- a/provider/defangaws/aws/recipe.go
+++ b/provider/defangaws/aws/recipe.go
@@ -24,5 +24,4 @@ var (
 	RetainBucketOnDelete    = common.Bool("retain-bucket-on-delete", false)
 	Route53SidecarLogs      = common.Bool("route53-sidecar-logs", false)
 	RetainDnsOnDelete       = common.Bool("retain-dns-on-delete", false)
-	StorageEncrypted        = common.Bool("storage-encrypted", false)
 )


### PR DESCRIPTION
-  ignore changes for existing RDS instances

There's no reason to not have this on all the time. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * RDS instances now have storage encryption automatically enabled by default.
  * Removed the storage encryption configuration option; encryption setting can no longer be modified after instance creation.
  * Storage encryption state is now locked and will not be reconciled during infrastructure updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->