### PR TITLE
Ignore change for azure container app cert as cert gen is done by cli

### DIFF
--- a/provider/defangazure/azure/containerapp.go
+++ b/provider/defangazure/azure/containerapp.go
@@ -287,6 +287,13 @@ func CreateContainerApp(
 		template.RevisionSuffix = pulumi.String(infra.Etag)
 	}
 
+	// `customDomains` is managed out-of-band by `defang cert generate`
+	// (BYOD flow). Ignoring it prevents subsequent `pulumi up` calls from
+	// clobbering the binding when other fields on the app change.
+	opts = append(opts, pulumi.IgnoreChanges([]string{
+		"configuration.ingress.customDomains",
+	}))
+
 	containerApp, err := app.NewContainerApp(ctx, serviceName, &app.ContainerAppArgs{
 		ResourceGroupName:    infra.ResourceGroup.Name,
 		ContainerAppName:     pulumi.StringPtr(serviceName),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Azure Container App custom domain configurations are now preserved during infrastructure updates. Custom domains will no longer be overwritten on subsequent deployments, ensuring your domain settings remain stable while other Container App configurations can still update normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->