### PR TITLE
Download the build context and upload to acr task staging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,12 @@ replace gopkg.in/yaml.v3 => go.yaml.in/yaml/v3 v3.0.1
 require (
 	cloud.google.com/go/cloudbuild v1.18.1
 	cloud.google.com/go/longrunning v0.6.2
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices v1.8.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.4.0
+	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.3.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.11
 	github.com/aws/aws-sdk-go-v2/service/codebuild v1.68.14
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.74.0
@@ -50,7 +52,6 @@ require (
 	cloud.google.com/go/logging v1.12.0 // indirect
 	cloud.google.com/go/storage v1.46.0 // indirect
 	dario.cat/mergo v1.0.0 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -82,10 +82,14 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFG
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0/go.mod h1:LRr2FzBTQlONPPa5HREE5+RjSCTXl7BwOvYOaWTqCaI=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1 h1:7CBQ+Ei8SP2c6ydQTGCCrS35bDxgTMfoP2miAwK++OU=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1/go.mod h1:c/wcGeGx5FUPbM/JltUYHZcKmigwyVLJlDq+4HdtXaw=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.5.0 h1:AifHbc4mg0x9zW52WOpKbsHaDKuRhlI7TVl47thgQ70=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.5.0/go.mod h1:T5RfihdXtBDxt1Ch2wobif3TvzTdumDy29kahv6AV9A=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.4.0 h1:/g8S6wk65vfC6m3FIxJ+i5QDyN9JWwXI8Hb0Img10hU=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.4.0/go.mod h1:gpl+q95AzZlKVI3xSoseF9QPrypk0hQqBiJYeB/cR/I=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 h1:nCYfgcSyHZXJI8J0IWE5MsCGlb2xp9fJiXyxWgmOFg4=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0/go.mod h1:ucUjca2JtSZboY8IoUqyQyuuXvwbMBVwFOm0vdQPNhA=
+github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.3.1 h1:fXPMAmuh0gDuRDey0atC8cXBuKIlqCzCkL8sm1n9Ov0=
+github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.3.1/go.mod h1:SUZc9YRRHfx2+FAQKNDGrssXehqLpxmwRv2mC/5ntj4=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2 h1:oygO0locgZJe7PpYPXT5A29ZkwJaPqcva7BVeemZOZs=

--- a/provider/defangazure/acr_image_build.go
+++ b/provider/defangazure/acr_image_build.go
@@ -15,9 +15,10 @@ import (
 )
 
 var (
-	ErrNoACRRunID     = errors.New("failed to schedule run: no run ID returned")
-	ErrACRRunTimedOut = errors.New("ACR task run timed out")
-	ErrACRRunFailed   = errors.New("ACR task run failed")
+	ErrNoACRRunID        = errors.New("failed to schedule run: no run ID returned")
+	ErrACRRunTimedOut    = errors.New("ACR task run timed out")
+	ErrACRRunFailed      = errors.New("ACR task run failed")
+	ErrACREmptyUploadURL = errors.New("empty upload URL response from ACR")
 )
 
 // ACRImageBuild is a custom resource that schedules an ACR task run and waits for completion.
@@ -284,14 +285,14 @@ func stageBuildContextToACR(
 	if err != nil {
 		return "", fmt.Errorf("opening download stream: %w", err)
 	}
-	defer dl.Body.Close()
+	defer func() { _ = dl.Body.Close() }()
 
 	up, err := rc.GetBuildSourceUploadURL(ctx, rgName, registryName, nil)
 	if err != nil {
 		return "", fmt.Errorf("getting ACR upload URL: %w", err)
 	}
 	if up.UploadURL == nil || up.RelativePath == nil {
-		return "", errors.New("empty upload URL response from ACR")
+		return "", ErrACREmptyUploadURL
 	}
 
 	bbClient, err := blockblob.NewClientWithNoCredential(*up.UploadURL, nil)

--- a/provider/defangazure/acr_image_build.go
+++ b/provider/defangazure/acr_image_build.go
@@ -6,8 +6,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
 	"github.com/pulumi/pulumi-go-provider/infer"
 )
 
@@ -41,8 +44,10 @@ type ACRImageBuildInputs struct {
 	// Registry login server, e.g. "myregistry.azurecr.io"
 	LoginServer string `pulumi:"loginServer"`
 
-	// Full context URL for the build (may include a SAS token query string).
-	// Passed at run time via EncodedTaskRunRequest so the ARM API never strips the token.
+	// Build context URL — a bare blob URL pointing at the tar that the CLI
+	// uploaded to the CD storage account. Restaged into ACR's own staging
+	// area at run time (see stageBuildContextToACR) so that ACR Tasks can
+	// fetch via its internal credentials, not via a SAS token in this URL.
 	ContextPath string `pulumi:"contextPath"`
 
 	// Base64-encoded ACR task YAML (from generateTaskYAML).
@@ -111,11 +116,13 @@ func (*ACRImageBuild) Create(
 	}, nil
 }
 
-// scheduleAndWaitACRRun schedules an inline ACR task run using EncodedTaskRunRequest
-// and polls until it reaches a terminal state.
-// Using EncodedTaskRunRequest (rather than TaskRunRequest) means the context URL is
-// passed in the request body, which is never persisted — so the ARM API cannot strip
-// the SAS query string the way it does when storing a task definition.
+// scheduleAndWaitACRRun stages the build context into ACR's own upload area,
+// schedules an inline ACR task run, and polls until it reaches a terminal state.
+//
+// Source contextPath is the bare blob URL of the tar in the CD storage account.
+// We download it via the CD task's managed identity and re-upload to ACR's
+// staging slot (GetBuildSourceUploadURL); ACR Tasks then fetches via its own
+// internal credentials, so neither the URL nor any SAS leaks into Pulumi state.
 func scheduleAndWaitACRRun(
 	ctx context.Context,
 	subscriptionID, rgName, registryName string,
@@ -138,6 +145,11 @@ func scheduleAndWaitACRRun(
 		return "", "", fmt.Errorf("creating runs client: %w", err)
 	}
 
+	sourceLocation, err := stageBuildContextToACR(ctx, cred, regClient, rgName, registryName, contextPath)
+	if err != nil {
+		return "", "", fmt.Errorf("staging build context: %w", err)
+	}
+
 	runType := "EncodedTaskRunRequest"
 	isArchiveEnabled := false
 	osLinux := armcontainerregistry.OSLinux
@@ -145,9 +157,9 @@ func scheduleAndWaitACRRun(
 	poller, err := regClient.BeginScheduleRun(ctx, rgName, registryName, &armcontainerregistry.EncodedTaskRunRequest{
 		Type:               &runType,
 		EncodedTaskContent: &encodedTaskContent,
-		// SourceLocation carries the full context URL including SAS token.
-		// EncodedTaskRunRequest is never persisted by ARM, so the query string is preserved.
-		SourceLocation:   &contextPath,
+		// Relative path returned by ACR's GetBuildSourceUploadURL — ACR Tasks
+		// reads this from its own staging area without needing caller credentials.
+		SourceLocation:   &sourceLocation,
 		IsArchiveEnabled: &isArchiveEnabled,
 		Platform: &armcontainerregistry.PlatformProperties{
 			OS: &osLinux,
@@ -248,4 +260,47 @@ func buildImageURI(
 		}
 	}
 	return fmt.Sprintf("%s/%s:%s", loginServer, imageName, runID)
+}
+
+// stageBuildContextToACR streams the tar at sourceURL (a bare blob URL in the
+// CD storage account) into ACR's own upload staging slot, returning the
+// relative path that EncodedTaskRunRequest.SourceLocation expects.
+//
+// The download uses the caller's managed identity; the upload uses a
+// short-lived SAS URL returned by GetBuildSourceUploadURL. Streaming is done
+// via blockblob.UploadStream, which stages blocks of bounded size and commits
+// at the end — no full buffering in memory.
+func stageBuildContextToACR(
+	ctx context.Context,
+	cred azcore.TokenCredential,
+	rc *armcontainerregistry.RegistriesClient,
+	rgName, registryName, sourceURL string,
+) (string, error) {
+	bc, err := blob.NewClient(sourceURL, cred, nil)
+	if err != nil {
+		return "", fmt.Errorf("creating blob client for %s: %w", sourceURL, err)
+	}
+	dl, err := bc.DownloadStream(ctx, nil)
+	if err != nil {
+		return "", fmt.Errorf("opening download stream: %w", err)
+	}
+	defer dl.Body.Close()
+
+	up, err := rc.GetBuildSourceUploadURL(ctx, rgName, registryName, nil)
+	if err != nil {
+		return "", fmt.Errorf("getting ACR upload URL: %w", err)
+	}
+	if up.UploadURL == nil || up.RelativePath == nil {
+		return "", errors.New("empty upload URL response from ACR")
+	}
+
+	bbClient, err := blockblob.NewClientWithNoCredential(*up.UploadURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("creating blockblob client: %w", err)
+	}
+	if _, err := bbClient.UploadStream(ctx, dl.Body, nil); err != nil {
+		return "", fmt.Errorf("uploading to ACR staging: %w", err)
+	}
+
+	return *up.RelativePath, nil
 }


### PR DESCRIPTION
Becuase ACR task context URL does not make use of any RBAC to download the context, and we do not want to pass the SAS token in the context URL for security reasons. So we let CD to copy the content from our blob storage to ACR task staging so ACR Task will be able to build without downloading and access the context from a local relative location.

The reasons we cannot upload the temporary staging location directly are:
1. The upload location is not fixed, while we use the hash of the context to prevent unnecessary rebuild
2. The upload location is temporary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies, including promoting core Azure SDK components and adding Azure Blob storage client.

* **Refactor**
  * Improved staging of build contexts for Azure Container Registry builds to make scheduling and uploads more reliable and secure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->