### PR TITLE
fix(upload): marshal EngineEvent asap to avoid mem leak

### DIFF
--- a/cd/main.go
+++ b/cd/main.go
@@ -205,14 +205,18 @@ func collectEvents(ctx context.Context) (chan<- events.EngineEvent, func()) {
 		// LIFO: close(done) runs last so waitEvents() only unblocks after
 		// uploadEvents returns, even on panic in the loop.
 		defer close(done)
-		var engineEvents []events.EngineEvent
+		// The events are marshaled asap so we capture the original event data
+		// before any of it gets mutated. This also allows the GC to collect
+		// the original event objects sooner instead of keeping them alive.
+		var engineEvents []json.RawMessage
 		defer func() {
 			uploadEvents(ctx, engineEvents)
 		}()
 		// Pulumi automation will close the channel when done: https://github.com/pulumi/pulumi/blob/master/sdk/go/auto/stack.go#L1956
 		for evt := range eventsChannel {
 			if eventsUploadUrl != "" {
-				engineEvents = append(engineEvents, evt)
+				bytes, _ := json.Marshal(evt)
+				engineEvents = append(engineEvents, json.RawMessage(bytes))
 			}
 			if jsonOutput {
 				if evt.ResourcePreEvent != nil {

--- a/cd/main_test.go
+++ b/cd/main_test.go
@@ -1,7 +1,14 @@
 package main
 
 import (
+	"compress/gzip"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/auto/events"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
 
 func TestColor(t *testing.T) {
@@ -335,5 +342,30 @@ func TestStackConfigAzure(t *testing.T) {
 	}
 	if cfg["azure-native:subscriptionId"].Value != "sub-123" {
 		t.Errorf("expected subscriptionId, got %q", cfg["azure-native:subscriptionId"].Value)
+	}
+}
+
+func TestCollectEvents(t *testing.T) {
+	savedEventsUploadUrl := eventsUploadUrl
+	t.Cleanup(func() { eventsUploadUrl = savedEventsUploadUrl })
+
+	var engineEvents map[string][]events.EngineEvent
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gz, _ := gzip.NewReader(r.Body)
+		defer gz.Close()
+		json.NewDecoder(gz).Decode(&engineEvents)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	eventsUploadUrl = srv.URL
+	ch, wait := collectEvents(t.Context())
+	ch <- events.EngineEvent{EngineEvent: apitype.EngineEvent{Sequence: 1}}
+	ch <- events.EngineEvent{EngineEvent: apitype.EngineEvent{Sequence: 2}}
+	close(ch)
+	wait()
+
+	if len(engineEvents["events"]) != 2 {
+		t.Errorf("expected 2 events, got %d", len(engineEvents["events"]))
 	}
 }

--- a/cd/upload.go
+++ b/cd/upload.go
@@ -14,13 +14,14 @@ import (
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
-	"github.com/pulumi/pulumi/sdk/v3/go/auto/events"
 )
 
-func uploadEvents(ctx context.Context, engineEvents []events.EngineEvent) {
+func uploadEvents[T any](ctx context.Context, engineEvents []T) {
 	if eventsUploadUrl == "" {
 		return
 	}
+	// We also upload empty events to signal the Portal that the deployment has
+	// completed, so log at least the count even if the upload fails.
 	Println("Sending", len(engineEvents), "deployment events to Portal...")
 	if err := doUpload(ctx, eventsUploadUrl, map[string]any{"events": engineEvents}); err != nil {
 		warn("Failed to send events:", err)

--- a/cd/upload_test.go
+++ b/cd/upload_test.go
@@ -51,19 +51,19 @@ func TestUploadEventsEmpty(t *testing.T) {
 	eventsUploadUrl = srv.URL
 	t.Cleanup(func() { eventsUploadUrl = saved })
 
-	uploadEvents(t.Context(), nil)
+	uploadEvents[any](t.Context(), nil)
 	uploadEvents(t.Context(), []events.EngineEvent{})
 
 	if called.Load() != 2 {
-		t.Errorf("expected 2 HTTP requests for empty events, got %d", called.Load())
+		t.Error("expected 2 HTTP requests for empty events")
 	}
 }
 
 func TestUploadEventsNoUrl(t *testing.T) {
 	// Should not send request when URL is empty
-	called := false
+	var called atomic.Bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		called = true
+		called.Store(true)
 	}))
 	t.Cleanup(srv.Close)
 
@@ -73,7 +73,7 @@ func TestUploadEventsNoUrl(t *testing.T) {
 
 	uploadEvents(t.Context(), []events.EngineEvent{{}})
 
-	if called {
+	if called.Load() {
 		t.Error("expected no HTTP request when URL is empty")
 	}
 }


### PR DESCRIPTION
Tested! JSON does indeed use less memory, plus we ensure we get the right events (snapshots).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end test to validate event collection and delivery using a local HTTP server.
  * Improved test synchronization and request-detection for more reliable assertions.

* **Refactor**
  * Generalized event upload handling to support more flexible event payload types and immediate payload buffering prior to upload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->