### PR TITLE
fix(azure): wait for Redis private DNS before starting Container Apps

### DIFF
--- a/provider/defangazure/azure/dns.go
+++ b/provider/defangazure/azure/dns.go
@@ -21,6 +21,12 @@ type DNSResult struct {
 	// ("privatelink.redis.azure.net"). The PrivateDnsZoneGroup on the private endpoint
 	// auto-registers A records here so cluster FQDNs resolve to private IPs within the VNet.
 	RedisPrivateZone *privatedns.PrivateZone
+
+	// RedisVNetLink links the Redis private zone to the project VNet. A registered
+	// A record only resolves from inside the VNet once this link is effective, so
+	// it's threaded into Redis readiness deps to keep apps from starting before
+	// the hostname resolves (see issue #287).
+	RedisVNetLink *privatedns.VirtualNetworkLink
 }
 
 // CreateDNSZones creates the private DNS zones linked to the project VNet:
@@ -80,7 +86,7 @@ func CreateDNSZones(
 			return nil, fmt.Errorf("creating Redis private DNS zone: %w", err)
 		}
 
-		_, err = privatedns.NewVirtualNetworkLink(ctx, redisServiceName, &privatedns.VirtualNetworkLinkArgs{
+		redisLink, err := privatedns.NewVirtualNetworkLink(ctx, redisServiceName, &privatedns.VirtualNetworkLinkArgs{
 			ResourceGroupName:   infra.ResourceGroup.Name,
 			PrivateZoneName:     redisZone.Name,
 			Location:            pulumi.String("global"),
@@ -92,6 +98,7 @@ func CreateDNSZones(
 		}
 
 		result.RedisPrivateZone = redisZone
+		result.RedisVNetLink = redisLink
 	}
 
 	return result, nil

--- a/provider/defangazure/azure/redis.go
+++ b/provider/defangazure/azure/redis.go
@@ -17,6 +17,14 @@ type RedisResult struct {
 	Cluster       *redis.RedisEnterprise
 	Database      *redis.Database
 	ConnectionURL pulumi.StringOutput // rediss://:<key>@<host>:10000
+
+	// Readiness lists resources that must be fully applied before downstream
+	// Container Apps connect to the cluster. For VNet deployments this is the
+	// private DNS plumbing (PrivateDnsZoneGroup + VirtualNetworkLink) that
+	// publishes the cluster's A record; without waiting for it, apps resolve the
+	// hostname before DNS is effective and ioredis exhausts its retry budget and
+	// wedges permanently (see issue #287). Empty for the standalone/no-VNet path.
+	Readiness []pulumi.Resource
 }
 
 // selectEnterpriseSkuName picks the Azure Managed Redis SKU name based on memory in MiB.
@@ -139,9 +147,17 @@ func CreateRedisEnterprise(
 		ResourceGroupName: infra.ResourceGroup.Name,
 	}, pulumi.Parent(cluster))
 
+	var readiness []pulumi.Resource
 	if useVNet {
-		if err := createRedisVNetEndpoint(ctx, serviceName, cluster, infra, opts...); err != nil {
+		zoneGroup, err := createRedisVNetEndpoint(ctx, serviceName, cluster, infra, opts...)
+		if err != nil {
 			return nil, err
+		}
+		// The zone group publishes the A record; the VNet link makes it resolvable
+		// from inside the VNet. Apps must wait for both before connecting.
+		readiness = []pulumi.Resource{zoneGroup}
+		if infra.DNS.RedisVNetLink != nil {
+			readiness = append(readiness, infra.DNS.RedisVNetLink)
 		}
 	}
 
@@ -154,18 +170,20 @@ func CreateRedisEnterprise(
 		},
 	).(pulumi.StringOutput)
 
-	return &RedisResult{Cluster: cluster, Database: db, ConnectionURL: connectionURL}, nil
+	return &RedisResult{Cluster: cluster, Database: db, ConnectionURL: connectionURL, Readiness: readiness}, nil
 }
 
 // createRedisVNetEndpoint creates a private endpoint and DNS zone group so that traffic to
-// the Redis cluster stays within the VNet (Plaintext protocol, plain redis:// URL).
+// the Redis cluster stays within the VNet (Plaintext protocol, plain redis:// URL). It
+// returns the PrivateDnsZoneGroup, which publishes the cluster's A record — downstream apps
+// must wait for it before resolving the hostname (see issue #287).
 func createRedisVNetEndpoint(
 	ctx *pulumi.Context,
 	serviceName string,
 	cluster *redis.RedisEnterprise,
 	infra *SharedInfra,
 	opts ...pulumi.ResourceOption,
-) error {
+) (pulumi.Resource, error) {
 	pe, err := network.NewPrivateEndpoint(ctx, serviceName, &network.PrivateEndpointArgs{
 		ResourceGroupName: infra.ResourceGroup.Name,
 		// Location:          pulumi.StringPtr(location),
@@ -182,12 +200,12 @@ func createRedisVNetEndpoint(
 		Tags: ServiceTags(serviceName),
 	}, opts...)
 	if err != nil {
-		return fmt.Errorf("creating Redis private endpoint: %w", err)
+		return nil, fmt.Errorf("creating Redis private endpoint: %w", err)
 	}
 
 	// Zone group auto-registers an A record in privatelink.redis.azure.net mapping
 	// the cluster's private-link FQDN to the private endpoint IP.
-	_, err = network.NewPrivateDnsZoneGroup(ctx, serviceName, &network.PrivateDnsZoneGroupArgs{
+	zoneGroup, err := network.NewPrivateDnsZoneGroup(ctx, serviceName, &network.PrivateDnsZoneGroupArgs{
 		ResourceGroupName:       infra.ResourceGroup.Name,
 		PrivateEndpointName:     pe.Name,
 		PrivateDnsZoneGroupName: pulumi.String("default"),
@@ -199,7 +217,7 @@ func createRedisVNetEndpoint(
 		},
 	}, append(opts, pulumi.Parent(pe))...)
 	if err != nil {
-		return fmt.Errorf("creating Redis private DNS zone group: %w", err)
+		return nil, fmt.Errorf("creating Redis private DNS zone group: %w", err)
 	}
-	return nil
+	return zoneGroup, nil
 }

--- a/provider/defangazure/azure/redis.go
+++ b/provider/defangazure/azure/redis.go
@@ -183,7 +183,7 @@ func createRedisVNetEndpoint(
 	cluster *redis.RedisEnterprise,
 	infra *SharedInfra,
 	opts ...pulumi.ResourceOption,
-) (pulumi.Resource, error) {
+) (*network.PrivateDnsZoneGroup, error) {
 	pe, err := network.NewPrivateEndpoint(ctx, serviceName, &network.PrivateEndpointArgs{
 		ResourceGroupName: infra.ResourceGroup.Name,
 		// Location:          pulumi.StringPtr(location),

--- a/provider/defangazure/azure/redis_test.go
+++ b/provider/defangazure/azure/redis_test.go
@@ -1,0 +1,104 @@
+package azure
+
+import (
+	"testing"
+
+	"github.com/DefangLabs/pulumi-defang/provider/compose"
+	"github.com/pulumi/pulumi-azure-native-sdk/network/v3"
+	"github.com/pulumi/pulumi-azure-native-sdk/privatedns/v3"
+	"github.com/pulumi/pulumi-azure-native-sdk/resources/v3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// vnetRedisInfra builds the minimal SharedInfra needed to exercise the
+// VNet/private-endpoint path of CreateRedisEnterprise: a resource group, a
+// private-endpoints subnet, and the Redis private DNS zone + VNet link.
+func vnetRedisInfra(t *testing.T, ctx *pulumi.Context) *SharedInfra {
+	t.Helper()
+
+	rg, err := resources.NewResourceGroup(ctx, "rg", &resources.ResourceGroupArgs{
+		ResourceGroupName: pulumi.String("rg"),
+	})
+	require.NoError(t, err)
+
+	vnet, err := network.NewVirtualNetwork(ctx, "vnet", &network.VirtualNetworkArgs{
+		ResourceGroupName: rg.Name,
+	})
+	require.NoError(t, err)
+
+	subnet, err := network.NewSubnet(ctx, "pe", &network.SubnetArgs{
+		ResourceGroupName:  rg.Name,
+		VirtualNetworkName: vnet.Name,
+	})
+	require.NoError(t, err)
+
+	zone, err := privatedns.NewPrivateZone(ctx, "redis", &privatedns.PrivateZoneArgs{
+		ResourceGroupName: rg.Name,
+		PrivateZoneName:   pulumi.String("privatelink.redis.azure.net"),
+	})
+	require.NoError(t, err)
+
+	link, err := privatedns.NewVirtualNetworkLink(ctx, "redis", &privatedns.VirtualNetworkLinkArgs{
+		ResourceGroupName: rg.Name,
+		PrivateZoneName:   zone.Name,
+		VirtualNetwork:    &privatedns.SubResourceArgs{Id: vnet.ID().ToStringOutput()},
+	})
+	require.NoError(t, err)
+
+	return &SharedInfra{
+		ResourceGroup: rg,
+		Networking:    &NetworkingResult{VNet: vnet, PrivateEndpointsSubnet: subnet},
+		DNS:           &DNSResult{RedisPrivateZone: zone, RedisVNetLink: link},
+	}
+}
+
+// TestCreateRedisEnterpriseReadinessVNet verifies that the VNet path populates
+// Readiness with the private-DNS plumbing (zone group + VNet link). Downstream
+// apps fold these into the outputs they consume so Pulumi won't start a Container
+// App before the cluster's A record is published and resolvable — the fix for the
+// fresh-deploy DNS race in issue #287.
+func TestCreateRedisEnterpriseReadinessVNet(t *testing.T) {
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		infra := vnetRedisInfra(t, ctx)
+		svc := compose.ServiceConfig{Redis: &compose.RedisConfig{}}
+
+		result, err := CreateRedisEnterprise(ctx, "cache", svc, infra)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		// Zone group (publishes the A record) + VNet link (makes it resolvable).
+		assert.Len(t, result.Readiness, 2,
+			"VNet Redis must expose the DNS zone group and VNet link as readiness deps")
+		for i, r := range result.Readiness {
+			assert.NotNil(t, r, "readiness resource %d must not be nil", i)
+		}
+		return nil
+	}, pulumi.WithMocks("proj", "stack", azureNoopMocks{}))
+	require.NoError(t, err)
+}
+
+// TestCreateRedisEnterpriseReadinessNoVNet verifies the standalone/no-VNet path
+// (Encrypted protocol, public rediss:// endpoint) exposes no readiness deps —
+// there is no private DNS to wait on, so apps connect directly to the cluster.
+func TestCreateRedisEnterpriseReadinessNoVNet(t *testing.T) {
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		rg, err := resources.NewResourceGroup(ctx, "rg", &resources.ResourceGroupArgs{
+			ResourceGroupName: pulumi.String("rg"),
+		})
+		require.NoError(t, err)
+
+		infra := &SharedInfra{ResourceGroup: rg} // no Networking, no DNS
+		svc := compose.ServiceConfig{Redis: &compose.RedisConfig{}}
+
+		result, err := CreateRedisEnterprise(ctx, "cache", svc, infra)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		assert.Empty(t, result.Readiness,
+			"no-VNet Redis has no private DNS to wait on, so Readiness must be empty")
+		return nil
+	}, pulumi.WithMocks("proj", "stack", azureNoopMocks{}))
+	require.NoError(t, err)
+}

--- a/provider/defangazure/project.go
+++ b/provider/defangazure/project.go
@@ -173,10 +173,16 @@ func createRedisResources(
 		return pulumi.StringOutput{}, fmt.Errorf("creating Redis for %s: %w", svcName, err)
 	}
 
+	// Fold the private-DNS readiness resources into the outputs apps consume so
+	// Pulumi won't create a Container App until the cluster's A record is published
+	// and resolvable in the VNet. Without this, the app starts before DNS is
+	// effective, ioredis exhausts its retry budget, and wedges permanently (#287).
 	// ConnectionURL is the full redis:// or rediss:// URL including auth.
-	managedEndpoints[svcName] = redisResult.ConnectionURL
-	serviceHosts[svcName] = redisResult.Cluster.HostName
-	return pulumi.Sprintf("%s:10000", redisResult.Cluster.HostName), nil
+	connURL := withResourceDeps(redisResult.ConnectionURL, redisResult.Readiness)
+	host := withResourceDeps(redisResult.Cluster.HostName, redisResult.Readiness)
+	managedEndpoints[svcName] = connURL
+	serviceHosts[svcName] = host
+	return pulumi.Sprintf("%s:10000", host), nil
 }
 
 // createServiceResources creates the component resource and underlying cloud resources


### PR DESCRIPTION
## Problem

Fixes #287. On a fresh Azure resource group, a Container App consuming managed Redis fails to connect on startup and never recovers.

A Container App only carries a **data** dependency on the Redis cluster and its keys (via the `REDIS_URL` env var string) — not on the private-DNS plumbing that publishes and resolves the cluster's A record. So Pulumi creates and starts the app before the `privatelink.redis.azure.net` record is effective. `ioredis` resolves the hostname, gets NXDOMAIN, exhausts its default 20-retry budget within ~1 minute, and wedges permanently: every Redis-touching endpoint 500s until the revision is manually restarted (`az containerapp revision restart`). The Container App stays "Running"/"Ready", so the failure is silent.

## Fix

Encode the dependency in the resource graph (issue's preferred option 1), reusing the existing `withResourceDeps` pattern that Postgres already uses in this provider:

- **`dns.go`** — surface the Redis `VirtualNetworkLink` on `DNSResult.RedisVNetLink` (was discarded into `_`). A registered A record only resolves from inside the VNet once this link is effective.
- **`redis.go`** — `createRedisVNetEndpoint` returns the `PrivateDnsZoneGroup` (the A-record publisher, also previously discarded). `RedisResult` gains a `Readiness []pulumi.Resource` field holding the zone group + VNet link (empty on the standalone/no-VNet path).
- **`project.go`** — `createRedisResources` folds `redisResult.Readiness` into both the connection URL and host outputs apps consume, so any Container App referencing them transitively `DependsOn` the DNS plumbing and isn't created until the hostname resolves.

`Readiness` is an untagged internal handle (like AWS's `Dependency`), so there is **no schema/SDK change**.

## Testing

- `go build ./provider/...`, `go vet ./provider/defangazure/...` — clean
- New `provider/defangazure/azure/redis_test.go` asserts the VNet path exposes 2 readiness deps (zone group + VNet link) and the no-VNet path exposes none. Full `go test ./provider/defangazure/...` passes.
- Not yet validated on a live fresh-RG deploy (the bug only reproduces on a brand-new resource group, which needs the CD-image-override flow). The unit tests plus the dependency wiring cover the logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redis deployments now expose readiness signals for dependent services to wait on private networking and private DNS setup.
  * Redis provisioning now returns explicit readiness information for the VNet/private-endpoint path.

* **Bug Fixes**
  * Connection and host outputs now honor readiness dependencies, improving startup reliability when private DNS resources are involved.

* **Tests**
  * Added automated coverage for Redis readiness behavior in both VNet and non-VNet deployment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->