### PR TITLE
Update naming pattern for Log Analytics workspace 

### DIFF
--- a/cd/cd_main.go
+++ b/cd/cd_main.go
@@ -309,7 +309,7 @@ func projectConfig(prefix string) map[string]workspace.ProjectConfigType {
 							// Log Analytics workspace names must be 4–63 chars. The workspace's
 							// logical ${name} is the project name, so the default pattern repeats
 							// the project twice and overflows on longer names; drop ${name}.
-							// https://learn.microsoft.com/en-us/azure/azure-monitor/logs/manage-logs-tables
+							// https://learn.microsoft.com/en-us/azure/templates/microsoft.operationalinsights/workspaces?pivots=deployment-language-bicep#microsoftoperationalinsightsworkspaces
 							"azure-native:operationalinsights:Workspace": map[string]string{"pattern": prefix + "${project}-${stack}-${hex(7)}"},
 						},
 					},

--- a/cd/cd_main.go
+++ b/cd/cd_main.go
@@ -306,6 +306,11 @@ func projectConfig(prefix string) map[string]workspace.ProjectConfigType {
 							// Numbers and hyphens are also allowed.
 							// https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.ContainerApp.EnvNaming
 							"azure-native:app:ManagedEnvironment": map[string]string{"pattern": prefix + "${project}-${stack}-${hex(7)}"},
+							// Log Analytics workspace names must be 4–63 chars. The workspace's
+							// logical ${name} is the project name, so the default pattern repeats
+							// the project twice and overflows on longer names; drop ${name}.
+							// https://learn.microsoft.com/en-us/azure/azure-monitor/logs/manage-logs-tables
+							"azure-native:operationalinsights:Workspace": map[string]string{"pattern": prefix + "${project}-${stack}-${hex(7)}"},
 						},
 					},
 					// Most GCP resources require names matching ^[a-z][-a-z0-9]{0,61}[a-z0-9]$


### PR DESCRIPTION
Somehow my other [PR](https://github.com/DefangLabs/pulumi-defang/pull/289) was force closed. Anyway this PR does fix it as well by dropping `name` in the naming pattern. Since the project and name are identical and are repeated.

```
Defang-golang-rest-api-production-golang-rest-api-d9f68a0
         └─ project ─┘ └─stack┘    └─ name ──┘
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Added inline documentation clarifying Log Analytics workspace naming constraints and the reasoning behind the naming pattern used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->