### PR TITLE
Azure: add log workspace quota

### DIFF
--- a/provider/defangazure/azure/recipe.go
+++ b/provider/defangazure/azure/recipe.go
@@ -9,8 +9,13 @@ var (
 	GeoRedundantBackup    = common.Bool("geo-redundant-backup", false)
 	HighAvailability      = common.Bool("high-availability", false)
 	LogWorkspaceSku       = common.String("log-workspace-sku", "PerGB2018")
-	MaxReplicas           = common.Int("max-replicas", 0)
-	PostgresTier          = common.String("postgres-tier", "burstable")
-	PostgresStorageSizeGB = common.Int("storage-size-gb", 32)
-	RegistrySku           = common.String("registry-sku", "Basic")
+	// LogWorkspaceDailyQuotaGb caps daily ingestion in GB. 0 = no cap.
+	// Default 1 GB/day = ~30 GB/mo, ~$70 ceiling on PerGB2018 (~$2.30/GB).
+	// Chatty workloads (AI agents) override upward; an unbounded default
+	// has been seen to bill >$700/mo against a single workspace.
+	LogWorkspaceDailyQuotaGb = common.Int("log-workspace-daily-quota-gb", 1)	
+	MaxReplicas              = common.Int("max-replicas", 0)
+	PostgresTier             = common.String("postgres-tier", "burstable")
+	PostgresStorageSizeGB    = common.Int("storage-size-gb", 32)
+	RegistrySku              = common.String("registry-sku", "Basic")
 )

--- a/provider/defangazure/project.go
+++ b/provider/defangazure/project.go
@@ -301,14 +301,24 @@ func createManagedEnvironment(
 	infra *providerazure.SharedInfra,
 	parentOpt pulumi.ResourceOrInvokeOption,
 ) (*app.ManagedEnvironment, error) {
-	logWorkspace, err := operationalinsights.NewWorkspace(ctx, name, &operationalinsights.WorkspaceArgs{
+	wsArgs := &operationalinsights.WorkspaceArgs{
 		ResourceGroupName: infra.ResourceGroup.Name,
 		// Location:          pulumi.String(location),
 		Sku: &operationalinsights.WorkspaceSkuArgs{
 			Name: pulumi.String(providerazure.LogWorkspaceSku.Get(ctx)),
 		},
 		RetentionInDays: pulumi.Int(max(30, common.LogRetentionDays.Get(ctx))), // 30≤…≤730 days
-	}, parentOpt)
+	}
+	// Daily ingestion cap: once exceeded Azure stops ingesting for the day.
+	// Backstop against runaway $$$ from chatty containers (a single AI agent
+	// workload has been seen burning >$700/mo here). Omit the field entirely
+	// when quota=0 so the API doesn't see a 0 GB cap.
+	if quotaGB := providerazure.LogWorkspaceDailyQuotaGb.Get(ctx); quotaGB > 0 {
+		wsArgs.WorkspaceCapping = &operationalinsights.WorkspaceCappingArgs{
+			DailyQuotaGb: pulumi.Float64Ptr(float64(quotaGB)),
+		}
+	}
+	logWorkspace, err := operationalinsights.NewWorkspace(ctx, name, wsArgs, parentOpt)
 	if err != nil {
 		return nil, fmt.Errorf("creating Log Analytics workspace: %w", err)
 	}


### PR DESCRIPTION
Refactor log workspace creation to use wsArgs and add daily quota handling.

Workaround for #247 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable daily quota limit for Azure log workspace ingestion to manage data capacity (default: 1 GB per day; set to 0 to disable limit)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefangLabs/pulumi-defang/pull/254?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->