### PR TITLE
Change recipe for Azure

### DIFF
--- a/cd/program/azure.go
+++ b/cd/program/azure.go
@@ -184,8 +184,8 @@ func saveProjectPbAzure(ctx *pulumi.Context, data pulumi.AnyOutput, dep pulumi.R
 	if err != nil || u == nil {
 		return err
 	}
-	if u.Scheme != "azblob" {
-		return fmt.Errorf("DEFANG_STATE_URL must be an azblob:// URL for Azure uploads, got %q", u.String())
+	if u.Scheme != "azblob" || u.Host == "" {
+		return fmt.Errorf("DEFANG_STATE_URL must be an azblob:// URL with a container for Azure uploads, got %q", u.String())
 	}
 	account := u.Query().Get("storage_account")
 	if account == "" {

--- a/provider/defangazure/azure/postgres.go
+++ b/provider/defangazure/azure/postgres.go
@@ -94,11 +94,11 @@ func buildPostgresServerArgs(
 		Version:           pg.Version,
 		Tags:              ServiceTags(serviceName),
 		Sku: &dbforpostgresql.SkuArgs{
-			Name: pulumi.String(SkuName.Get(ctx)),
+			Name: pulumi.String(PostgresSku.Get(ctx)),
 			Tier: pulumi.String(string(dbforpostgresql.SkuTierBurstable)),
 		},
 		Storage: &dbforpostgresql.StorageArgs{
-			StorageSizeGB: pulumi.Int(StorageSizeGB.Get(ctx)),
+			StorageSizeGB: pulumi.Int(PostgresStorageSizeGB.Get(ctx)),
 		},
 		Backup: &dbforpostgresql.BackupTypeArgs{
 			BackupRetentionDays: pulumi.Int(backupRetention),

--- a/provider/defangazure/azure/postgres.go
+++ b/provider/defangazure/azure/postgres.go
@@ -50,11 +50,17 @@ type postgresResult struct {
 // buildPostgresServerArgs constructs the ServerArgs for an Azure PostgreSQL Flexible Server.
 func buildPostgresServerArgs(
 	pg *compose.PostgresConfigArgs,
+	svc compose.ServiceConfig,
 	serviceName, sanitized string,
 	infra *SharedInfra,
 	ctx *pulumi.Context,
 	opts ...pulumi.ResourceOption,
 ) (*dbforpostgresql.ServerArgs, error) {
+	// Pick a SKU that satisfies the compose `deploy.resources.reservations`,
+	// constrained to the recipe-selected tier. The picker also returns the
+	// tier so Sku.Name and Sku.Tier can never disagree (Azure rejects mismatches).
+	skuName, skuTier := postgresFlexibleSku(svc.GetCPUs(), svc.GetMemoryMiB(), PostgresTier.Get(ctx))
+
 	// Backup config
 	backupRetention := BackupRetentionDays.Get(ctx)
 	geoBackup := dbforpostgresql.GeoRedundantBackupDisabled
@@ -94,8 +100,8 @@ func buildPostgresServerArgs(
 		Version:           pg.Version,
 		Tags:              ServiceTags(serviceName),
 		Sku: &dbforpostgresql.SkuArgs{
-			Name: pulumi.String(PostgresSku.Get(ctx)),
-			Tier: pulumi.String(string(dbforpostgresql.SkuTierBurstable)),
+			Name: pulumi.String(skuName),
+			Tier: pulumi.String(string(skuTier)),
 		},
 		Storage: &dbforpostgresql.StorageArgs{
 			StorageSizeGB: pulumi.Int(PostgresStorageSizeGB.Get(ctx)),
@@ -153,7 +159,7 @@ func CreatePostgresFlexible(
 	// letters, digits, and hyphens. StackDir-style names contain slashes etc.
 	sanitized := sanitizePostgresName(serviceName)
 
-	serverArgs, err := buildPostgresServerArgs(pg, serviceName, sanitized, infra, ctx, opts...)
+	serverArgs, err := buildPostgresServerArgs(pg, svc, serviceName, sanitized, infra, ctx, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/defangazure/azure/postgres_sku.go
+++ b/provider/defangazure/azure/postgres_sku.go
@@ -1,0 +1,129 @@
+package azure
+
+import (
+	"math"
+	"sort"
+
+	"github.com/pulumi/pulumi-azure-native-sdk/dbforpostgresql/v3"
+)
+
+// skuInfo describes a Postgres Flexible Server SKU's resources and a relative cost.
+type skuInfo struct {
+	vcpu int
+	gib  float64
+	cost float64 // approximate USD/hour, used only to rank candidates within a tier
+}
+
+// SKU catalogs for Azure Database for PostgreSQL Flexible Server.
+// Specs from MS Learn (https://learn.microsoft.com/azure/postgresql/flexible-server/concepts-compute);
+// approximate East US PAYG hourly prices for ranking only — not authoritative for billing.
+//
+// We expose `_ds_v5` (Intel) for D/E series; AMD `_ads_v5` and v4/v3 generations are
+// also accepted by the API but `_ds_v5` is current-gen and the broadest fit.
+
+// Burstable (B-series): single CPU credit family, no generation suffix.
+var burstableSkus = map[string]skuInfo{
+	"Standard_B1ms":  {vcpu: 1, gib: 2, cost: 0.022},
+	"Standard_B2s":   {vcpu: 2, gib: 4, cost: 0.041},
+	"Standard_B2ms":  {vcpu: 2, gib: 8, cost: 0.083},
+	"Standard_B4ms":  {vcpu: 4, gib: 16, cost: 0.166},
+	"Standard_B8ms":  {vcpu: 8, gib: 32, cost: 0.331},
+	"Standard_B12ms": {vcpu: 12, gib: 48, cost: 0.497},
+	"Standard_B16ms": {vcpu: 16, gib: 64, cost: 0.662},
+	"Standard_B20ms": {vcpu: 20, gib: 80, cost: 0.828},
+}
+
+// General Purpose (D-series, v5 Intel).
+var generalSkus = map[string]skuInfo{
+	"Standard_D2ds_v5":  {vcpu: 2, gib: 8, cost: 0.182},
+	"Standard_D4ds_v5":  {vcpu: 4, gib: 16, cost: 0.364},
+	"Standard_D8ds_v5":  {vcpu: 8, gib: 32, cost: 0.728},
+	"Standard_D16ds_v5": {vcpu: 16, gib: 64, cost: 1.456},
+	"Standard_D32ds_v5": {vcpu: 32, gib: 128, cost: 2.911},
+	"Standard_D48ds_v5": {vcpu: 48, gib: 192, cost: 4.367},
+	"Standard_D64ds_v5": {vcpu: 64, gib: 256, cost: 5.823},
+	"Standard_D96ds_v5": {vcpu: 96, gib: 384, cost: 8.734},
+}
+
+// Memory Optimized (E-series, v5 Intel).
+var memoryOptimizedSkus = map[string]skuInfo{
+	"Standard_E2ds_v5":  {vcpu: 2, gib: 16, cost: 0.234},
+	"Standard_E4ds_v5":  {vcpu: 4, gib: 32, cost: 0.468},
+	"Standard_E8ds_v5":  {vcpu: 8, gib: 64, cost: 0.936},
+	"Standard_E16ds_v5": {vcpu: 16, gib: 128, cost: 1.872},
+	"Standard_E20ds_v5": {vcpu: 20, gib: 160, cost: 2.340},
+	"Standard_E32ds_v5": {vcpu: 32, gib: 256, cost: 3.744},
+	"Standard_E48ds_v5": {vcpu: 48, gib: 384, cost: 5.616},
+	"Standard_E64ds_v5": {vcpu: 64, gib: 512, cost: 7.487},
+	"Standard_E96ds_v5": {vcpu: 96, gib: 672, cost: 11.231},
+}
+
+// skuCatalog pairs a tier with its SKU table so the picker can return both
+// without having to parse the tier back out of the chosen SKU name.
+type skuCatalog struct {
+	tier dbforpostgresql.SkuTier
+	skus map[string]skuInfo
+}
+
+var (
+	burstableCatalog       = skuCatalog{dbforpostgresql.SkuTierBurstable, burstableSkus}
+	generalCatalog         = skuCatalog{dbforpostgresql.SkuTierGeneralPurpose, generalSkus}
+	memoryOptimizedCatalog = skuCatalog{dbforpostgresql.SkuTierMemoryOptimized, memoryOptimizedSkus}
+)
+
+// tierCatalogs maps recipe postgres-tier values to their catalog search order.
+// A workload that won't fit in the preferred tier falls back to the next larger one,
+// matching the AWS provider's behavior.
+var tierCatalogs = map[string][]skuCatalog{
+	"burstable":        {burstableCatalog, generalCatalog, memoryOptimizedCatalog},
+	"general":          {generalCatalog, memoryOptimizedCatalog},
+	"memory-optimized": {memoryOptimizedCatalog},
+}
+
+// postgresFlexibleSku returns the cheapest SKU that meets the requested CPU/memory
+// budget along with its tier. tier selects the preferred tier ("burstable",
+// "general", "memory-optimized"); unknown values fall back to "burstable".
+func postgresFlexibleSku(minCPUs float64, minMemoryMiB int, tier string) (string, dbforpostgresql.SkuTier) {
+	minGiB := float64(minMemoryMiB) / 1024
+
+	catalogs, ok := tierCatalogs[tier]
+	if !ok {
+		catalogs = tierCatalogs["burstable"]
+	}
+
+	for _, c := range catalogs {
+		if name := cheapestSkuMatch(c.skus, minCPUs, minGiB); name != "" {
+			return name, c.tier
+		}
+	}
+
+	// Fallback: smallest burstable. Reached only if every catalog is empty,
+	// which shouldn't happen with the tables above.
+	return "Standard_B1ms", dbforpostgresql.SkuTierBurstable
+}
+
+// cheapestSkuMatch finds the cheapest SKU in catalog meeting the minimum requirements.
+func cheapestSkuMatch(catalog map[string]skuInfo, minCPUs float64, minGiB float64) string {
+	type entry struct {
+		name string
+		cost float64
+	}
+	var matches []entry
+	minVcpu := int(math.Ceil(minCPUs))
+	for name, info := range catalog {
+		if info.vcpu >= minVcpu && info.gib >= minGiB {
+			matches = append(matches, entry{name, info.cost})
+		}
+	}
+	if len(matches) == 0 {
+		return ""
+	}
+	sort.Slice(matches, func(i, j int) bool {
+		if matches[i].cost != matches[j].cost {
+			return matches[i].cost < matches[j].cost
+		}
+		// Stable order on ties so the same inputs always pick the same SKU.
+		return matches[i].name < matches[j].name
+	})
+	return matches[0].name
+}

--- a/provider/defangazure/azure/postgres_sku_test.go
+++ b/provider/defangazure/azure/postgres_sku_test.go
@@ -1,0 +1,105 @@
+package azure
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-azure-native-sdk/dbforpostgresql/v3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPostgresFlexibleSku(t *testing.T) {
+	tests := []struct {
+		name     string
+		cpus     float64
+		memMiB   int
+		tier     string
+		wantSku  string
+		wantTier dbforpostgresql.SkuTier
+	}{
+		{
+			name:     "default-burstable-no-reservation",
+			cpus:     0,
+			memMiB:   0,
+			tier: "burstable",
+			wantSku:  "Standard_B1ms",
+			wantTier: dbforpostgresql.SkuTierBurstable,
+		},
+		{
+			name:     "burstable-2cpu-4gib",
+			cpus:     2,
+			memMiB:   4096,
+			tier: "burstable",
+			wantSku:  "Standard_B2s",
+			wantTier: dbforpostgresql.SkuTierBurstable,
+		},
+		{
+			name:     "burstable-2cpu-8gib-needs-B2ms",
+			cpus:     2,
+			memMiB:   8192,
+			tier: "burstable",
+			wantSku:  "Standard_B2ms",
+			wantTier: dbforpostgresql.SkuTierBurstable,
+		},
+		{
+			// 128 GiB doesn't fit in any burstable; fallback chain goes
+			// burstable → general, where D32ds_v5 is the cheapest 128 GiB option.
+			// We don't continue to memory-optimized once general has a match.
+			name:     "burstable-overflows-to-general",
+			cpus:     2,
+			memMiB:   128 * 1024,
+			tier: "burstable",
+			wantSku:  "Standard_D32ds_v5",
+			wantTier: dbforpostgresql.SkuTierGeneralPurpose,
+		},
+		{
+			// 500 GiB doesn't fit in burstable or general; only E64ds_v5 (512 GiB)
+			// in memory-optimized matches. Exercises the full fallback chain.
+			name:     "exceeds-general-falls-through-to-memory-optimized",
+			cpus:     2,
+			memMiB:   500 * 1024,
+			tier: "burstable",
+			wantSku:  "Standard_E64ds_v5",
+			wantTier: dbforpostgresql.SkuTierMemoryOptimized,
+		},
+		{
+			name:     "general-tier-explicit",
+			cpus:     4,
+			memMiB:   16 * 1024,
+			tier: "general",
+			wantSku:  "Standard_D4ds_v5",
+			wantTier: dbforpostgresql.SkuTierGeneralPurpose,
+		},
+		{
+			name:     "memory-optimized-tier",
+			cpus:     2,
+			memMiB:   16 * 1024,
+			tier: "memory-optimized",
+			wantSku:  "Standard_E2ds_v5",
+			wantTier: dbforpostgresql.SkuTierMemoryOptimized,
+		},
+		{
+			name:     "unknown-node-type-falls-back-to-burstable",
+			cpus:     0,
+			memMiB:   0,
+			tier: "wat",
+			wantSku:  "Standard_B1ms",
+			wantTier: dbforpostgresql.SkuTierBurstable,
+		},
+		{
+			name:     "fractional-cpu-rounds-up",
+			cpus:     1.1,
+			memMiB:   2048,
+			tier: "burstable",
+			wantSku:  "Standard_B2s",
+			wantTier: dbforpostgresql.SkuTierBurstable,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotSku, gotTier := postgresFlexibleSku(tc.cpus, tc.memMiB, tc.tier)
+			assert.Equal(t, tc.wantSku, gotSku)
+			assert.Equal(t, tc.wantTier, gotTier)
+		})
+	}
+}

--- a/provider/defangazure/azure/recipe.go
+++ b/provider/defangazure/azure/recipe.go
@@ -4,13 +4,13 @@ import "github.com/DefangLabs/pulumi-defang/provider/common"
 
 // Azure recipe config accessors. Each reads from defang:<key> in stack config.
 var (
-	BackupRetentionDays = common.Int("backup-retention-days", 7)
-	DeletionProtection  = common.DeletionProtection
-	GeoRedundantBackup  = common.Bool("geo-redundant-backup", false)
-	HighAvailability    = common.Bool("high-availability", false)
-	LogWorkspaceSku     = common.String("log-workspace-sku", "PerGB2018")
-	MaxReplicas         = common.Int("max-replicas", 0)
-	RegistrySku         = common.String("registry-sku", "Standard")
-	SkuName             = common.String("sku-name", "Standard_B1ms")
-	StorageSizeGB       = common.Int("storage-size-gb", 32)
+	BackupRetentionDays   = common.Int("backup-retention-days", 7)
+	DeletionProtection    = common.DeletionProtection
+	GeoRedundantBackup    = common.Bool("geo-redundant-backup", false)
+	HighAvailability      = common.Bool("high-availability", false)
+	LogWorkspaceSku       = common.String("log-workspace-sku", "PerGB2018")
+	MaxReplicas           = common.Int("max-replicas", 0)
+	PostgresSku           = common.String("postgres-sku", "Standard_B1ms")
+	PostgresStorageSizeGB = common.Int("storage-size-gb", 32)
+	RegistrySku           = common.String("registry-sku", "Basic")
 )

--- a/provider/defangazure/azure/recipe.go
+++ b/provider/defangazure/azure/recipe.go
@@ -10,7 +10,7 @@ var (
 	HighAvailability      = common.Bool("high-availability", false)
 	LogWorkspaceSku       = common.String("log-workspace-sku", "PerGB2018")
 	MaxReplicas           = common.Int("max-replicas", 0)
-	PostgresSku           = common.String("postgres-sku", "Standard_B1ms")
+	PostgresTier          = common.String("postgres-tier", "burstable")
 	PostgresStorageSizeGB = common.Int("storage-size-gb", 32)
 	RegistrySku           = common.String("registry-sku", "Basic")
 )


### PR DESCRIPTION
- Prefix Postgres recipe values with `Postgres`
- Change KeyVault SKU to `Basic`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PostgreSQL databases now automatically sized with appropriate SKU based on CPU and memory requirements.

* **Bug Fixes**
  * Azure blob storage URL validation now enforces non-empty container names.

* **Improvements**
  * Default container registry SKU changed to Basic.
  * Updated PostgreSQL configuration variable names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->