### PR TITLE
Adds naming pattern for Azure ManagedEnvironment resources

### DIFF
--- a/cd/main.go
+++ b/cd/main.go
@@ -67,6 +67,12 @@ func projectConfig(prefix string) map[string]workspace.ProjectConfigType {
 							// https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftcontainerregistry
 							// 5-50	Alphanumerics, hyphens, and underscores
 							"azure-native:containerregistry:Task": map[string]string{"pattern": "${name}-${hex(7)}"},
+							// ManagedEnvironment names must be 2–32 chars, alphanumerics and hyphens,
+							// starting with a letter. Default ${prefix}-${project}-${stack}-${name}-${hex(7)}
+							// overflows. One ManagedEnvironment per project per RG, so ${name} alone
+							// disambiguates within the RG; the hex suffix is just to avoid replace-on-rename.
+							// https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftapp
+							"azure-native:app:ManagedEnvironment": map[string]string{"pattern": "${name}-${hex(7)}"},
 						},
 					},
 					// Most GCP resources require names matching ^[a-z][-a-z0-9]{0,61}[a-z0-9]$

--- a/cd/main.go
+++ b/cd/main.go
@@ -67,12 +67,11 @@ func projectConfig(prefix string) map[string]workspace.ProjectConfigType {
 							// https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftcontainerregistry
 							// 5-50	Alphanumerics, hyphens, and underscores
 							"azure-native:containerregistry:Task": map[string]string{"pattern": "${name}-${hex(7)}"},
-							// ManagedEnvironment names must be 2–32 chars, alphanumerics and hyphens,
-							// starting with a letter. Default ${prefix}-${project}-${stack}-${name}-${hex(7)}
-							// overflows. One ManagedEnvironment per project per RG, so ${name} alone
-							// disambiguates within the RG; the hex suffix is just to avoid replace-on-rename.
-							// https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftapp
-							"azure-native:app:ManagedEnvironment": map[string]string{"pattern": "${name}-${hex(7)}"},
+							// Requirements for Container App Environment resource names:
+							// Between 2 and 60 characters long.
+							// Lowercase letters, numbers, and hyphens.
+							// https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.ContainerApp.EnvNaming
+							"azure-native:app:ManagedEnvironment": map[string]string{"pattern": prefix + "${project}-${stack}-${hex(7)}"},
 						},
 					},
 					// Most GCP resources require names matching ^[a-z][-a-z0-9]{0,61}[a-z0-9]$


### PR DESCRIPTION
Introduces a naming pattern for Azure ManagedEnvironment resources to comply with Azure's 2–32 character limit and naming rules, ensuring disambiguation within a resource group. The hex suffix prevents name conflicts during renaming.

References: https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftapp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated resource naming configuration for Azure Managed Environment resources with an improved naming pattern to ensure consistent resource identification and management across deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->