### PR TITLE
feat: set DEFANG_FQDN

### DIFF
--- a/provider/common/dns.go
+++ b/provider/common/dns.go
@@ -3,6 +3,8 @@ package common
 import (
 	"regexp"
 	"strings"
+
+	"github.com/DefangLabs/pulumi-defang/provider/compose"
 )
 
 type RecordType string
@@ -28,9 +30,42 @@ func NormalizeDNS(name string) string {
 }
 
 func SafeLabel(name string) string {
-	// Technically DNS names can have underscores, but these are reserved for SRV
-	// records and some systems have issues with them.
+	// Technically DNS names can have underscores, so we won't touch them here.
 	return strings.ReplaceAll(strings.ToLower(name), ".", "-")
+}
+
+// ServiceLabel converts a Compose service name into the DNS label used in
+// generated FQDNs (e.g. "<service>.<domain>"). It mirrors the CLI's
+// getServiceLabel: underscores are mapped to hyphens before SafeLabel because,
+// while technically valid in DNS names, they are reserved for SRV records and
+// break some systems. Use this (not SafeLabel) for anything derived from a
+// service name so provider-generated hostnames match what the CLI computed.
+func ServiceLabel(name string) string {
+	return SafeLabel(strings.ReplaceAll(name, "_", "-"))
+}
+
+// ServiceFQDN returns the public-facing fully-qualified domain name for a
+// service, following the CLI source-of-truth precedence
+// (cd: domainname || publicFqdn || privateFqdn):
+//   - the custom DomainName if set;
+//   - else "<ServiceLabel>.<publicDomain>" when the service has ingress ports;
+//   - else "<ServiceLabel>.<privateDomain>" when it has host (internal) ports.
+//
+// publicDomain is the project's delegate domain, privateDomain its internal
+// domain; pass "" for either when the provider has no such concept (e.g. GCP and
+// Azure today have no private-FQDN fallback). Returns "" when no FQDN applies,
+// which callers use to decide whether to set DEFANG_FQDN.
+func ServiceFQDN(serviceName string, svc compose.ServiceConfig, publicDomain, privateDomain string) string {
+	if svc.DomainName != "" {
+		return svc.DomainName
+	}
+	switch {
+	case svc.HasIngressPorts() && publicDomain != "":
+		return ServiceLabel(serviceName) + "." + publicDomain
+	case svc.HasHostPorts() && privateDomain != "":
+		return ServiceLabel(serviceName) + "." + privateDomain
+	}
+	return ""
 }
 
 // https://www.rfc-editor.org/rfc/rfc6762#appendix-G and https://www.rfc-editor.org/rfc/rfc8375

--- a/provider/common/dns_test.go
+++ b/provider/common/dns_test.go
@@ -1,6 +1,10 @@
 package common
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/DefangLabs/pulumi-defang/provider/compose"
+)
 
 func TestNormalizeDNS(t *testing.T) {
 	tests := []struct {
@@ -43,6 +47,112 @@ func TestSafeLabel(t *testing.T) {
 		if got := SafeLabel(tt.input); got != tt.want {
 			t.Errorf("SafeLabel(%q) = %q, want %q", tt.input, got, tt.want)
 		}
+	}
+}
+
+func TestServiceLabel(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"name", "name"},
+		{"Name", "name"},
+		{"my_svc", "my-svc"}, // underscores -> hyphens (unlike SafeLabel)
+		{"My.Svc", "my-svc"}, // lowercased + dots -> hyphens
+		{"a_b.c", "a-b-c"},   // combined
+		{"name__hyphen", "name--hyphen"},
+	}
+	for _, tt := range tests {
+		if got := ServiceLabel(tt.input); got != tt.want {
+			t.Errorf("ServiceLabel(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestServiceFQDN(t *testing.T) {
+	ingress := compose.ServicePortConfig{Target: 80, Mode: compose.PortModeIngress}
+	host := compose.ServicePortConfig{Target: 5432, Mode: compose.PortModeHost}
+	const pub, priv = "proj.tenant.defang.app", "proj.internal"
+
+	tests := []struct {
+		name          string
+		serviceName   string
+		svc           compose.ServiceConfig
+		publicDomain  string
+		privateDomain string
+		want          string
+	}{
+		{
+			"custom domain wins",
+			"web",
+			compose.ServiceConfig{DomainName: "example.com", Ports: []compose.ServicePortConfig{ingress}},
+			pub,
+			priv,
+			"example.com",
+		},
+		{
+			"public fqdn for ingress",
+			"web",
+			compose.ServiceConfig{Ports: []compose.ServicePortConfig{ingress}},
+			pub,
+			priv,
+			"web." + pub,
+		},
+		{
+			"private fqdn for host",
+			"db",
+			compose.ServiceConfig{Ports: []compose.ServicePortConfig{host}},
+			pub,
+			priv,
+			"db." + priv,
+		},
+		{
+			"ingress beats host",
+			"web",
+			compose.ServiceConfig{Ports: []compose.ServicePortConfig{ingress, host}},
+			pub,
+			priv,
+			"web." + pub,
+		},
+		{
+			"label sanitized",
+			"my_api",
+			compose.ServiceConfig{Ports: []compose.ServicePortConfig{ingress}},
+			pub,
+			priv,
+			"my-api." + pub,
+		},
+		{
+			"ingress but no public domain",
+			"web",
+			compose.ServiceConfig{Ports: []compose.ServicePortConfig{ingress}},
+			"",
+			priv,
+			"",
+		},
+		{
+			"host but no private domain (GCP/Azure)",
+			"db",
+			compose.ServiceConfig{Ports: []compose.ServicePortConfig{host}},
+			pub,
+			"",
+			"",
+		},
+		{
+			"no ports",
+			"worker",
+			compose.ServiceConfig{},
+			pub,
+			priv,
+			"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ServiceFQDN(tt.serviceName, tt.svc, tt.publicDomain, tt.privateDomain); got != tt.want {
+				t.Errorf("ServiceFQDN(%q, ...) = %q, want %q", tt.serviceName, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/provider/defangaws/aws/ecs.go
+++ b/provider/defangaws/aws/ecs.go
@@ -640,7 +640,8 @@ func CreateECSService(
 			func(dns string) string { return "http://" + dns },
 		)
 	case svc.HasHostPorts() && infra.PrivateDomain != "":
-		endpointOutput = pulumix.Val(fmt.Sprintf("%s.%s", serviceName, infra.PrivateDomain))
+		// serviceLabel (not raw serviceName) to match the private DNS record.
+		endpointOutput = pulumix.Val(fmt.Sprintf("%s.%s", serviceLabel, infra.PrivateDomain))
 	default:
 		endpointOutput = pulumix.Val(serviceName)
 	}

--- a/provider/defangaws/aws/ecs.go
+++ b/provider/defangaws/aws/ecs.go
@@ -336,8 +336,14 @@ func CreateECSService(
 	if infra != nil && infra.Etag != "" {
 		staticEnvVars = append(staticEnvVars, KeyValuePair{Name: "DEFANG_ETAG", Value: infra.Etag})
 	}
-	if svc.DomainName != "" {
-		staticEnvVars = append(staticEnvVars, KeyValuePair{Name: "DEFANG_FQDN", Value: svc.DomainName})
+	// DEFANG_FQDN: custom domain, else public FQDN (ingress), else private FQDN
+	// (host-port). See common.ServiceFQDN for the source-of-truth precedence.
+	var publicDomain, privateDomain string
+	if infra != nil {
+		publicDomain, privateDomain = infra.ProjectDomain, infra.PrivateDomain
+	}
+	if fqdn := common.ServiceFQDN(serviceName, svc, publicDomain, privateDomain); fqdn != "" {
+		staticEnvVars = append(staticEnvVars, KeyValuePair{Name: "DEFANG_FQDN", Value: fqdn})
 	}
 
 	// Resolve outputs (image URI, log group name, env vars) before building the container
@@ -422,7 +428,7 @@ func CreateECSService(
 
 		if svc.HasHostPorts() && hasPrivateZone {
 			privateZoneID := all[2].(string)                                         // FIXME: this is [1] if there's no loggroup
-			privateFqdn := common.SafeLabel(serviceName) + "." + infra.PrivateDomain // route53 sidecar needs FQDN
+			privateFqdn := common.ServiceLabel(serviceName) + "." + infra.PrivateDomain // route53 sidecar needs FQDN
 			sidecarDef := ContainerDefinition{
 				Name:      "route53-sidecar",
 				Image:     "public.ecr.aws/defang-io/route53-sidecar:65e431c",
@@ -497,7 +503,7 @@ func CreateECSService(
 	}
 
 	if svc.HasIngressPorts() && listener != nil {
-		serviceLabel := common.SafeLabel(serviceName)
+		serviceLabel := common.ServiceLabel(serviceName)
 
 		firstIngress := true
 		for _, port := range svc.Ports {
@@ -620,7 +626,7 @@ func CreateECSService(
 	}
 
 	hasIngress := svc.HasIngressPorts() && infra.HttpListener != nil
-	serviceLabel := common.SafeLabel(serviceName)
+	serviceLabel := common.ServiceLabel(serviceName)
 	switch {
 	case hasIngress && infra.ProjectDomain != "":
 		// HTTP listener redirects to HTTPS when a cert is bound, so advertise https://.

--- a/provider/defangaws/postgres.go
+++ b/provider/defangaws/postgres.go
@@ -93,7 +93,7 @@ func createPostgres(
 
 	var dependency pulumi.Resource = rdsResult.Instance
 	if infra.PrivateZoneID != nil {
-		privateFqdn := common.SafeLabel(serviceName) //+ "." + infra.PrivateDomain
+		privateFqdn := common.ServiceLabel(serviceName) //+ "." + infra.PrivateDomain
 		record, cnameErr := provideraws.CreateRecord(ctx, privateFqdn, common.RecordTypeCNAME, &route53.RecordArgs{
 			ZoneId:  infra.PrivateZoneID.ToStringPtrOutput().Elem(),
 			Records: pulumi.StringArray{rdsResult.Instance.Address},

--- a/provider/defangaws/redis.go
+++ b/provider/defangaws/redis.go
@@ -88,7 +88,7 @@ func createRedis(
 
 	var dependency pulumi.Resource // stays nil when no CNAME and no explicit cluster handle
 	if infra.PrivateZoneID != nil {
-		privateFqdn := common.SafeLabel(serviceName) //+ "." + infra.PrivateDomain
+		privateFqdn := common.ServiceLabel(serviceName) //+ "." + infra.PrivateDomain
 		record, cnameErr := provideraws.CreateRecord(ctx, privateFqdn, common.RecordTypeCNAME, &route53.RecordArgs{
 			ZoneId:  infra.PrivateZoneID.ToStringPtrOutput().Elem(),
 			Records: pulumi.StringArray{redisResult.Address},

--- a/provider/defangazure/azure/containerapp.go
+++ b/provider/defangazure/azure/containerapp.go
@@ -150,6 +150,15 @@ func buildEnvVars(
 			Value: pulumi.String(infra.Etag),
 		})
 	}
+	// DEFANG_FQDN: custom domain, else public FQDN (ingress) under the delegate
+	// domain — matches the CNAME from CreateCustomDomain. Azure has no
+	// private-FQDN fallback. See common.ServiceFQDN for the precedence.
+	if fqdn := common.ServiceFQDN(serviceName, svc, infra.Domain, ""); fqdn != "" {
+		envs = append(envs, app.EnvironmentVarArgs{
+			Name:  pulumi.String("DEFANG_FQDN"),
+			Value: pulumi.String(fqdn),
+		})
+	}
 
 	var appSecrets app.SecretArray
 	// Multiple env vars can reference the same secret (FOO=${X}, BAR=${X}); we

--- a/provider/defangazure/azure/customdomain.go
+++ b/provider/defangazure/azure/customdomain.go
@@ -28,6 +28,7 @@ package azure
 import (
 	"fmt"
 
+	"github.com/DefangLabs/pulumi-defang/provider/common"
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
 	"github.com/pulumi/pulumi-azure-native-sdk/app/v3"
 	"github.com/pulumi/pulumi-azure-native-sdk/dns/v3"
@@ -80,7 +81,7 @@ func CreateCustomDomain(
 	cname, err := dns.NewRecordSet(ctx, serviceName+"-cname", &dns.RecordSetArgs{
 		ResourceGroupName:     rgName,
 		ZoneName:              zoneName,
-		RelativeRecordSetName: pulumi.String(serviceName),
+		RelativeRecordSetName: pulumi.String(common.ServiceLabel(serviceName)),
 		RecordType:            pulumi.String("CNAME"),
 		Ttl:                   pulumi.Float64(60),
 		CnameRecord: &dns.CnameRecordArgs{
@@ -98,7 +99,7 @@ func CreateCustomDomain(
 	asuid, err := dns.NewRecordSet(ctx, serviceName+"-asuid", &dns.RecordSetArgs{
 		ResourceGroupName:     rgName,
 		ZoneName:              zoneName,
-		RelativeRecordSetName: pulumi.String("asuid." + serviceName),
+		RelativeRecordSetName: pulumi.String("asuid." + common.ServiceLabel(serviceName)),
 		RecordType:            pulumi.String("TXT"),
 		Ttl:                   pulumi.Float64(60),
 		TxtRecords: dns.TxtRecordArray{

--- a/provider/defanggcp/gcp/alb.go
+++ b/provider/defanggcp/gcp/alb.go
@@ -212,7 +212,7 @@ func createInternalLoadBalancer(
 				firstPrivateBackendID = serviceBackend.ID()
 			}
 
-			internalServiceName := service.Name
+			internalServiceName := common.ServiceLabel(service.Name)
 			privateHostRules = append(privateHostRules, &compute.RegionUrlMapHostRuleArgs{
 				Hosts:       pulumi.StringArray{pulumi.String(internalServiceName)},
 				PathMatcher: pulumi.String(pathMatcherName(internalServiceName)),
@@ -298,7 +298,7 @@ func createInternalLoadBalancer(
 					firstPrivateBackendID = serviceBackend.ID()
 				}
 
-				internalServiceName := service.Name
+				internalServiceName := common.ServiceLabel(service.Name)
 				privateHostRules = append(privateHostRules, &compute.RegionUrlMapHostRuleArgs{
 					Hosts:       pulumi.StringArray{pulumi.String(internalServiceName)},
 					PathMatcher: pulumi.String(pathMatcherName(internalServiceName)),

--- a/provider/defanggcp/gcp/alb.go
+++ b/provider/defanggcp/gcp/alb.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/DefangLabs/pulumi-defang/provider/common"
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/certificatemanager"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/cloudrunv2"
@@ -85,7 +86,7 @@ func createExternalLoadBalancers(
 	if config.Domain != "" {
 		ip := pulumi.StringArray{config.PublicIP.Address}
 		for _, entry := range ingressEntries {
-			svcDomain := entry.Name + "." + config.Domain
+			svcDomain := common.ServiceLabel(entry.Name) + "." + config.Domain
 			if err := CreatePublicDNSRecord(ctx, config.PublicZoneId, svcDomain, "A", pulumi.Int(60), ip, opts...); err != nil {
 				return err
 			}
@@ -93,7 +94,7 @@ func createExternalLoadBalancers(
 				if !port.IsIngress() {
 					continue
 				}
-				portDomain := fmt.Sprintf("%s--%d.%s", entry.Name, port.Target, config.Domain)
+				portDomain := fmt.Sprintf("%s--%d.%s", common.ServiceLabel(entry.Name), port.Target, config.Domain)
 				if err := CreatePublicDNSRecord(
 					ctx, config.PublicZoneId, portDomain, "A", pulumi.Int(60), ip, opts...,
 				); err != nil {
@@ -557,7 +558,9 @@ func createInternalLoadBalancer(
 }
 
 func internalServiceDns(name string) string {
-	return name + `.google.internal.`
+	// ServiceLabel so the record name matches the PrivateFqdn handle
+	// (project.go/service.go) and the DEFANG_FQDN injected on the CE path.
+	return common.ServiceLabel(name) + `.google.internal.`
 }
 
 func newCertMap(

--- a/provider/defanggcp/gcp/cloudrun.go
+++ b/provider/defanggcp/gcp/cloudrun.go
@@ -89,7 +89,7 @@ func CreateCloudRunService(
 func buildEnvVars(
 	ctx *pulumi.Context,
 	configProvider compose.ConfigProvider,
-	serviceName, etag string,
+	serviceName, etag, fqdn string,
 	svc compose.ServiceConfig,
 	opts ...pulumi.InvokeOption,
 ) (cloudrunv2.ServiceTemplateContainerEnvArray, []string) {
@@ -109,6 +109,12 @@ func buildEnvVars(
 		envs = append(envs, &cloudrunv2.ServiceTemplateContainerEnvArgs{
 			Name:  pulumi.String("DEFANG_ETAG"),
 			Value: pulumi.String(etag),
+		})
+	}
+	if fqdn != "" {
+		envs = append(envs, &cloudrunv2.ServiceTemplateContainerEnvArgs{
+			Name:  pulumi.String("DEFANG_FQDN"),
+			Value: pulumi.String(fqdn),
 		})
 	}
 	for k, v := range common.Sorted(svc.Environment) {
@@ -161,7 +167,14 @@ func buildTemplate(
 	if gcpConfig != nil {
 		etag = gcpConfig.Etag
 	}
-	envs, secretIds := buildEnvVars(ctx, configProvider, serviceName, etag, svc, opts...)
+	// DEFANG_FQDN: custom domain, else public FQDN (ingress). GCP has no
+	// private-FQDN fallback. See common.ServiceFQDN for the precedence.
+	var domain string
+	if gcpConfig != nil {
+		domain = gcpConfig.Domain
+	}
+	fqdn := common.ServiceFQDN(serviceName, svc, domain, "")
+	envs, secretIds := buildEnvVars(ctx, configProvider, serviceName, etag, fqdn, svc, opts...)
 
 	// Build port config
 	var ports *cloudrunv2.ServiceTemplateContainerPortsArgs

--- a/provider/defanggcp/gcp/compute.go
+++ b/provider/defanggcp/gcp/compute.go
@@ -58,7 +58,11 @@ func CreateComputeEngine(
 		healthCheckPort = &p
 	}
 
-	cloudInit := getCloudInitConfig(serviceName, image, svc, gcpConfig.Region, addHealthCheckSidecar)
+	// DEFANG_FQDN: custom domain, else public FQDN (ingress), else the private
+	// FQDN (<label>.google.internal) for internal services — the private zone is
+	// provisioned in alb.go and resolves within the VPC. See common.ServiceFQDN.
+	fqdn := common.ServiceFQDN(serviceName, svc, gcpConfig.Domain, "google.internal")
+	cloudInit := getCloudInitConfig(serviceName, image, svc, gcpConfig.Region, gcpConfig.Etag, fqdn, addHealthCheckSidecar)
 
 	instanceTemplate, err := createInstanceTemplate(
 		ctx, serviceName, serviceName, machineType, cloudInit, sa, gcpConfig, iamDeps, parentOpt)
@@ -316,11 +320,13 @@ func getComputeMachineType(svc compose.ServiceConfig) string {
 // getCloudInitConfig generates a cloud-init YAML string for running a container on
 // Container-Optimized OS using systemd. For portless services it adds an HTTP health
 // check sidecar so the MIG auto-healer can probe container liveness.
+//
+//nolint:funlen
 func getCloudInitConfig(
 	serviceName string,
 	image pulumi.StringInput,
 	svc compose.ServiceConfig,
-	region string,
+	region, etag, fqdn string,
 	addHealthCheckSidecar bool,
 ) pulumi.StringOutput {
 	var buf strings.Builder
@@ -346,6 +352,17 @@ func getCloudInitConfig(
 	}
 
 	var envFlags strings.Builder
+	// Defang-injected runtime vars, mirroring the Cloud Run path (buildEnvVars).
+	staticEnv := [][2]string{{"DEFANG_SERVICE", serviceName}}
+	if etag != "" {
+		staticEnv = append(staticEnv, [2]string{"DEFANG_ETAG", etag})
+	}
+	if fqdn != "" {
+		staticEnv = append(staticEnv, [2]string{"DEFANG_FQDN", fqdn})
+	}
+	for _, kv := range staticEnv {
+		fmt.Fprintf(&envFlags, "-e %q ", fmt.Sprintf("%s=%s", kv[0], kv[1]))
+	}
 	for k, v := range common.Sorted(svc.Environment) {
 		// Compute/VM deploys embed concrete values into the `docker run -e` cmd
 		// string — no runtime config-provider resolution is available here, so

--- a/provider/defanggcp/gcp/compute_test.go
+++ b/provider/defanggcp/gcp/compute_test.go
@@ -1,0 +1,65 @@
+package gcp
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/DefangLabs/pulumi-defang/provider/compose"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// getCloudInitConfig must inject the Defang runtime env vars into the
+// `docker run` command, mirroring the Cloud Run path. DEFANG_SERVICE is always
+// present; DEFANG_ETAG/DEFANG_FQDN only when non-empty.
+func TestGetCloudInitConfigDefangEnv(t *testing.T) {
+	svc := compose.ServiceConfig{
+		Ports: []compose.ServicePortConfig{{Target: 8080, Mode: compose.PortModeHost}},
+	}
+
+	tests := []struct {
+		name    string
+		etag    string
+		fqdn    string
+		present []string
+		absent  []string
+	}{
+		{
+			name:    "all set",
+			etag:    "etag123",
+			fqdn:    "api.google.internal",
+			present: []string{`-e "DEFANG_SERVICE=api"`, `-e "DEFANG_ETAG=etag123"`, `-e "DEFANG_FQDN=api.google.internal"`},
+		},
+		{
+			name:    "no etag or fqdn",
+			present: []string{`-e "DEFANG_SERVICE=api"`},
+			absent:  []string{"DEFANG_ETAG", "DEFANG_FQDN"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cloudInit string
+			var wg sync.WaitGroup
+			wg.Add(1)
+			err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+				out := getCloudInitConfig("api", pulumi.String("img:latest"), svc, "us-central1", tt.etag, tt.fqdn, false)
+				out.ApplyT(func(s string) string {
+					defer wg.Done()
+					cloudInit = s
+					return s
+				})
+				return nil
+			}, pulumi.WithMocks("proj", "stack", testMocks{}))
+			require.NoError(t, err)
+			wg.Wait()
+
+			for _, want := range tt.present {
+				assert.Contains(t, cloudInit, want)
+			}
+			for _, notWant := range tt.absent {
+				assert.NotContains(t, cloudInit, notWant)
+			}
+		})
+	}
+}

--- a/provider/defanggcp/project.go
+++ b/provider/defanggcp/project.go
@@ -220,7 +220,7 @@ func buildService(
 	// createX workers don't build the LBEntry themselves. createService sets
 	// PrivateFqdn internally for the Service case.
 	if lbEntry != nil && svc.HasHostPorts() && lbEntry.PrivateFqdn == "" {
-		lbEntry.PrivateFqdn = fmt.Sprintf("%s.%s", svcName, "google.internal")
+		lbEntry.PrivateFqdn = fmt.Sprintf("%s.%s", common.ServiceLabel(svcName), "google.internal")
 	}
 
 	return endpoint, svcComp, lbEntry, nil

--- a/provider/defanggcp/service.go
+++ b/provider/defanggcp/service.go
@@ -156,7 +156,7 @@ func createService(
 	}
 
 	if lbEntry != nil && svc.HasHostPorts() {
-		lbEntry.PrivateFqdn = fmt.Sprintf("%s.%s", serviceName, "google.internal")
+		lbEntry.PrivateFqdn = fmt.Sprintf("%s.%s", common.ServiceLabel(serviceName), "google.internal")
 	}
 
 	comp.Endpoint = endpoint


### PR DESCRIPTION
matches old behaviour

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Services now receive a `DEFANG_FQDN` environment variable when a fully qualified domain can be resolved.
  - DNS/hostname generation for service-based records is now normalized using consistent service labeling (including underscore/dot handling).

- **Bug Fixes**
  - FQDN resolution now follows correct precedence: custom domain first, then public domain, then private domain (only when applicable).

- **Tests**
  - Added coverage to validate service label formatting and FQDN resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->