### PR TITLE
replace '+' with '-' in Docker image tag 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -175,7 +175,10 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "IMAGE_TAG=pr-${{ github.event.pull_request.number }}" >> "$GITHUB_ENV"
           else
-            echo "IMAGE_TAG=$(make version)" >> "$GITHUB_ENV"
+            # `make version` emits SemVer, which may include a `+<commit>` build-metadata
+            # suffix (e.g. 2.1.2-alpha+a3aefa34). Docker tags disallow `+`, so swap it for `-`.
+            VERSION="$(make version)"
+            echo "IMAGE_TAG=${VERSION//+/-}" >> "$GITHUB_ENV"
           fi
 
       - name: Build and push image to GHCR


### PR DESCRIPTION
On main-branch pushes, the CD image tag is derived from make version, which emits SemVer that can include a +<commit> build-metadata suffix (e.g. 2.1.2-alpha+a3aefa34). Docker tags disallow +, so the build failed with:

invalid tag "ghcr.io/defanglabs/cd:2.1.2-alpha+a3aefa34": invalid reference format

One of the [example of failing CI ](https://github.com/DefangLabs/pulumi-defang/actions/runs/27633031187/job/81714835139)because of this issue.

This swaps + → - before using the version as the image tag (2.1.2-alpha-a3aefa34). PR runs (pr-<number>) and clean tagged releases are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image tagging logic to properly normalize semantic versioning formats in continuous integration workflows for consistent image publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->