### PR TITLE
Use the standard prefix instead of lower case

### DIFF
--- a/provider/defangazure/azure/azure.go
+++ b/provider/defangazure/azure/azure.go
@@ -150,7 +150,7 @@ func KeyVaultName(ctx *pulumi.Context, composeProject string) string {
 // compose file's top-level `name:`), which may differ from ctx.Project() —
 // a single Pulumi project can host multiple Defang Compose projects.
 func ProjectResourceGroupName(ctx *pulumi.Context, composeProject string) string {
-	prefix := strings.ToLower(common.Prefix.Get(ctx))
+	prefix := common.Prefix.Get(ctx)
 	if prefix != "" {
 		prefix += "-"
 	}


### PR DESCRIPTION
Ref: https://github.com/DefangLabs/pulumi-defang/issues/207 and https://github.com/DefangLabs/defang/pull/2086

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Azure resource group names now preserve the configured prefix casing instead of converting it to lowercase, ensuring consistency with your configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->