### PR TITLE
Overwrite project update PB endpoints before upload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
       - main
   pull_request:
     paths:
+      - "cd/**"
       - "provider/**"
       - "sdk/v2/**"
       - "tests/**"

--- a/cd/main.go
+++ b/cd/main.go
@@ -18,9 +18,11 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 	"github.com/DefangLabs/pulumi-defang/examples/cd/program"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"google.golang.org/protobuf/proto"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/debug"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/events"
@@ -184,13 +186,15 @@ func fetchHTTP(ctx context.Context, uri string) ([]byte, error) {
 
 // stackConfig returns config for Pulumi.<stack>.yaml (stack-level settings).
 func stackConfig() auto.ConfigMap {
+	provider := detectProvider()
 	cfg := auto.ConfigMap{
 		// Defang program config
-		"defang:provider": auto.ConfigValue{Value: detectProvider()},
+		"defang:provider": auto.ConfigValue{Value: provider},
+		"defang:stateUrl": auto.ConfigValue{Value: stateUrl},
 	}
 
 	// Cloud provider config read by the explicit providers in the program
-	switch detectProvider() {
+	switch provider {
 	case "aws":
 		if awsRegion == "" {
 			log.Fatal("missing required environment variable: AWS_REGION or REGION")
@@ -236,9 +240,11 @@ func stackConfig() auto.ConfigMap {
 		cfg["defang:privateDomain"] = auto.ConfigValue{Value: privateDomain}
 	}
 	if delegationSetId != "" {
+		// FIXME: should use defang-aws namespace
 		cfg["defang:delegationSetId"] = auto.ConfigValue{Value: delegationSetId}
 	}
 	if registryCredsArn != "" {
+		// FIXME: should use defang-aws namespace
 		cfg["defang:ciRegistryCredentialsArn"] = auto.ConfigValue{Value: registryCredsArn}
 	}
 
@@ -348,11 +354,15 @@ func main() {
 		// the protobuf as a Pulumi-managed blob after the deploy succeeds —
 		// so the file only appears on success and is tracked in state (vs. a
 		// pre-Pulumi SDK upload that would leave stale records on failure).
-		var projectUpdate []byte
+		var projectUpdate *defangv1.ProjectUpdate
 		if payload != "" {
-			projectUpdate, err = fetchPayload(ctx, payload)
+			projectPb, err := fetchPayload(ctx, payload)
 			if err != nil {
 				log.Fatalf("failed to fetch payload: %v", err)
+			}
+			projectUpdate = &defangv1.ProjectUpdate{}
+			if err := proto.Unmarshal(projectPb, projectUpdate); err != nil {
+				log.Fatalf("failed to unmarshal ProjectUpdate protobuf: %v", err)
 			}
 		}
 		s, err = auto.UpsertStackInlineSource(ctx, stack, project, program.NewRun(projectUpdate))

--- a/cd/main_test.go
+++ b/cd/main_test.go
@@ -348,6 +348,7 @@ func TestStackConfigAWS(t *testing.T) {
 	savedDelegationSetId := delegationSetId
 	savedRegistryCredsArn := registryCredsArn
 	savedAwsProfile := awsProfile
+	savedStateUrl := stateUrl
 	t.Cleanup(func() {
 		awsRegion = savedAwsRegion
 		gcpProject = savedGcpProject
@@ -360,6 +361,7 @@ func TestStackConfigAWS(t *testing.T) {
 		delegationSetId = savedDelegationSetId
 		registryCredsArn = savedRegistryCredsArn
 		awsProfile = savedAwsProfile
+		stateUrl = savedStateUrl
 	})
 
 	awsRegion = "us-east-1"
@@ -373,11 +375,15 @@ func TestStackConfigAWS(t *testing.T) {
 	delegationSetId = "DELEGSET123"
 	registryCredsArn = "arn:aws:secretsmanager:us-east-1:123456789:secret:creds"
 	awsProfile = "myprofile"
+	stateUrl = "http://example.com/state"
 
 	cfg := stackConfig()
 
 	if cfg["defang:provider"].Value != "aws" {
 		t.Errorf("expected provider aws, got %q", cfg["defang:provider"].Value)
+	}
+	if cfg["defang:stateUrl"].Value != "http://example.com/state" {
+		t.Errorf("expected stateUrl http://example.com/state, got %q", cfg["defang:stateUrl"].Value)
 	}
 	if cfg["aws:region"].Value != "us-east-1" {
 		t.Errorf("expected region us-east-1, got %q", cfg["aws:region"].Value)

--- a/cd/program/aws.go
+++ b/cd/program/aws.go
@@ -1,21 +1,25 @@
 package program
 
 import (
+	"encoding/base64"
+	"fmt"
+
+	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 	"github.com/DefangLabs/pulumi-defang/provider/common"
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
 	defangaws "github.com/DefangLabs/pulumi-defang/sdk/v2/go/defang-aws"
 	awscompose "github.com/DefangLabs/pulumi-defang/sdk/v2/go/defang-aws/compose"
 	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws"
+	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/config"
 	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/route53"
+	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/s3"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
+	"google.golang.org/protobuf/proto"
 )
 
-func deployAWS(ctx *pulumi.Context, cf *compose.Project, domain string, projectPb []byte) (pulumi.StringMapOutput, pulumi.StringPtrOutput, error) {
-	awsCfg := config.New(ctx, "aws")
-
+func deployAWS(ctx *pulumi.Context, cf *compose.Project, domain string, projectUpdate *defangv1.ProjectUpdate) (pulumi.StringMapOutput, pulumi.StringPtrOutput, error) {
 	providerArgs := &aws.ProviderArgs{
-		Region: pulumi.StringPtr(awsCfg.Require("region")),
+		Region: pulumi.StringPtr(config.GetRegion(ctx)),
 		DefaultTags: &aws.ProviderDefaultTagsArgs{
 			Tags: pulumi.StringMap{
 				"defang:org":     pulumi.String(ctx.Organization()),
@@ -25,7 +29,7 @@ func deployAWS(ctx *pulumi.Context, cf *compose.Project, domain string, projectP
 			},
 		},
 	}
-	if profile := awsCfg.Get("profile"); profile != "" {
+	if profile := config.GetProfile(ctx); profile != "" {
 		providerArgs.Profile = pulumi.StringPtr(profile)
 	}
 
@@ -36,17 +40,17 @@ func deployAWS(ctx *pulumi.Context, cf *compose.Project, domain string, projectP
 
 	args := toAWSArgs(cf)
 	if domain != "" {
-		awsCfg := defangaws.AWSConfigArgs{
+		awsCfgArgs := defangaws.AWSConfigArgs{
 			ProjectDomain: pulumi.StringPtr(domain),
 		}
 		// Recursively look up the public Route53 zone for HTTPS support
 		if zone, err := getHostedZoneForHost(ctx, domain, pulumi.Provider(awsProvider)); err == nil {
-			awsCfg.PublicZoneId = pulumi.StringPtr(zone.ZoneId)
+			awsCfgArgs.PublicZoneId = pulumi.StringPtr(zone.ZoneId)
 		}
-		args.Aws = awsCfg
+		args.Aws = awsCfgArgs
 	}
 
-	project, err := defangaws.NewProject(ctx, cf.Name, args, pulumi.Providers(awsProvider))
+	project, err := defangaws.NewProject(ctx, cf.Name, args, pulumi.Provider(awsProvider))
 	if err != nil {
 		return pulumi.StringMapOutput{}, pulumi.StringPtrOutput{}, err
 	}
@@ -55,8 +59,17 @@ func deployAWS(ctx *pulumi.Context, cf *compose.Project, domain string, projectP
 	// the project component so it only runs after all services are created.
 	// pulumi.Provider(awsProvider) is required because
 	// pulumi:disable-default-providers excludes aws (see cd/main.go projectConfig).
-	if len(projectPb) > 0 {
-		if err := saveProjectPbAWS(ctx, projectPb, project, pulumi.Provider(awsProvider)); err != nil {
+	if projectUpdate != nil {
+		updatedPb := project.Endpoints.ApplyT(func(endpoints map[string]string) ([]byte, error) {
+			for _, svc := range projectUpdate.Services {
+				if ep, ok := endpoints[svc.GetService().GetName()]; ok {
+					svc.Endpoints = []string{ep}
+				}
+			}
+			return proto.Marshal(projectUpdate)
+		}).(pulumi.AnyOutput)
+
+		if err := saveProjectPbAWS(ctx, updatedPb, project, pulumi.Provider(awsProvider)); err != nil {
 			return pulumi.StringMapOutput{}, pulumi.StringPtrOutput{}, err
 		}
 	}
@@ -187,4 +200,38 @@ func getHostedZoneForHost(ctx *pulumi.Context, hostname string, opts ...pulumi.I
 		return route53.LookupZone(ctx, &route53.LookupZoneArgs{Name: &parentZoneName, PrivateZone: &isPrivate}, opts...)
 	}
 	return result, nil
+}
+
+// saveProjectPbAWS uploads data as a Pulumi-managed S3 object at the key
+// derived from DEFANG_STATE_URL. Gated on dep so the upload only runs after
+// the project component (and its services) have been created successfully —
+// matching the pattern used by the legacy defang-mvp CD pipeline.
+//
+// opts should include pulumi.Provider(...) or pulumi.Parent(...) because
+// pulumi:disable-default-providers excludes aws (see cd/main.go projectConfig).
+func saveProjectPbAWS(ctx *pulumi.Context, data pulumi.AnyOutput, dep pulumi.Resource, opts ...pulumi.ResourceOption) error {
+	u, err := parseStateURL(ctx)
+	if err != nil || u == nil {
+		return err
+	}
+	if u.Scheme != "s3" || u.Host == "" {
+		return fmt.Errorf("DEFANG_STATE_URL must be an s3:// URL with a bucket for AWS uploads, got %q", u.String())
+	}
+	// ContentBase64 preserves binary bytes; Content (string) would fail gRPC
+	// marshaling because protobuf is not valid UTF-8. The provider decodes
+	// the base64 server-side and stores raw bytes in S3.
+	// Note that the -v2 version of BucketObject will be removed in the next
+	// major version of the AWS provider.
+	// See https://www.pulumi.com/registry/packages/aws/how-to-guides/7-0-migration/#s3-bucketbucketv2-changes
+	contentBase64 := data.ApplyT(func(v any) string {
+		return base64.StdEncoding.EncodeToString(v.([]byte))
+	}).(pulumi.StringOutput)
+
+	_, err = s3.NewBucketObject(ctx, "project-pb", &s3.BucketObjectArgs{
+		Bucket:        pulumi.String(u.Host),
+		Key:           pulumi.String(projectPbKey(ctx)),
+		ContentBase64: contentBase64,
+		ContentType:   pulumi.String(protobufContentType),
+	}, common.MergeOptions(opts, pulumi.DependsOn([]pulumi.Resource{dep}))...)
+	return err
 }

--- a/cd/program/azure.go
+++ b/cd/program/azure.go
@@ -1,12 +1,14 @@
 package program
 
 import (
+	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
 	defangazure "github.com/DefangLabs/pulumi-defang/sdk/v2/go/defang-azure"
 	azurecompose "github.com/DefangLabs/pulumi-defang/sdk/v2/go/defang-azure/compose"
 	pulumiazure "github.com/pulumi/pulumi-azure-native-sdk/v3"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
+	"google.golang.org/protobuf/proto"
 )
 
 func deployAzure(ctx *pulumi.Context, cf *compose.Project, projectPb []byte) (pulumi.StringMapOutput, pulumi.StringPtrOutput, error) {
@@ -34,9 +36,31 @@ func deployAzure(ctx *pulumi.Context, cf *compose.Project, projectPb []byte) (pu
 	// pulumi.Provider(azureProvider) is required because
 	// pulumi:disable-default-providers excludes azure-native (see cd/main.go projectConfig).
 	if len(projectPb) > 0 {
-		if err := saveProjectPbAzure(ctx, projectPb, project, pulumi.Provider(azureProvider)); err != nil {
+		var pu defangv1.ProjectUpdate
+		// update projectPb with assigned endpoints and load balancer DNS (if applicable) before uploading
+		// unmarshal to a ProjectUpdate, update the fields, then marshal back to bytes
+		if err := proto.Unmarshal(projectPb, &pu); err != nil {
 			return pulumi.StringMapOutput{}, pulumi.StringPtrOutput{}, err
 		}
+		project.Endpoints.ApplyT(func(endpoints map[string]string) (map[string]string, error) {
+			for _, svc := range pu.Services {
+				svcName := svc.GetService().GetName()
+				svcEndpoint, ok := endpoints[svcName]
+				if !ok {
+					continue
+				}
+				svc.Endpoints = []string{svcEndpoint}
+			}
+			updatedProjectPb, err := proto.Marshal(&pu)
+			if err != nil {
+				return nil, err
+			}
+
+			if err := saveProjectPbAzure(ctx, updatedProjectPb, project, pulumi.Provider(azureProvider)); err != nil {
+				return nil, err
+			}
+			return endpoints, nil
+		})
 	}
 	return project.Endpoints, project.LoadBalancerDns, nil
 }

--- a/cd/program/azure.go
+++ b/cd/program/azure.go
@@ -37,30 +37,21 @@ func deployAzure(ctx *pulumi.Context, cf *compose.Project, projectPb []byte) (pu
 	// pulumi:disable-default-providers excludes azure-native (see cd/main.go projectConfig).
 	if len(projectPb) > 0 {
 		var pu defangv1.ProjectUpdate
-		// update projectPb with assigned endpoints and load balancer DNS (if applicable) before uploading
-		// unmarshal to a ProjectUpdate, update the fields, then marshal back to bytes
 		if err := proto.Unmarshal(projectPb, &pu); err != nil {
 			return pulumi.StringMapOutput{}, pulumi.StringPtrOutput{}, err
 		}
-		project.Endpoints.ApplyT(func(endpoints map[string]string) (map[string]string, error) {
+		updatedPb := project.Endpoints.ApplyT(func(endpoints map[string]string) ([]byte, error) {
 			for _, svc := range pu.Services {
-				svcName := svc.GetService().GetName()
-				svcEndpoint, ok := endpoints[svcName]
-				if !ok {
-					continue
+				if ep, ok := endpoints[svc.GetService().GetName()]; ok {
+					svc.Endpoints = []string{ep}
 				}
-				svc.Endpoints = []string{svcEndpoint}
 			}
-			updatedProjectPb, err := proto.Marshal(&pu)
-			if err != nil {
-				return nil, err
-			}
+			return proto.Marshal(&pu)
+		}).(pulumi.AnyOutput)
 
-			if err := saveProjectPbAzure(ctx, updatedProjectPb, project, pulumi.Provider(azureProvider)); err != nil {
-				return nil, err
-			}
-			return endpoints, nil
-		})
+		if err := saveProjectPbAzure(ctx, updatedPb, project, pulumi.Provider(azureProvider)); err != nil {
+			return pulumi.StringMapOutput{}, pulumi.StringPtrOutput{}, err
+		}
 	}
 	return project.Endpoints, project.LoadBalancerDns, nil
 }

--- a/cd/program/azure.go
+++ b/cd/program/azure.go
@@ -1,24 +1,27 @@
 package program
 
 import (
+	"fmt"
+	"strings"
+
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
+	"github.com/DefangLabs/pulumi-defang/provider/common"
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
 	defangazure "github.com/DefangLabs/pulumi-defang/sdk/v2/go/defang-azure"
 	azurecompose "github.com/DefangLabs/pulumi-defang/sdk/v2/go/defang-azure/compose"
+	"github.com/pulumi/pulumi-azure-native-sdk/storage/v3"
 	pulumiazure "github.com/pulumi/pulumi-azure-native-sdk/v3"
+	"github.com/pulumi/pulumi-azure-native-sdk/v3/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 	"google.golang.org/protobuf/proto"
 )
 
-func deployAzure(ctx *pulumi.Context, cf *compose.Project, projectPb []byte) (pulumi.StringMapOutput, pulumi.StringPtrOutput, error) {
-	azureCfg := config.New(ctx, "azure-native")
-
+func deployAzure(ctx *pulumi.Context, cf *compose.Project, projectUpdate *defangv1.ProjectUpdate) (pulumi.StringMapOutput, pulumi.StringPtrOutput, error) {
 	providerArgs := &pulumiazure.ProviderArgs{
-		Location:                  pulumi.StringPtr(azureCfg.Require("location")),
+		Location:                  pulumi.StringPtr(config.GetLocation(ctx)),
 		UseDefaultAzureCredential: pulumi.BoolPtr(true),
 	}
-	if subID := azureCfg.Get("subscriptionId"); subID != "" {
+	if subID := config.GetSubscriptionId(ctx); subID != "" {
 		providerArgs.SubscriptionId = pulumi.StringPtr(subID)
 	}
 	azureProvider, err := pulumiazure.NewProvider(ctx, "azure", providerArgs)
@@ -35,18 +38,14 @@ func deployAzure(ctx *pulumi.Context, cf *compose.Project, projectPb []byte) (pu
 	// the project component so it only runs after all services are created.
 	// pulumi.Provider(azureProvider) is required because
 	// pulumi:disable-default-providers excludes azure-native (see cd/main.go projectConfig).
-	if len(projectPb) > 0 {
-		var pu defangv1.ProjectUpdate
-		if err := proto.Unmarshal(projectPb, &pu); err != nil {
-			return pulumi.StringMapOutput{}, pulumi.StringPtrOutput{}, err
-		}
+	if projectUpdate != nil {
 		updatedPb := project.Endpoints.ApplyT(func(endpoints map[string]string) ([]byte, error) {
-			for _, svc := range pu.Services {
+			for _, svc := range projectUpdate.Services {
 				if ep, ok := endpoints[svc.GetService().GetName()]; ok {
 					svc.Endpoints = []string{ep}
 				}
 			}
-			return proto.Marshal(&pu)
+			return proto.Marshal(projectUpdate)
 		}).(pulumi.AnyOutput)
 
 		if err := saveProjectPbAzure(ctx, updatedPb, project, pulumi.Provider(azureProvider)); err != nil {
@@ -164,4 +163,50 @@ func toAzureServiceArgs(svc compose.ServiceConfig) azurecompose.ServiceConfigArg
 		args.Llm = azurecompose.LlmConfigArgs{}
 	}
 	return args
+}
+
+// saveProjectPbAzure uploads data as a Pulumi-managed Azure Blob in the CD
+// storage account's `projects` container. See saveProjectPbAWS for semantics.
+// data is a pulumi.AnyOutput wrapping []byte so callers can produce the bytes
+// inside an ApplyT (e.g. after updating endpoints) without creating resources
+// inside that callback.
+func saveProjectPbAzure(ctx *pulumi.Context, data pulumi.AnyOutput, dep pulumi.Resource, opts ...pulumi.ResourceOption) error {
+	u, err := parseStateURL(ctx)
+	if err != nil || u == nil {
+		return err
+	}
+	if u.Scheme != "azblob" {
+		return fmt.Errorf("DEFANG_STATE_URL must be an azblob:// URL for Azure uploads, got %q", u.String())
+	}
+	account := u.Query().Get("storage_account")
+	if account == "" {
+		return fmt.Errorf("DEFANG_STATE_URL %q missing storage_account", u.String())
+	}
+
+	// The CD storage account lives in the shared CD resource group, named
+	// `defang-cd-<location>` by convention (see defang/src/pkg/clouds/azure/cd/driver.go).
+	location := config.GetLocation(ctx)
+	if location == "" {
+		return fmt.Errorf("AZURE_LOCATION must be set to derive the CD resource group")
+	}
+	cdRG := "defang-cd-" + location
+
+	// Azure uses a dedicated `projects` container, so strip the AWS/GCS-style
+	// `projects/` prefix from the object key — otherwise the blob lands at
+	// `projects/projects/<project>/<stack>/project.pb`.
+	containerName, blobName, _ := strings.Cut(projectPbKey(ctx), "/")
+
+	source := data.ApplyT(func(v any) (pulumi.Asset, error) {
+		return NewTempFileAsset("project-pb-*.pb", v.([]byte))
+	}).(pulumi.AssetOutput)
+
+	_, err = storage.NewBlob(ctx, "project-pb", &storage.BlobArgs{
+		ResourceGroupName: pulumi.String(cdRG),
+		AccountName:       pulumi.String(account),
+		ContainerName:     pulumi.String(containerName),
+		BlobName:          pulumi.String(blobName),
+		Source:            source,
+		ContentType:       pulumi.String(protobufContentType),
+	}, common.MergeOptions(opts, pulumi.DependsOn([]pulumi.Resource{dep}))...)
+	return err
 }

--- a/cd/program/gcp.go
+++ b/cd/program/gcp.go
@@ -1,12 +1,14 @@
 package program
 
 import (
+	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
 	defanggcp "github.com/DefangLabs/pulumi-defang/sdk/v2/go/defang-gcp"
 	gcpcompose "github.com/DefangLabs/pulumi-defang/sdk/v2/go/defang-gcp/compose"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
+	"google.golang.org/protobuf/proto"
 )
 
 func deployGCP(ctx *pulumi.Context, cf *compose.Project, projectPb []byte) (pulumi.StringMapOutput, pulumi.StringPtrOutput, error) {
@@ -36,7 +38,20 @@ func deployGCP(ctx *pulumi.Context, cf *compose.Project, projectPb []byte) (pulu
 	// pulumi.Provider(gcpProvider) is required because
 	// pulumi:disable-default-providers excludes gcp (see cd/main.go projectConfig).
 	if len(projectPb) > 0 {
-		if err := saveProjectPbGCP(ctx, projectPb, project, pulumi.Provider(gcpProvider)); err != nil {
+		var pu defangv1.ProjectUpdate
+		if err := proto.Unmarshal(projectPb, &pu); err != nil {
+			return pulumi.StringMapOutput{}, pulumi.StringPtrOutput{}, err
+		}
+		updatedPb := project.Endpoints.ApplyT(func(endpoints map[string]string) ([]byte, error) {
+			for _, svc := range pu.Services {
+				if ep, ok := endpoints[svc.GetService().GetName()]; ok {
+					svc.Endpoints = []string{ep}
+				}
+			}
+			return proto.Marshal(&pu)
+		}).(pulumi.AnyOutput)
+
+		if err := saveProjectPbGCP(ctx, updatedPb, project, pulumi.Provider(gcpProvider)); err != nil {
 			return pulumi.StringMapOutput{}, pulumi.StringPtrOutput{}, err
 		}
 	}

--- a/cd/program/gcp.go
+++ b/cd/program/gcp.go
@@ -1,22 +1,24 @@
 package program
 
 import (
+	"fmt"
+
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
+	"github.com/DefangLabs/pulumi-defang/provider/common"
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
 	defanggcp "github.com/DefangLabs/pulumi-defang/sdk/v2/go/defang-gcp"
 	gcpcompose "github.com/DefangLabs/pulumi-defang/sdk/v2/go/defang-gcp/compose"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp"
+	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/config"
+	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/storage"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 	"google.golang.org/protobuf/proto"
 )
 
-func deployGCP(ctx *pulumi.Context, cf *compose.Project, projectPb []byte) (pulumi.StringMapOutput, pulumi.StringPtrOutput, error) {
-	gcpCfg := config.New(ctx, "gcp")
-
+func deployGCP(ctx *pulumi.Context, cf *compose.Project, projectUpdate *defangv1.ProjectUpdate) (pulumi.StringMapOutput, pulumi.StringPtrOutput, error) {
 	gcpProvider, err := gcp.NewProvider(ctx, "gcp", &gcp.ProviderArgs{
-		Project: pulumi.StringPtr(gcpCfg.Require("project")),
-		Region:  pulumi.StringPtr(gcpCfg.Require("region")),
+		Project: pulumi.StringPtr(config.GetProject(ctx)),
+		Region:  pulumi.StringPtr(config.GetRegion(ctx)),
 		DefaultLabels: pulumi.StringMap{
 			"defang-org":     pulumi.String(ctx.Organization()),
 			"defang-project": pulumi.String(ctx.Project()),
@@ -37,18 +39,14 @@ func deployGCP(ctx *pulumi.Context, cf *compose.Project, projectPb []byte) (pulu
 	// the project component so it only runs after all services are created.
 	// pulumi.Provider(gcpProvider) is required because
 	// pulumi:disable-default-providers excludes gcp (see cd/main.go projectConfig).
-	if len(projectPb) > 0 {
-		var pu defangv1.ProjectUpdate
-		if err := proto.Unmarshal(projectPb, &pu); err != nil {
-			return pulumi.StringMapOutput{}, pulumi.StringPtrOutput{}, err
-		}
+	if projectUpdate != nil {
 		updatedPb := project.Endpoints.ApplyT(func(endpoints map[string]string) ([]byte, error) {
-			for _, svc := range pu.Services {
+			for _, svc := range projectUpdate.Services {
 				if ep, ok := endpoints[svc.GetService().GetName()]; ok {
 					svc.Endpoints = []string{ep}
 				}
 			}
-			return proto.Marshal(&pu)
+			return proto.Marshal(projectUpdate)
 		}).(pulumi.AnyOutput)
 
 		if err := saveProjectPbGCP(ctx, updatedPb, project, pulumi.Provider(gcpProvider)); err != nil {
@@ -166,4 +164,31 @@ func toGCPServiceArgs(svc compose.ServiceConfig) gcpcompose.ServiceConfigArgs {
 		args.Llm = gcpcompose.LlmConfigArgs{}
 	}
 	return args
+}
+
+// saveProjectPbGCP uploads data as a Pulumi-managed GCS object at the key
+// derived from DEFANG_STATE_URL. See saveProjectPbAWS for semantics.
+// data is a pulumi.AnyOutput wrapping []byte so callers can produce the bytes
+// inside an ApplyT (e.g. after updating endpoints) without creating resources
+// inside that callback.
+func saveProjectPbGCP(ctx *pulumi.Context, data pulumi.AnyOutput, dep pulumi.Resource, opts ...pulumi.ResourceOption) error {
+	u, err := parseStateURL(ctx)
+	if err != nil || u == nil {
+		return err
+	}
+	if u.Scheme != "gs" || u.Host == "" {
+		return fmt.Errorf("DEFANG_STATE_URL must be a gs:// URL with a bucket for GCP uploads, got %q", u.String())
+	}
+
+	source := data.ApplyT(func(v any) (pulumi.Asset, error) {
+		return NewTempFileAsset("project-pb-*.pb", v.([]byte))
+	}).(pulumi.AssetOutput)
+
+	_, err = storage.NewBucketObject(ctx, "project-pb", &storage.BucketObjectArgs{
+		Bucket:      pulumi.String(u.Host),
+		Name:        pulumi.String(projectPbKey(ctx)),
+		Source:      source,
+		ContentType: pulumi.String(protobufContentType),
+	}, common.MergeOptions(opts, pulumi.DependsOn([]pulumi.Resource{dep}))...)
+	return err
 }

--- a/cd/program/program.go
+++ b/cd/program/program.go
@@ -3,13 +3,11 @@ package program
 import (
 	"errors"
 	"fmt"
-	"log"
 
-	"github.com/DefangLabs/pulumi-defang/provider/compose"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
+	"github.com/DefangLabs/pulumi-defang/provider/compose"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
-	"google.golang.org/protobuf/proto"
 	"gopkg.in/yaml.v3"
 )
 
@@ -25,21 +23,24 @@ func parseCompose(data []byte, projectName string) (*compose.Project, error) {
 }
 
 // NewRun returns a Pulumi inline program that deploys the given compose YAML.
-// projectPb is the raw ProjectUpdate protobuf; each per-provider deploy
+// projectUpdate is the ProjectUpdate protobuf; each per-provider deploy
 // function uploads it as a Pulumi-managed blob at the end of the deploy
 // (gated on the project component so the upload only happens on success).
-func NewRun(projectPb []byte) pulumi.RunFunc {
+func NewRun(projectUpdate *defangv1.ProjectUpdate) pulumi.RunFunc {
 	return func(ctx *pulumi.Context) error {
 		defangCfg := config.New(ctx, "defang")
 
 		provider := defangCfg.Require("provider") // "aws", "gcp", or "azure"
 		domain := defangCfg.Get("domain")         // optional project domain
 
-		composeYaml, err := extractComposeYaml(projectPb)
-		if err != nil {
-			log.Fatalf("failed to extract compose: %v", err)
+		if projectUpdate == nil {
+			return errors.New("ProjectUpdate is nil")
 		}
-		project, err := parseCompose(composeYaml, ctx.Project())
+		if len(projectUpdate.Compose) == 0 {
+			return errors.New("ProjectUpdate has no compose field")
+		}
+
+		project, err := parseCompose(projectUpdate.Compose, ctx.Project())
 		if err != nil {
 			return err
 		}
@@ -49,11 +50,11 @@ func NewRun(projectPb []byte) pulumi.RunFunc {
 
 		switch provider {
 		case "aws":
-			endpoints, loadBalancerDns, err = deployAWS(ctx, project, domain, projectPb)
+			endpoints, loadBalancerDns, err = deployAWS(ctx, project, domain, projectUpdate)
 		case "gcp":
-			endpoints, loadBalancerDns, err = deployGCP(ctx, project, projectPb)
+			endpoints, loadBalancerDns, err = deployGCP(ctx, project, projectUpdate)
 		case "azure":
-			endpoints, loadBalancerDns, err = deployAzure(ctx, project, projectPb)
+			endpoints, loadBalancerDns, err = deployAzure(ctx, project, projectUpdate)
 		default:
 			return fmt.Errorf("unsupported provider: %q (must be aws, gcp, or azure)", provider)
 		}
@@ -66,19 +67,4 @@ func NewRun(projectPb []byte) pulumi.RunFunc {
 
 		return nil
 	}
-}
-
-// extractComposeYaml unmarshals a ProjectUpdate protobuf and returns its
-// embedded compose YAML bytes. Errors if the protobuf is malformed or the
-// Compose field is empty (e.g. the CLI sent a ProjectUpdate without a
-// compose file).
-func extractComposeYaml(projectUpdate []byte) ([]byte, error) {
-	var pu defangv1.ProjectUpdate
-	if err := proto.Unmarshal(projectUpdate, &pu); err != nil {
-		return nil, fmt.Errorf("unmarshaling ProjectUpdate: %w", err)
-	}
-	if len(pu.Compose) == 0 {
-		return nil, errors.New("ProjectUpdate has no compose field")
-	}
-	return pu.Compose, nil
 }

--- a/cd/program/project_pb.go
+++ b/cd/program/project_pb.go
@@ -53,7 +53,10 @@ func saveProjectPbAWS(ctx *pulumi.Context, data []byte, dep pulumi.Resource, ext
 
 // saveProjectPbGCP uploads data as a Pulumi-managed GCS object at the key
 // derived from DEFANG_STATE_URL. See saveProjectPbAWS for semantics.
-func saveProjectPbGCP(ctx *pulumi.Context, data []byte, dep pulumi.Resource, extraOpts ...pulumi.ResourceOption) error {
+// data is a pulumi.AnyOutput wrapping []byte so callers can produce the bytes
+// inside an ApplyT (e.g. after updating endpoints) without creating resources
+// inside that callback.
+func saveProjectPbGCP(ctx *pulumi.Context, data pulumi.AnyOutput, dep pulumi.Resource, extraOpts ...pulumi.ResourceOption) error {
 	stateURL := os.Getenv("DEFANG_STATE_URL")
 	if stateURL == "" {
 		return fmt.Errorf("DEFANG_STATE_URL is not set; cannot upload project.pb")
@@ -65,23 +68,36 @@ func saveProjectPbGCP(ctx *pulumi.Context, data []byte, dep pulumi.Resource, ext
 	if u.Scheme != "gs" || u.Host == "" {
 		return fmt.Errorf("DEFANG_STATE_URL must be a gs:// URL with a bucket for GCP uploads, got %q", stateURL)
 	}
+
+	cleanupCh := make(chan func(), 1)
+	source := data.ApplyT(func(v any) (pulumi.AssetOrArchive, error) {
+		asset, cleanup, err := binaryFileAsset(v.([]byte), "project-pb-*.pb")
+		if err != nil {
+			return nil, err
+		}
+		cleanupCh <- cleanup
+		return asset, nil
+	}).(pulumi.AssetOrArchiveOutput)
+
 	opts := append([]pulumi.ResourceOption{pulumi.DependsOn([]pulumi.Resource{dep})}, extraOpts...)
-	asset, cleanup, err := binaryFileAsset(data, "project-pb-*.pb")
-	if err != nil {
-		return err
-	}
 	obj, err := gcpstorage.NewBucketObject(ctx, "project-pb", &gcpstorage.BucketObjectArgs{
 		Bucket:      pulumi.String(u.Host),
 		Name:        pulumi.String(projectPbKey(ctx)),
-		Source:      asset,
+		Source:      source,
 		ContentType: pulumi.String("application/protobuf"),
 	}, opts...)
 	if err != nil {
-		cleanup()
 		return err
 	}
-	// Remove the temp file after the blob has been created (Crc32c resolves post-create).
-	obj.Crc32c.ApplyT(func(string) error { cleanup(); return nil })
+	// Remove the temp file after the object has been created (Crc32c resolves post-create).
+	obj.Crc32c.ApplyT(func(string) error {
+		select {
+		case fn := <-cleanupCh:
+			fn()
+		default:
+		}
+		return nil
+	})
 	return nil
 }
 

--- a/cd/program/project_pb.go
+++ b/cd/program/project_pb.go
@@ -1,16 +1,27 @@
 package program
 
 import (
-	"encoding/base64"
 	"fmt"
 	"net/url"
 	"os"
 
-	awss3 "github.com/pulumi/pulumi-aws/sdk/v7/go/aws/s3"
-	azurestorage "github.com/pulumi/pulumi-azure-native-sdk/storage/v3"
-	gcpstorage "github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/storage"
+	"github.com/DefangLabs/pulumi-defang/provider/common"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
+
+const protobufContentType = "application/protobuf"
+
+func parseStateURL(ctx *pulumi.Context) (*url.URL, error) {
+	stateURL := common.String("stateUrl", "").Get(ctx)
+	if stateURL == "" {
+		return nil, nil
+	}
+	u, err := url.Parse(stateURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid DEFANG_STATE_URL %q: %w", stateURL, err)
+	}
+	return u, nil
+}
 
 // projectPbKey returns the object-store key for the ProjectUpdate protobuf:
 // `projects/{project}/{stack}/project.pb`. For Azure, the `projects/` prefix
@@ -19,176 +30,21 @@ func projectPbKey(ctx *pulumi.Context) string {
 	return fmt.Sprintf("projects/%s/%s/project.pb", ctx.Project(), ctx.Stack())
 }
 
-// saveProjectPbAWS uploads data as a Pulumi-managed S3 object at the key
-// derived from DEFANG_STATE_URL. Gated on dep so the upload only runs after
-// the project component (and its services) have been created successfully —
-// matching the pattern used by the legacy defang-mvp CD pipeline.
-//
-// extraOpts should include pulumi.Provider(...) because
-// pulumi:disable-default-providers excludes aws (see cd/main.go projectConfig).
-func saveProjectPbAWS(ctx *pulumi.Context, data []byte, dep pulumi.Resource, extraOpts ...pulumi.ResourceOption) error {
-	stateURL := os.Getenv("DEFANG_STATE_URL")
-	if stateURL == "" {
-		return fmt.Errorf("DEFANG_STATE_URL is not set; cannot upload project.pb")
-	}
-	u, err := url.Parse(stateURL)
-	if err != nil {
-		return fmt.Errorf("invalid DEFANG_STATE_URL %q: %w", stateURL, err)
-	}
-	if u.Scheme != "s3" || u.Host == "" {
-		return fmt.Errorf("DEFANG_STATE_URL must be an s3:// URL with a bucket for AWS uploads, got %q", stateURL)
-	}
-	opts := append([]pulumi.ResourceOption{pulumi.DependsOn([]pulumi.Resource{dep})}, extraOpts...)
-	// ContentBase64 preserves binary bytes; Content (string) would fail gRPC
-	// marshaling because protobuf is not valid UTF-8. The provider decodes
-	// the base64 server-side and stores raw bytes in S3.
-	_, err = awss3.NewBucketObjectv2(ctx, "project-pb", &awss3.BucketObjectv2Args{
-		Bucket:        pulumi.String(u.Host),
-		Key:           pulumi.String(projectPbKey(ctx)),
-		ContentBase64: pulumi.String(base64.StdEncoding.EncodeToString(data)),
-		ContentType:   pulumi.String("application/protobuf"),
-	}, opts...)
-	return err
-}
-
-// saveProjectPbGCP uploads data as a Pulumi-managed GCS object at the key
-// derived from DEFANG_STATE_URL. See saveProjectPbAWS for semantics.
-// data is a pulumi.AnyOutput wrapping []byte so callers can produce the bytes
-// inside an ApplyT (e.g. after updating endpoints) without creating resources
-// inside that callback.
-func saveProjectPbGCP(ctx *pulumi.Context, data pulumi.AnyOutput, dep pulumi.Resource, extraOpts ...pulumi.ResourceOption) error {
-	stateURL := os.Getenv("DEFANG_STATE_URL")
-	if stateURL == "" {
-		return fmt.Errorf("DEFANG_STATE_URL is not set; cannot upload project.pb")
-	}
-	u, err := url.Parse(stateURL)
-	if err != nil {
-		return fmt.Errorf("invalid DEFANG_STATE_URL %q: %w", stateURL, err)
-	}
-	if u.Scheme != "gs" || u.Host == "" {
-		return fmt.Errorf("DEFANG_STATE_URL must be a gs:// URL with a bucket for GCP uploads, got %q", stateURL)
-	}
-
-	cleanupCh := make(chan func(), 1)
-	source := data.ApplyT(func(v any) (pulumi.AssetOrArchive, error) {
-		asset, cleanup, err := binaryFileAsset(v.([]byte), "project-pb-*.pb")
-		if err != nil {
-			return nil, err
-		}
-		cleanupCh <- cleanup
-		return asset, nil
-	}).(pulumi.AssetOrArchiveOutput)
-
-	opts := append([]pulumi.ResourceOption{pulumi.DependsOn([]pulumi.Resource{dep})}, extraOpts...)
-	obj, err := gcpstorage.NewBucketObject(ctx, "project-pb", &gcpstorage.BucketObjectArgs{
-		Bucket:      pulumi.String(u.Host),
-		Name:        pulumi.String(projectPbKey(ctx)),
-		Source:      source,
-		ContentType: pulumi.String("application/protobuf"),
-	}, opts...)
-	if err != nil {
-		return err
-	}
-	// Remove the temp file after the object has been created (Crc32c resolves post-create).
-	obj.Crc32c.ApplyT(func(string) error {
-		select {
-		case fn := <-cleanupCh:
-			fn()
-		default:
-		}
-		return nil
-	})
-	return nil
-}
-
-// saveProjectPbAzure uploads data as a Pulumi-managed Azure Blob in the CD
-// storage account's `projects` container. See saveProjectPbAWS for semantics.
-// data is a pulumi.AnyOutput wrapping []byte so callers can produce the bytes
-// inside an ApplyT (e.g. after updating endpoints) without creating resources
-// inside that callback.
-func saveProjectPbAzure(ctx *pulumi.Context, data pulumi.AnyOutput, dep pulumi.Resource, extraOpts ...pulumi.ResourceOption) error {
-	stateURL := os.Getenv("DEFANG_STATE_URL")
-	if stateURL == "" {
-		return fmt.Errorf("DEFANG_STATE_URL is not set; cannot upload project.pb")
-	}
-	u, err := url.Parse(stateURL)
-	if err != nil {
-		return fmt.Errorf("invalid DEFANG_STATE_URL %q: %w", stateURL, err)
-	}
-	if u.Scheme != "azblob" {
-		return fmt.Errorf("DEFANG_STATE_URL must be an azblob:// URL for Azure uploads, got %q", stateURL)
-	}
-	account := u.Query().Get("storage_account")
-	if account == "" {
-		return fmt.Errorf("DEFANG_STATE_URL %q missing storage_account", stateURL)
-	}
-	// The CD storage account lives in the shared CD resource group, named
-	// `defang-cd-<location>` by convention (see defang/src/pkg/clouds/azure/cd/driver.go).
-	location := os.Getenv("AZURE_LOCATION")
-	if location == "" {
-		return fmt.Errorf("AZURE_LOCATION must be set to derive the CD resource group")
-	}
-	cdRG := "defang-cd-" + location
-
-	// Azure uses a dedicated `projects` container, so strip the AWS/GCS-style
-	// `projects/` prefix from the object key — otherwise the blob lands at
-	// `projects/projects/<project>/<stack>/project.pb`.
-	blobName := fmt.Sprintf("%s/%s/project.pb", ctx.Project(), ctx.Stack())
-
-	// cleanupCh carries the temp-file cleanup fn from the source ApplyT to the
-	// post-create ApplyT below; buffer of 1 avoids blocking if cleanup fires
-	// before the consumer runs (e.g. during a dry-run).
-	cleanupCh := make(chan func(), 1)
-	source := data.ApplyT(func(v any) (pulumi.AssetOrArchive, error) {
-		asset, cleanup, err := binaryFileAsset(v.([]byte), "project-pb-*.pb")
-		if err != nil {
-			return nil, err
-		}
-		cleanupCh <- cleanup
-		return asset, nil
-	}).(pulumi.AssetOrArchiveOutput)
-
-	opts := append([]pulumi.ResourceOption{pulumi.DependsOn([]pulumi.Resource{dep})}, extraOpts...)
-	blob, err := azurestorage.NewBlob(ctx, "project-pb", &azurestorage.BlobArgs{
-		ResourceGroupName: pulumi.String(cdRG),
-		AccountName:       pulumi.String(account),
-		ContainerName:     pulumi.String("projects"),
-		BlobName:          pulumi.String(blobName),
-		Source:            source,
-		ContentType:       pulumi.StringPtr("application/protobuf"),
-	}, opts...)
-	if err != nil {
-		return err
-	}
-	blob.Url.ApplyT(func(string) error {
-		select {
-		case fn := <-cleanupCh:
-			fn()
-		default:
-		}
-		return nil
-	})
-	return nil
-}
-
-// binaryFileAsset writes data to a temp file and returns a FileAsset referencing it.
+// NewTempFileAsset writes data to a temp file and returns a FileAsset referencing it.
 // Pulumi's StringAsset rejects non-UTF-8 data (gRPC marshal error), so binary
-// protobufs must go through the filesystem. Returned cleanup should be invoked
-// after the consuming resource has been created.
-func binaryFileAsset(data []byte, pattern string) (pulumi.Asset, func(), error) {
-	f, err := os.CreateTemp("", pattern)
+// protobufs must go through the filesystem. The temp file is left for the OS
+// to reap — it's a few KB and Pulumi may still be reading it after this returns.
+func NewTempFileAsset(pattern string, data []byte) (pulumi.Asset, error) {
+	f, err := os.CreateTemp("defang-cd", pattern)
 	if err != nil {
-		return nil, func() {}, fmt.Errorf("creating temp file for project.pb: %w", err)
+		return nil, fmt.Errorf("creating temp file for project.pb: %w", err)
 	}
-	cleanup := func() { _ = os.Remove(f.Name()) }
 	if _, err := f.Write(data); err != nil {
 		f.Close()
-		cleanup()
-		return nil, func() {}, fmt.Errorf("writing temp file for project.pb: %w", err)
+		return nil, fmt.Errorf("writing temp file for project.pb: %w", err)
 	}
 	if err := f.Close(); err != nil {
-		cleanup()
-		return nil, func() {}, fmt.Errorf("closing temp file for project.pb: %w", err)
+		return nil, fmt.Errorf("closing temp file for project.pb: %w", err)
 	}
-	return pulumi.NewFileAsset(f.Name()), cleanup, nil
+	return pulumi.NewFileAsset(f.Name()), nil
 }

--- a/cd/program/project_pb.go
+++ b/cd/program/project_pb.go
@@ -87,7 +87,10 @@ func saveProjectPbGCP(ctx *pulumi.Context, data []byte, dep pulumi.Resource, ext
 
 // saveProjectPbAzure uploads data as a Pulumi-managed Azure Blob in the CD
 // storage account's `projects` container. See saveProjectPbAWS for semantics.
-func saveProjectPbAzure(ctx *pulumi.Context, data []byte, dep pulumi.Resource, extraOpts ...pulumi.ResourceOption) error {
+// data is a pulumi.AnyOutput wrapping []byte so callers can produce the bytes
+// inside an ApplyT (e.g. after updating endpoints) without creating resources
+// inside that callback.
+func saveProjectPbAzure(ctx *pulumi.Context, data pulumi.AnyOutput, dep pulumi.Resource, extraOpts ...pulumi.ResourceOption) error {
 	stateURL := os.Getenv("DEFANG_STATE_URL")
 	if stateURL == "" {
 		return fmt.Errorf("DEFANG_STATE_URL is not set; cannot upload project.pb")
@@ -116,24 +119,39 @@ func saveProjectPbAzure(ctx *pulumi.Context, data []byte, dep pulumi.Resource, e
 	// `projects/projects/<project>/<stack>/project.pb`.
 	blobName := fmt.Sprintf("%s/%s/project.pb", ctx.Project(), ctx.Stack())
 
+	// cleanupCh carries the temp-file cleanup fn from the source ApplyT to the
+	// post-create ApplyT below; buffer of 1 avoids blocking if cleanup fires
+	// before the consumer runs (e.g. during a dry-run).
+	cleanupCh := make(chan func(), 1)
+	source := data.ApplyT(func(v any) (pulumi.AssetOrArchive, error) {
+		asset, cleanup, err := binaryFileAsset(v.([]byte), "project-pb-*.pb")
+		if err != nil {
+			return nil, err
+		}
+		cleanupCh <- cleanup
+		return asset, nil
+	}).(pulumi.AssetOrArchiveOutput)
+
 	opts := append([]pulumi.ResourceOption{pulumi.DependsOn([]pulumi.Resource{dep})}, extraOpts...)
-	asset, cleanup, err := binaryFileAsset(data, "project-pb-*.pb")
-	if err != nil {
-		return err
-	}
 	blob, err := azurestorage.NewBlob(ctx, "project-pb", &azurestorage.BlobArgs{
 		ResourceGroupName: pulumi.String(cdRG),
 		AccountName:       pulumi.String(account),
 		ContainerName:     pulumi.String("projects"),
 		BlobName:          pulumi.String(blobName),
-		Source:            asset,
+		Source:            source,
 		ContentType:       pulumi.StringPtr("application/protobuf"),
 	}, opts...)
 	if err != nil {
-		cleanup()
 		return err
 	}
-	blob.Url.ApplyT(func(string) error { cleanup(); return nil })
+	blob.Url.ApplyT(func(string) error {
+		select {
+		case fn := <-cleanupCh:
+			fn()
+		default:
+		}
+		return nil
+	})
 	return nil
 }
 

--- a/provider/defangazure/acr_image_build.go
+++ b/provider/defangazure/acr_image_build.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -277,7 +278,18 @@ func stageBuildContextToACR(
 	rc *armcontainerregistry.RegistriesClient,
 	rgName, registryName, sourceURL string,
 ) (string, error) {
-	bc, err := blob.NewClient(sourceURL, cred, nil)
+	// A SAS URL is self-authenticating via query params; passing a credential
+	// alongside it causes Azure to reject the request with InvalidAuthenticationInfo
+	// (two auth methods conflict). Use no-credential client when a SAS is present.
+	var (
+		bc  *blob.Client
+		err error
+	)
+	if u, _ := url.Parse(sourceURL); u != nil && u.RawQuery != "" {
+		bc, err = blob.NewClientWithNoCredential(sourceURL, nil)
+	} else {
+		bc, err = blob.NewClient(sourceURL, cred, nil)
+	}
 	if err != nil {
 		return "", fmt.Errorf("creating blob client for %s: %w", sourceURL, err)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Azure and GCP deployments now persist and publish the actual assigned service endpoints so deployed services reflect their real endpoints.
  * Image staging detects SAS blob URLs and uses anonymous access when appropriate to avoid authentication errors during builds.

* **Chores**
  * CI workflow trigger updated to run on changes in the deployment/configuration directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->