### PR TITLE
Limit AZs to 2 by default

### DIFF
--- a/cd/main.go
+++ b/cd/main.go
@@ -366,7 +366,7 @@ func main() {
 
 	// Set workspace env vars
 	if etag != "" {
-		// USER ends up in Pulumi lock files for debugging; FIXME: doens't work on linux
+		// USER ends up in Pulumi lock files for debugging; FIXME: doesn't work on linux
 		stack.Workspace().SetEnvVar("USER", etag)
 	}
 

--- a/cd/program/project_pb.go
+++ b/cd/program/project_pb.go
@@ -29,7 +29,7 @@ func projectPbKey(ctx *pulumi.Context) string {
 func saveProjectPbAWS(ctx *pulumi.Context, data []byte, dep pulumi.Resource, extraOpts ...pulumi.ResourceOption) error {
 	stateURL := os.Getenv("DEFANG_STATE_URL")
 	if stateURL == "" {
-		return fmt.Errorf("DEFANG_STATE_URL is not set; cannot upload project.pb")
+		return nil
 	}
 	u, err := url.Parse(stateURL)
 	if err != nil {
@@ -56,7 +56,7 @@ func saveProjectPbAWS(ctx *pulumi.Context, data []byte, dep pulumi.Resource, ext
 func saveProjectPbGCP(ctx *pulumi.Context, data []byte, dep pulumi.Resource, extraOpts ...pulumi.ResourceOption) error {
 	stateURL := os.Getenv("DEFANG_STATE_URL")
 	if stateURL == "" {
-		return fmt.Errorf("DEFANG_STATE_URL is not set; cannot upload project.pb")
+		return nil
 	}
 	u, err := url.Parse(stateURL)
 	if err != nil {
@@ -90,7 +90,7 @@ func saveProjectPbGCP(ctx *pulumi.Context, data []byte, dep pulumi.Resource, ext
 func saveProjectPbAzure(ctx *pulumi.Context, data []byte, dep pulumi.Resource, extraOpts ...pulumi.ResourceOption) error {
 	stateURL := os.Getenv("DEFANG_STATE_URL")
 	if stateURL == "" {
-		return fmt.Errorf("DEFANG_STATE_URL is not set; cannot upload project.pb")
+		return nil
 	}
 	u, err := url.Parse(stateURL)
 	if err != nil {

--- a/provider/defangaws/aws/networking.go
+++ b/provider/defangaws/aws/networking.go
@@ -28,6 +28,7 @@ func ResolveNetworking(
 	privateDomain := common.SafeLabel(projectName) + ".internal"
 
 	strategy := awsxec2.NatGatewayStrategy(NatGatewayStrategy.Get(ctx)) // TODO: missing type checking
+	numberOfAZs := NumberOfAvailabilityZones.Get(ctx)
 
 	// if cfg != nil && cfg.VpcID != "" {
 	// 	// Use provided VPC and subnet IDs
@@ -56,15 +57,31 @@ func ResolveNetworking(
 		return nil, fmt.Errorf("getting AWS region: %w", err)
 	}
 
+	// Probe the AZs available to this account in this region. If fewer are accessible than the
+	// recipe asks for, awsx would fail with "does not have at least N Availability Zones"; instead
+	// pin the explicit list and warn so the user can lower the recipe value or change region.
+	azs, err := aws.GetAvailabilityZones(ctx, &aws.GetAvailabilityZonesArgs{State: common.Ptr("available")}, opt)
+	if err != nil {
+		return nil, fmt.Errorf("getting AWS availability zones: %w", err)
+	}
+
+	if len(azs.Names) < numberOfAZs {
+		// slices.Sort(azs.Names) // deterministic order: AWS does not guarantee response ordering
+		_ = ctx.Log.Warn(fmt.Sprintf("region %s only has %d availability zone(s) (%v); recipe %q requested %d",
+			region.Region, len(azs.Names), azs.Names, "number-of-availability-zones", numberOfAZs), nil)
+		numberOfAZs = len(azs.Names)
+	}
+
 	// Create a new VPC with public and private subnets.
 	vpcName := common.AutonamingPrefix(ctx, "shared-vpc")
 
-	vpc, err := awsxec2.NewVpc(ctx, "shared-vpc", &awsxec2.VpcArgs{
+	vpcArgs := &awsxec2.VpcArgs{
 		EnableDnsHostnames: pulumi.Bool(true),
 		// EnableDnsSupport:   pulumi.Bool(true),
 		NatGateways: &awsxec2.NatGatewayConfigurationArgs{
 			Strategy: strategy,
 		},
+		NumberOfAvailabilityZones: &numberOfAZs,
 		VpcEndpointSpecs: []awsxec2.VpcEndpointSpecArgs{
 			{
 				ServiceName:     fmt.Sprintf("com.amazonaws.%s.s3", region.Region),
@@ -77,7 +94,9 @@ func ResolveNetworking(
 		Tags: pulumi.StringMap{
 			"Name": pulumi.String(vpcName),
 		},
-	}, opt)
+	}
+
+	vpc, err := awsxec2.NewVpc(ctx, "shared-vpc", vpcArgs, opt)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/defangaws/aws/recipe.go
+++ b/provider/defangaws/aws/recipe.go
@@ -4,24 +4,25 @@ import "github.com/DefangLabs/pulumi-defang/provider/common"
 
 // AWS recipe config accessors. Each reads from defang:<key> in stack config.
 var (
-	AllowBurstable          = common.Bool("allow-burstable", true)
-	AllowOverwriteRecords   = common.Bool("allow-overwrite-records", false)
-	BackupRetentionDays     = common.Int("backup-retention-days", 0)
-	BackupWindow            = common.String("backup-window", "04:00-05:00")
-	BucketKeyEnabled        = common.Bool("bucket-key-enabled", true) // minimize KMS costs in non-prod environments
-	CreateApexRecord        = common.Bool("create-apex-record", true)
-	DeletionProtection      = common.DeletionProtection
-	DeregistrationDelay     = common.Int("deregistration-delay", 0)
-	FargateCapacityProvider = common.String("fargate-capacity-provider", "FARGATE_SPOT")
-	ForceDestroyBucket      = common.Bool("force-destroy-bucket", true)
-	ForceDestroyHostedzone  = common.Bool("force-destroy-hostedzone", false)
-	HealthCheckInterval     = common.Int("health-check-interval", 5)
-	HealthCheckThreshold    = common.Int("health-check-threshold", 2)
-	HttpRedirectToHttps     = common.String("http-redirect-to-https", "HTTP_302")
-	MinHealthyPercent       = common.Int("min-healthy-percent", 0)
-	NatGatewayStrategy      = common.String("nat-gateway-strategy", "None") // None, Single, or OnePerAz
-	RDSNodeType             = common.String("rds-node-type", "burstable")
-	RetainBucketOnDelete    = common.Bool("retain-bucket-on-delete", false)
-	Route53SidecarLogs      = common.Bool("route53-sidecar-logs", false)
-	RetainDnsOnDelete       = common.Bool("retain-dns-on-delete", false)
+	AllowBurstable            = common.Bool("allow-burstable", true)
+	AllowOverwriteRecords     = common.Bool("allow-overwrite-records", false)
+	BackupRetentionDays       = common.Int("backup-retention-days", 0)
+	BackupWindow              = common.String("backup-window", "04:00-05:00")
+	BucketKeyEnabled          = common.Bool("bucket-key-enabled", true) // minimize KMS costs in non-prod environments
+	CreateApexRecord          = common.Bool("create-apex-record", true)
+	DeletionProtection        = common.DeletionProtection
+	DeregistrationDelay       = common.Int("deregistration-delay", 0)
+	FargateCapacityProvider   = common.String("fargate-capacity-provider", "FARGATE_SPOT")
+	ForceDestroyBucket        = common.Bool("force-destroy-bucket", true)
+	ForceDestroyHostedzone    = common.Bool("force-destroy-hostedzone", false)
+	HealthCheckInterval       = common.Int("health-check-interval", 5)
+	HealthCheckThreshold      = common.Int("health-check-threshold", 2)
+	HttpRedirectToHttps       = common.String("http-redirect-to-https", "HTTP_302")
+	MinHealthyPercent         = common.Int("min-healthy-percent", 0)
+	NatGatewayStrategy        = common.String("nat-gateway-strategy", "None") // None, Single, or OnePerAz
+	NumberOfAvailabilityZones = common.Int("number-of-availability-zones", 2)
+	RDSNodeType               = common.String("rds-node-type", "burstable")
+	RetainBucketOnDelete      = common.Bool("retain-bucket-on-delete", false)
+	Route53SidecarLogs        = common.Bool("route53-sidecar-logs", false)
+	RetainDnsOnDelete         = common.Bool("retain-dns-on-delete", false)
 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to specify the number of AWS Availability Zones for VPC deployments (default: 2)
  * VPC creation now automatically detects available zones in the target region and adapts accordingly with warnings when more zones are requested than available

* **Bug Fixes**
  * State upload operations now handle missing environment configuration gracefully instead of failing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->