### PR TITLE
Import keyvault and retain on delete

### DIFF
--- a/provider/defangazure/azure/keyvault.go
+++ b/provider/defangazure/azure/keyvault.go
@@ -3,6 +3,7 @@ package azure
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/pulumi/pulumi-azure-native-sdk/authorization/v3"
 	"github.com/pulumi/pulumi-azure-native-sdk/keyvault/v3"
@@ -48,9 +49,10 @@ func EnsureKeyVault(
 		VaultName:         vaultName,
 	}, parentOpt)
 	if err != nil {
-		// Vault doesn't exist (CLI hasn't run SetUp yet).
-		// Treat as "no vault" — CreateKeyVaultIdentity will be skipped too.
-		return nil, ErrNoKeyVault
+		if strings.Contains(err.Error(), `Code="ResourceNotFound"`) {
+			return nil, ErrNoKeyVault
+		}
+		return nil, fmt.Errorf("looking up existing Key Vault: %w", err)
 	}
 
 	args := &keyvault.VaultArgs{

--- a/provider/defangazure/azure/keyvault.go
+++ b/provider/defangazure/azure/keyvault.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/pulumi/pulumi-azure-native-sdk/authorization/v3"
+	"github.com/pulumi/pulumi-azure-native-sdk/keyvault/v3"
 	"github.com/pulumi/pulumi-azure-native-sdk/managedidentity/v3"
 	"github.com/pulumi/pulumi-azure-native-sdk/v3/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -14,16 +15,88 @@ import (
 //nolint:gosec // built-in role definition ID, not a secret
 const keyVaultSecretsUserRoleID = "4633458b-17de-408a-b874-0445c86b69e6"
 
+// EnsureKeyVault adopts the CLI-created project Key Vault into Pulumi state
+// with RetainOnDelete=true, so:
+//
+//   - the project tags are applied via the cascading transformation
+//     (DefaultTagsTransformation in azure.go);
+//   - `pulumi destroy` (defang compose down) does NOT issue a delete API call
+//     against the vault, preserving the user's secrets across deploys.
+//
+// The vault itself is provisioned by the defang CLI (see
+// defang/src/pkg/clouds/azure/keyvault.SetUp) before the CD task runs, so
+// args here mirror the CLI's BeginCreateOrUpdate parameters exactly to avoid
+// proposing a replacement on import.
+//
+// Returns (nil, nil) when the vault doesn't exist yet — the CLI may not have
+// run SetUp (e.g. the user never ran `defang config set`). Callers should
+// treat that as "no vault, no identity binding".
+func EnsureKeyVault(
+	ctx *pulumi.Context,
+	composeProject string,
+	infra *SharedInfra,
+	parentOpt pulumi.ResourceOrInvokeOption,
+) (*keyvault.Vault, error) {
+	vaultName := KeyVaultName(ctx, composeProject)
+	rgName := ProjectResourceGroupName(ctx, composeProject)
+
+	existing, err := keyvault.LookupVault(ctx, &keyvault.LookupVaultArgs{
+		ResourceGroupName: rgName,
+		VaultName:         vaultName,
+	}, parentOpt)
+	if err != nil {
+		// Vault doesn't exist (CLI hasn't run SetUp yet).
+		// Treat as "no vault" — CreateKeyVaultIdentity will be skipped too.
+		return nil, nil //nolint:nilerr // intentional: missing vault is not an error
+	}
+
+	args := &keyvault.VaultArgs{
+		Location:          pulumi.StringPtrFromPtr(existing.Location),
+		ResourceGroupName: infra.ResourceGroup.Name,
+		VaultName:         pulumi.String(vaultName),
+		Properties: &keyvault.VaultPropertiesArgs{
+			TenantId:                  pulumi.String(existing.Properties.TenantId),
+			EnableRbacAuthorization:   pulumi.BoolPtr(true),
+			EnableSoftDelete:          pulumi.BoolPtr(true),
+			SoftDeleteRetentionInDays: pulumi.IntPtr(7),
+			Sku: &keyvault.SkuArgs{
+				Family: pulumi.String("A"),
+				Name:   keyvault.SkuNameStandard,
+			},
+		},
+	}
+
+	vault, err := keyvault.NewVault(ctx, "config-vault", args,
+		parentOpt,
+		pulumi.Import(pulumi.ID(existing.Id)),
+		pulumi.RetainOnDelete(true),
+		// Don't fight the CLI / Azure on properties we don't actively manage.
+		// Tags are intentionally NOT ignored — that's the whole point.
+		pulumi.IgnoreChanges([]string{
+			"properties.networkAcls",
+			"properties.accessPolicies",
+			"properties.publicNetworkAccess",
+			"properties.enabledForDeployment",
+			"properties.enabledForDiskEncryption",
+			"properties.enabledForTemplateDeployment",
+		}),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("importing Key Vault: %w", err)
+	}
+	return vault, nil
+}
+
 // CreateKeyVaultIdentity creates a user-assigned managed identity with
 // Key Vault Secrets User role on the vault. Returns the identity resource ID
 // (with an implicit dependency on the role assignment completing).
 //
-// The vault may live in a different resource group than the project (set via
-// defang-azure:keyVaultResourceGroup); if unset, it's assumed to share the
-// project RG.
+// vault is the imported Pulumi Vault resource (from EnsureKeyVault); its ID
+// output is the canonical Azure scope, which avoids any case mismatch between
+// the locally-derived RG/vault name and what's stored in Azure.
 func CreateKeyVaultIdentity(
 	ctx *pulumi.Context,
-	vaultName, projectName string,
+	vault *keyvault.Vault,
 	infra *SharedInfra,
 	opts ...pulumi.ResourceOption,
 ) (pulumi.StringOutput, error) {
@@ -42,20 +115,11 @@ func CreateKeyVaultIdentity(
 		subID, keyVaultSecretsUserRoleID,
 	)
 
-	var rgID pulumi.StringOutput
-	if infra.ResourceGroup == nil {
-		kvRG := ProjectResourceGroupName(ctx, projectName)
-		rgID = pulumi.Sprintf("/subscriptions/%s/resourceGroups/%s", subID, kvRG)
-	} else {
-		rgID = infra.ResourceGroup.ID().ToStringOutput()
-	}
-	vaultScope := pulumi.Sprintf("%s/providers/Microsoft.KeyVault/vaults/%s", rgID, vaultName)
-
 	// Parent defaults to the surrounding component (via opts). Pulumi's SDK
 	// discourages using custom resources as parents — destruction order here is
 	// already enforced by the implicit data dependency on identity.PrincipalId.
 	roleAssignment, err := authorization.NewRoleAssignment(ctx, "kv-secrets-user", &authorization.RoleAssignmentArgs{
-		Scope:            vaultScope,
+		Scope:            vault.ID().ToStringOutput(),
 		RoleDefinitionId: pulumi.String(roleDefID),
 		PrincipalId:      identity.PrincipalId,
 		PrincipalType:    pulumi.String("ServicePrincipal"),

--- a/provider/defangazure/azure/keyvault.go
+++ b/provider/defangazure/azure/keyvault.go
@@ -1,6 +1,7 @@
 package azure
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/pulumi/pulumi-azure-native-sdk/authorization/v3"
@@ -14,6 +15,8 @@ import (
 //
 //nolint:gosec // built-in role definition ID, not a secret
 const keyVaultSecretsUserRoleID = "4633458b-17de-408a-b874-0445c86b69e6"
+
+var ErrNoKeyVault = errors.New("no Key Vault found")
 
 // EnsureKeyVault adopts the CLI-created project Key Vault into Pulumi state
 // with RetainOnDelete=true, so:
@@ -47,7 +50,7 @@ func EnsureKeyVault(
 	if err != nil {
 		// Vault doesn't exist (CLI hasn't run SetUp yet).
 		// Treat as "no vault" — CreateKeyVaultIdentity will be skipped too.
-		return nil, nil //nolint:nilerr // intentional: missing vault is not an error
+		return nil, ErrNoKeyVault
 	}
 
 	args := &keyvault.VaultArgs{

--- a/provider/defangazure/azure/keyvault.go
+++ b/provider/defangazure/azure/keyvault.go
@@ -32,9 +32,9 @@ var ErrNoKeyVault = errors.New("no Key Vault found")
 // args here mirror the CLI's BeginCreateOrUpdate parameters exactly to avoid
 // proposing a replacement on import.
 //
-// Returns (nil, nil) when the vault doesn't exist yet — the CLI may not have
-// run SetUp (e.g. the user never ran `defang config set`). Callers should
-// treat that as "no vault, no identity binding".
+// Returns (nil, ErrNoKeyVault) when the vault doesn't exist yet — the CLI may
+// not have run SetUp (e.g. the user never ran `defang config set`). Callers
+// should treat that as "no vault, no identity binding".
 func EnsureKeyVault(
 	ctx *pulumi.Context,
 	composeProject string,

--- a/provider/defangazure/project.go
+++ b/provider/defangazure/project.go
@@ -410,7 +410,7 @@ func setupSharedInfra(
 	}
 
 	vault, err := providerazure.EnsureKeyVault(ctx, projectName, infra, parentOpt)
-	if err != nil {
+	if err != nil && !errors.Is(err, providerazure.ErrNoKeyVault) {
 		return nil, nil, err
 	}
 	if vault != nil {

--- a/provider/defangazure/project.go
+++ b/provider/defangazure/project.go
@@ -10,7 +10,6 @@ import (
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
 	providerazure "github.com/DefangLabs/pulumi-defang/provider/defangazure/azure"
 	"github.com/pulumi/pulumi-azure-native-sdk/app/v3"
-	"github.com/pulumi/pulumi-azure-native-sdk/keyvault/v3"
 	"github.com/pulumi/pulumi-azure-native-sdk/operationalinsights/v3"
 	"github.com/pulumi/pulumi-azure-native-sdk/resources/v3"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -266,7 +265,15 @@ func createProjectResourceGroup(
 		ResourceGroupName: pulumi.String(projectRG),
 		// Location: pulumi.String(location),
 	}
-	rgOpts := []pulumi.ResourceOption{childOpt}
+	// RetainOnDelete: the CLI provisions the project Key Vault inside this RG
+	// (see defang/src/pkg/clouds/azure/keyvault.SetUp). Deleting the RG would
+	// trigger an Azure cascade delete that wipes the vault and its secrets,
+	// regardless of any RetainOnDelete on the vault itself. Retaining the RG
+	// stops Pulumi from issuing the delete API call, so `defang compose down`
+	// preserves user secrets. The CLI already keeps this RG around between
+	// deploys (it hosts the Pulumi state storage account too), so there's no
+	// new orphan-resource cost.
+	rgOpts := []pulumi.ResourceOption{childOpt, pulumi.RetainOnDelete(true)}
 
 	if existingRG, err := resources.LookupResourceGroup(ctx, &resources.LookupResourceGroupArgs{
 		ResourceGroupName: projectRG,
@@ -402,12 +409,12 @@ func setupSharedInfra(
 		infra.BuildInfra = buildInfra
 	}
 
-	if _, err := keyvault.LookupVault(ctx, &keyvault.LookupVaultArgs{
-		ResourceGroupName: providerazure.ProjectResourceGroupName(ctx, projectName),
-		VaultName:         kvName,
-	}, parentOpt); err == nil {
-		// Only create the KV access identity and role assignment if the vault exists
-		kvIdentityID, err := providerazure.CreateKeyVaultIdentity(ctx, kvName, projectName, infra, parentOpt)
+	vault, err := providerazure.EnsureKeyVault(ctx, projectName, infra, parentOpt)
+	if err != nil {
+		return nil, nil, err
+	}
+	if vault != nil {
+		kvIdentityID, err := providerazure.CreateKeyVaultIdentity(ctx, vault, infra, parentOpt)
 		if err != nil {
 			return nil, nil, fmt.Errorf("creating Key Vault identity: %w", err)
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * External Key Vaults are now imported into state and retained on deletion to avoid accidental cascade removal of secrets.
  * The workflow tolerates missing Key Vaults and only provisions access and role assignments when a vault exists.
  * Vault tags remain managed while selected platform-managed properties are ignored during import.

* **Refactor**
  * Key Vault access identity and role-assignment handling simplified for more reliable scope resolution and stable resource dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->