### PR TITLE
fix event channel deadlock; gate LLM PE on account readiness

### DIFF
--- a/cd/main.go
+++ b/cd/main.go
@@ -189,9 +189,10 @@ func stackConfig() (auto.ConfigMap, error) {
 // completes before run() returns and its deferred ctx cancels fire —
 // otherwise the in-flight uploadEvents request gets canceled.
 func collectEvents(ctx context.Context) (chan<- events.EngineEvent, func()) {
-	if eventsUploadUrl == "" && !jsonOutput {
-		return nil, func() {}
-	}
+	// Always create a real channel even when there's no consumer (no upload URL,
+	// no JSON output). Returning nil makes Pulumi's auto SDK block forever on
+	// a chan-send to a nil channel — the events.StreamEvents goroutine
+	// deadlocks and the deploy never completes.
 	eventsChannel := make(chan events.EngineEvent)
 	done := make(chan struct{})
 	go func() {
@@ -204,7 +205,9 @@ func collectEvents(ctx context.Context) (chan<- events.EngineEvent, func()) {
 		}()
 		// Pulumi automation will close the channel when done: https://github.com/pulumi/pulumi/blob/master/sdk/go/auto/stack.go#L1956
 		for evt := range eventsChannel {
-			engineEvents = append(engineEvents, evt)
+			if eventsUploadUrl != "" {
+				engineEvents = append(engineEvents, evt)
+			}
 			if jsonOutput {
 				if evt.ResourcePreEvent != nil {
 					data, _ := json.Marshal(evt.ResourcePreEvent.Metadata)

--- a/defang-azure.mk
+++ b/defang-azure.mk
@@ -100,8 +100,24 @@ sdks: go_sdk nodejs_sdk python_sdk dotnet_sdk
 build: provider schema sdks
 
 .PHONY: install
-install: provider
+install: provider install_plugin
 	cp "$(WORKING_DIR)/bin/${PROVIDER}" "${GOPATH}/bin"
+
+# install_plugin overwrites the resource-defang-azure plugin in
+# ~/.pulumi/plugins/ so that local Pulumi CLI / inline programs
+# (DEFANG_PULUMI_DIR mode) pick up the freshly-built provider rather
+# than a stale binary from a prior `pulumi plugin install` run.
+#
+# Pulumi resolves the plugin version from schema.json (recorded in the
+# generated SDK), which on a dirty tree can drift from $(VERSION) (the
+# git-tag-derived value). Install under the schema's version so the
+# lookup path matches.
+SCHEMA_VERSION  := $(shell jq -r .version "$(WORKING_DIR)/$(PROVIDER_PATH)/cmd/$(PROVIDER)/schema.json" 2>/dev/null || echo "$(VERSION)")
+.PHONY: install_plugin
+install_plugin: provider
+	mkdir -p "$(HOME)/.pulumi/plugins/resource-$(PACK)-v$(SCHEMA_VERSION)"
+	cp "$(WORKING_DIR)/bin/${PROVIDER}" "$(HOME)/.pulumi/plugins/resource-$(PACK)-v$(SCHEMA_VERSION)/${PROVIDER}"
+	@echo "Installed plugin: $(HOME)/.pulumi/plugins/resource-$(PACK)-v$(SCHEMA_VERSION)/${PROVIDER}"
 
 .PHONY: clean
 clean:

--- a/defang-azure.mk
+++ b/defang-azure.mk
@@ -115,9 +115,7 @@ install: provider install_plugin
 SCHEMA_VERSION  := $(shell jq -r .version "$(WORKING_DIR)/$(PROVIDER_PATH)/cmd/$(PROVIDER)/schema.json" 2>/dev/null || echo "$(VERSION)")
 .PHONY: install_plugin
 install_plugin: provider
-	mkdir -p "$(HOME)/.pulumi/plugins/resource-$(PACK)-v$(SCHEMA_VERSION)"
-	cp "$(WORKING_DIR)/bin/${PROVIDER}" "$(HOME)/.pulumi/plugins/resource-$(PACK)-v$(SCHEMA_VERSION)/${PROVIDER}"
-	@echo "Installed plugin: $(HOME)/.pulumi/plugins/resource-$(PACK)-v$(SCHEMA_VERSION)/${PROVIDER}"
+	pulumi plugin install resource $(PACK) $(SCHEMA_VERSION) -f "$(WORKING_DIR)/bin/$(PROVIDER)" --reinstall
 
 .PHONY: clean
 clean:

--- a/provider/defangazure/azure/llm.go
+++ b/provider/defangazure/azure/llm.go
@@ -108,19 +108,25 @@ func CreateLLMInfra(
 		return nil, fmt.Errorf("creating Azure AI Foundry account: %w", err)
 	}
 
-	if useVNet {
-		if err := createLLMPrivateEndpoint(ctx, name, account, infra, opts...); err != nil {
-			return nil, fmt.Errorf("creating LLM private endpoint: %w", err)
-		}
-	}
-
 	// pulumi.Parent(account) routes the invoke through the account's provider —
 	// required because pulumi:disable-default-providers excludes azure-native
 	// (see cd/main.go projectConfig).
+	//
+	// Called *before* the PE so its resolution can act as a sync barrier:
+	// pulumi-azure-native treats the account LRO as complete at state=Accepted,
+	// but ListAccountKeys won't succeed until the account is actually
+	// provisioned. Threading keysOut.Key1() into the PE's PrivateLinkServiceId
+	// gates PE creation on real account readiness.
 	keysOut := cognitiveservices.ListAccountKeysOutput(ctx, cognitiveservices.ListAccountKeysOutputArgs{
 		AccountName:       account.Name,
 		ResourceGroupName: infra.ResourceGroup.Name,
 	}, pulumi.Parent(account))
+
+	if useVNet {
+		if err := createLLMPrivateEndpoint(ctx, name, account, keysOut, infra, opts...); err != nil {
+			return nil, fmt.Errorf("creating LLM private endpoint: %w", err)
+		}
+	}
 
 	apiKey := keysOut.Key1().ApplyT(func(k *string) string {
 		if k != nil {
@@ -257,10 +263,20 @@ func createLLMPrivateEndpoint(
 	ctx *pulumi.Context,
 	serviceName string,
 	account *cognitiveservices.Account,
+	keysOut cognitiveservices.ListAccountKeysResultOutput,
 	infra *SharedInfra,
 	opts ...pulumi.ResourceOption,
 ) error {
 	peName := serviceName + "-llm"
+	// Gate PrivateLinkServiceId on keysOut so PE creation waits for the
+	// account to be actually provisioned. Plain account.ID() resolves at
+	// state=Accepted, which Azure rejects with AccountProvisioningStateInvalid
+	// when used as PE PrivateLinkServiceId.
+	gatedAccountID := pulumi.All(account.ID(), keysOut.Key1()).ApplyT(
+		func(args []interface{}) string {
+			return string(args[0].(pulumi.ID))
+		},
+	).(pulumi.StringOutput)
 	pe, err := network.NewPrivateEndpoint(ctx, peName, &network.PrivateEndpointArgs{
 		ResourceGroupName: infra.ResourceGroup.Name,
 		// Location:          pulumi.StringPtr(location),
@@ -270,7 +286,7 @@ func createLLMPrivateEndpoint(
 		PrivateLinkServiceConnections: network.PrivateLinkServiceConnectionArray{
 			&network.PrivateLinkServiceConnectionArgs{
 				Name:                 pulumi.String(peName),
-				PrivateLinkServiceId: account.ID().ToStringOutput(),
+				PrivateLinkServiceId: gatedAccountID,
 				GroupIds:             pulumi.StringArray{pulumi.String("account")},
 			},
 		},

--- a/provider/defangazure/project.go
+++ b/provider/defangazure/project.go
@@ -421,13 +421,15 @@ func setupSharedInfra(
 func (*Project) Construct(
 	ctx *pulumi.Context, name, typ string, inputs ProjectInputs, opts pulumi.ResourceOption,
 ) (*ProjectOutputs, error) {
+	baseTags := providerazure.BaseTags(ctx, inputs.Etag)
+
 	// Cascade a transformation to all child resources that injects
 	// defang-project / defang-stack / defang-etag into every azure-native
 	// resource's Tags. azure-native has no DefaultTags, and pulumi-go-provider's
 	// Construct ctx lacks a stack so RegisterStackTransformation panics — the
 	// resource-level Transformations option is the supported cascade.
 	tagOpts := opts
-	if t := providerazure.DefaultTagsTransformation(providerazure.BaseTags(ctx, inputs.Etag)); t != nil {
+	if t := providerazure.DefaultTagsTransformation(baseTags); t != nil {
 		tagOpts = pulumi.Composite(opts, pulumi.Transformations([]pulumi.ResourceTransformation{t}))
 	}
 


### PR DESCRIPTION
- cd: always create event channel; nil channel deadlocks Pulumi's StreamEvents goroutine
- llm: thread ListAccountKeys through PrivateEndpoint to wait for real account provisioning (Accepted state rejects PE attach)
- azure.mk: add install_plugin to overwrite ~/.pulumi/plugins binary using schema.json version to prevent running local cd with outdated provider