### PR TITLE
Define ACR task name and remove -build suffix

### DIFF
--- a/cd/main.go
+++ b/cd/main.go
@@ -76,13 +76,16 @@ func projectConfig(prefix string) map[string]workspace.ProjectConfigType {
 							"aws:rds/subnetGroup:SubnetGroup":         map[string]string{"pattern": lowerPrefix + "${project}-${stack}-${name}-${hex(7)}"}, // lowercase
 						},
 					},
-					// ACR registry names must be alphanumeric only (^[a-zA-Z0-9]*$, 5–50 chars).
-					// The default pattern includes hyphens from project/stack names, so override it.
-					// ${name} is already sanitized to alphanumeric by sanitizeRegistryName() in image.go.
-					// ${stack} is safe to include: stacks are lowercase with no hyphens.
 					"azure-native": map[string]any{
 						"resources": map[string]any{
-							"azure-native:containerregistry:Registry": map[string]string{"pattern": "${name}${stack}${hex(7)}"},
+							// ACR registry names must be alphanumeric only (^[a-zA-Z0-9]*$, 5–50 chars).
+							// The default pattern includes hyphens from project/stack names, so override it.
+							// ${name} is already sanitized to alphanumeric by sanitizeRegistryName() in image.go.
+							// ${stack} is safe to include: stacks are lowercase with no hyphens.
+							"azure-native:containerregistry:Registry": map[string]string{"pattern": "${stack}${name}${hex(7)}"},
+							// https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftcontainerregistry
+							// 5-50	Alphanumerics, hyphens, and underscores
+							"azure-native:containerregistry:Task": map[string]string{"pattern": "${stack}-${name}-${hex(7)}"},
 						},
 					},
 				},

--- a/cd/main.go
+++ b/cd/main.go
@@ -85,7 +85,7 @@ func projectConfig(prefix string) map[string]workspace.ProjectConfigType {
 							"azure-native:containerregistry:Registry": map[string]string{"pattern": "${stack}${name}${hex(7)}"},
 							// https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftcontainerregistry
 							// 5-50	Alphanumerics, hyphens, and underscores
-							"azure-native:containerregistry:Task": map[string]string{"pattern": "${stack}-${name}-${hex(7)}"},
+							"azure-native:containerregistry:Task": map[string]string{"pattern": "${name}-${hex(7)}"},
 						},
 					},
 				},

--- a/provider/defangaws/aws/image.go
+++ b/provider/defangaws/aws/image.go
@@ -115,7 +115,7 @@ func buildServiceImage(
 	// region.Region
 
 	var buildResource codeBuildImageBuildResource
-	err = ctx.RegisterResource("defang-aws:index:Build", serviceName+"-build", pulumi.Map{
+	err = ctx.RegisterResource("defang-aws:index:Build", serviceName, pulumi.Map{
 		"projectName": cbResult.project.Name,
 		"profile":     pulumi.String(infra.profile),
 		"region":      pulumi.String(infra.region),

--- a/provider/defangazure/azure/image.go
+++ b/provider/defangazure/azure/image.go
@@ -173,7 +173,7 @@ func buildServiceImage(
 
 	task, err := createACRTask(
 		ctx,
-		serviceName+"-build",
+		serviceName,
 		encodedYAML,
 		svc.Build.Context,
 		infra.registry,
@@ -192,7 +192,7 @@ func buildServiceImage(
 	// rebuild even when source is unchanged. Real source changes propagate via
 	// triggers (buildTriggerHash strips the SAS before hashing).
 	buildOpts := append([]pulumi.ResourceOption{pulumi.IgnoreChanges([]string{"contextPath"})}, opts...)
-	err = ctx.RegisterResource("defang-azure:index:ACRImageBuild", serviceName+"-build", pulumi.Map{
+	err = ctx.RegisterResource("defang-azure:index:ACRImageBuild", serviceName, pulumi.Map{
 		"subscriptionId":     infra.subscriptionID,
 		"resourceGroupName":  sharedInfra.ResourceGroup.Name,
 		"registryName":       infra.registry.Name,

--- a/provider/defanggcp/gcp/image.go
+++ b/provider/defanggcp/gcp/image.go
@@ -257,7 +257,7 @@ func buildServiceImage(
 	var buildRes gcpBuildResource
 	if err := ctx.RegisterResource(
 		"defang-gcp:defanggcp:Build",
-		serviceName+"-build",
+		serviceName,
 		pulumi.Map{
 			"projectId":      pulumi.String(infra.GcpProject),
 			"location":       pulumi.String(infra.Region),


### PR DESCRIPTION
There was bug where my container registry task name got to long and Pulumi errored:
```
azure-native:containerregistry:Task worker-build  error: azure-native:containerregistry:Task resource 'worker-build' has a problem: 'taskName' is too long (55): at most 50 characters allowed
```

This is because `azure-native:containerregistry:Task` was never define and it defaulted back to `"pattern": prefix + "${project}-${stack}-${name}-${hex(7)}"` which exceeded the 50 character count.

I also had remove all "-build" suffix from all 3 clouds. Lastly the the pattern naming was flip from `${name}${stack}${hex(7)}` to `${stack}${name}${hex(7)}` because stack name should come first before logical name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified logical names for cloud build resources across AWS, Azure, and GCP to use the service name directly for more consistent identities.
  * Updated Azure Container Registry autonaming patterns for registries and tasks to standardize naming formats and align with ACR constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->