### PR TITLE
Import delegate domain zone to pulumi for clean up

### DIFF
--- a/provider/defangazure/azure/azure.go
+++ b/provider/defangazure/azure/azure.go
@@ -9,6 +9,7 @@ import (
 	"github.com/DefangLabs/pulumi-defang/provider/common"
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
 	"github.com/pulumi/pulumi-azure-native-sdk/app/v3"
+	"github.com/pulumi/pulumi-azure-native-sdk/dns/v3"
 	"github.com/pulumi/pulumi-azure-native-sdk/resources/v3"
 	azureconfig "github.com/pulumi/pulumi-azure-native-sdk/v3/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -34,6 +35,10 @@ type SharedInfra struct {
 	// ResourceGroup. The zone itself is created out-of-band by the defang CLI
 	// (PrepareDomainDelegation), so Pulumi only manages the records and the cert.
 	Domain string
+	// DomainZone is the public DNS zone named Domain, adopted into Pulumi state by
+	// EnsureDomainZone so that `defang compose down` deletes it (and its records)
+	// instead of orphaning it in the resource group. Nil when Domain is empty.
+	DomainZone *dns.Zone
 }
 
 // BaseTags returns the project-wide tag map: defang-project (Pulumi project),

--- a/provider/defangazure/azure/customdomain.go
+++ b/provider/defangazure/azure/customdomain.go
@@ -55,6 +55,12 @@ type CustomDomainResult struct {
 // EnsureKeyVault, which retains the vault to preserve user secrets). The args
 // mirror a public zone exactly so the import doesn't propose a replacement.
 //
+// The import ID is constructed (see domainZoneID) rather than fetched via
+// dns.LookupZone: every component is already known, so a lookup invoke would
+// only add an ARM round-trip without buying safety — a missing zone fails the
+// import just the same. It also keeps `pulumi preview` from failing before the
+// CLI has created the zone (an invoke runs in preview; an import is a no-op).
+//
 // Returns (nil, nil) when the project has no delegate domain. The returned zone
 // is stored on infra.DomainZone and referenced by CreateCustomDomain so the
 // per-service records depend on it (created after / deleted before the zone).
@@ -68,13 +74,7 @@ func EnsureDomainZone(
 		return nil, nil //nolint:nilnil // no delegate domain; nothing to import
 	}
 
-	existing, err := dns.LookupZone(ctx, &dns.LookupZoneArgs{
-		ResourceGroupName: ProjectResourceGroupName(ctx, projectName),
-		ZoneName:          infra.Domain,
-	}, parentOpt)
-	if err != nil {
-		return nil, fmt.Errorf("looking up DNS zone %q for import: %w", infra.Domain, err)
-	}
+	importID := domainZoneID(resolveSubscriptionID(ctx), ProjectResourceGroupName(ctx, projectName), infra.Domain)
 
 	// Public DNS zones always live at location "global". ResourceGroupName uses
 	// the live RG resource handle (not the computed name) so the import is
@@ -84,11 +84,22 @@ func EnsureDomainZone(
 		ZoneName:          pulumi.String(infra.Domain),
 		Location:          pulumi.String("global"),
 		ZoneType:          dns.ZoneTypePublic,
-	}, parentOpt, pulumi.Import(pulumi.ID(existing.Id)))
+	}, parentOpt, pulumi.Import(pulumi.ID(importID)))
 	if err != nil {
 		return nil, fmt.Errorf("importing DNS zone %q: %w", infra.Domain, err)
 	}
 	return zone, nil
+}
+
+// domainZoneID builds the ARM resource ID of a public DNS zone from its parts.
+// Azure's canonical ID lowercases the provider path segment ("dnszones"), so we
+// match that exactly — a casing mismatch can make the import propose a
+// replacement. This is the same value dns.LookupZone would return.
+func domainZoneID(subscriptionID, resourceGroup, zoneName string) string {
+	return fmt.Sprintf(
+		"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/dnszones/%s",
+		subscriptionID, resourceGroup, zoneName,
+	)
 }
 
 // CreateCustomDomain provisions per-service DNS records under infra.Domain.

--- a/provider/defangazure/azure/customdomain.go
+++ b/provider/defangazure/azure/customdomain.go
@@ -2,7 +2,9 @@
 //
 // The defang CLI creates the public DNS zone (PrepareDomainDelegation) in the
 // project resource group before this provider runs, and tells Fabric to point
-// NS records at it. Inside the zone, Pulumi owns:
+// NS records at it. EnsureDomainZone then imports that zone into Pulumi state so
+// teardown (`defang compose down`) deletes it instead of orphaning it. Inside
+// the zone, Pulumi owns:
 //
 //  1. A CNAME `<service>.<delegate-domain>` → the Container App's stable FQDN
 //     (`<appName>.<env.DefaultDomain>`), so the host header reaches ACA.
@@ -42,6 +44,53 @@ type CustomDomainResult struct {
 	Asuid *dns.RecordSet
 }
 
+// EnsureDomainZone adopts the project's public DNS zone (infra.Domain) into
+// Pulumi state by importing it. The zone is provisioned out-of-band by the
+// defang CLI (PrepareDomainDelegation) before the CD task runs; until now Pulumi
+// only managed the records inside it, so the zone itself was orphaned on
+// teardown. Importing it makes `defang compose down` delete the zone — and
+// every record set within it — as part of the normal destroy.
+//
+// Deliberately NO RetainOnDelete: cleanup on teardown is the whole point (unlike
+// EnsureKeyVault, which retains the vault to preserve user secrets). The args
+// mirror a public zone exactly so the import doesn't propose a replacement.
+//
+// Returns (nil, nil) when the project has no delegate domain. The returned zone
+// is stored on infra.DomainZone and referenced by CreateCustomDomain so the
+// per-service records depend on it (created after / deleted before the zone).
+func EnsureDomainZone(
+	ctx *pulumi.Context,
+	projectName string,
+	infra *SharedInfra,
+	parentOpt pulumi.ResourceOrInvokeOption,
+) (*dns.Zone, error) {
+	if infra == nil || infra.Domain == "" {
+		return nil, nil //nolint:nilnil // no delegate domain; nothing to import
+	}
+
+	existing, err := dns.LookupZone(ctx, &dns.LookupZoneArgs{
+		ResourceGroupName: ProjectResourceGroupName(ctx, projectName),
+		ZoneName:          infra.Domain,
+	}, parentOpt)
+	if err != nil {
+		return nil, fmt.Errorf("looking up DNS zone %q for import: %w", infra.Domain, err)
+	}
+
+	// Public DNS zones always live at location "global". ResourceGroupName uses
+	// the live RG resource handle (not the computed name) so the import is
+	// ordered after the RG is adopted into state.
+	zone, err := dns.NewZone(ctx, "domain-zone", &dns.ZoneArgs{
+		ResourceGroupName: infra.ResourceGroup.Name,
+		ZoneName:          pulumi.String(infra.Domain),
+		Location:          pulumi.String("global"),
+		ZoneType:          dns.ZoneTypePublic,
+	}, parentOpt, pulumi.Import(pulumi.ID(existing.Id)))
+	if err != nil {
+		return nil, fmt.Errorf("importing DNS zone %q: %w", infra.Domain, err)
+	}
+	return zone, nil
+}
+
 // CreateCustomDomain provisions per-service DNS records under infra.Domain.
 // Returns (nil, nil) — and creates nothing — when the project has no delegate
 // domain or when the service does not expose a public ingress.
@@ -71,7 +120,14 @@ func CreateCustomDomain(
 	}
 
 	rgName := infra.ResourceGroup.Name
-	zoneName := pulumi.String(infra.Domain)
+	// Reference the imported zone's Name (same value as infra.Domain) so each
+	// record set depends on the zone resource: created after the zone is adopted,
+	// and deleted before it on teardown. Fall back to the literal domain when the
+	// zone wasn't imported (e.g. standalone callers that set Domain directly).
+	var zoneName pulumi.StringInput = pulumi.String(infra.Domain)
+	if infra.DomainZone != nil {
+		zoneName = infra.DomainZone.Name
+	}
 	tags := ServiceTags(serviceName)
 
 	// CNAME — `<service>.<domain>` points at the app's stable FQDN. Using the

--- a/provider/defangazure/azure/customdomain_zone_test.go
+++ b/provider/defangazure/azure/customdomain_zone_test.go
@@ -1,6 +1,7 @@
 package azure
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/pulumi/pulumi-azure-native-sdk/resources/v3"
@@ -10,51 +11,80 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// zoneLookupMocks answers the dns.LookupZone invoke with a concrete resource ID
-// so EnsureDomainZone has something to import; every other call/resource echoes
+// zoneImportMocks captures the import ID and inputs of the imported DNS zone
+// resource ("domain-zone") so tests can assert EnsureDomainZone imports the
+// right zone in the right resource group. Every other resource echoes its
 // inputs like azureNoopMocks.
-type zoneLookupMocks struct{}
+type zoneImportMocks struct {
+	importID   string
+	zoneInputs resource.PropertyMap
+}
 
-func (zoneLookupMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+func (m *zoneImportMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+	if strings.HasSuffix(args.TypeToken, ":Zone") {
+		m.importID = args.ID // the physical ID passed via pulumi.Import
+		m.zoneInputs = args.Inputs
+	}
 	return args.Name + "_id", args.Inputs, nil
 }
 
-func (zoneLookupMocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
-	out := args.Args.Copy()
-	out["id"] = resource.NewStringProperty(
-		"/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/dnszones/proj.example.com",
-	)
-	return out, nil
+func (zoneImportMocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
+	return args.Args, nil
 }
 
 // TestEnsureDomainZoneNoDomain verifies the no-op path: a project without a
 // delegate domain imports nothing and returns (nil, nil), so infra.DomainZone
 // stays nil and CreateCustomDomain keeps its literal-domain fallback.
 func TestEnsureDomainZoneNoDomain(t *testing.T) {
+	mocks := &zoneImportMocks{}
 	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
 		zone, err := EnsureDomainZone(ctx, "proj", &SharedInfra{Domain: ""}, nil)
 		require.NoError(t, err)
 		assert.Nil(t, zone, "no delegate domain must import no zone")
 		return nil
-	}, pulumi.WithMocks("proj", "stack", azureNoopMocks{}))
+	}, pulumi.WithMocks("proj", "stack", mocks))
 	require.NoError(t, err)
+	assert.Empty(t, mocks.importID, "no zone resource should be created without a domain")
 }
 
 // TestEnsureDomainZoneImports verifies that with a delegate domain set, the
-// CLI-created zone is looked up and adopted into Pulumi state (no RetainOnDelete,
-// so teardown deletes it). Asserts a non-nil zone resource is returned.
+// CLI-created zone is adopted into Pulumi state by importing the constructed ARM
+// resource ID (no RetainOnDelete, so teardown deletes it). The assertion pins
+// the import ID to domainZoneID(subscription, project RG, domain) so the test
+// fails if EnsureDomainZone imports the wrong zone or resource group, or stops
+// importing entirely.
 func TestEnsureDomainZoneImports(t *testing.T) {
+	mocks := &zoneImportMocks{}
+	var wantID string
 	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
 		rg, err := resources.NewResourceGroup(ctx, "rg", &resources.ResourceGroupArgs{
 			ResourceGroupName: pulumi.String("rg"),
 		})
 		require.NoError(t, err)
 
+		// Expected ID uses the same derivation as the implementation: the lookup
+		// RG is ProjectResourceGroupName(ctx, projectName), NOT the fixture RG.
+		wantID = domainZoneID(resolveSubscriptionID(ctx), ProjectResourceGroupName(ctx, "proj"), "proj.example.com")
+
 		infra := &SharedInfra{ResourceGroup: rg, Domain: "proj.example.com"}
 		zone, err := EnsureDomainZone(ctx, "proj", infra, pulumi.Parent(rg))
 		require.NoError(t, err)
 		require.NotNil(t, zone, "a delegate domain must import the zone")
 		return nil
-	}, pulumi.WithMocks("proj", "stack", zoneLookupMocks{}))
+	}, pulumi.WithMocks("proj", "stack", mocks))
 	require.NoError(t, err)
+
+	assert.Equal(t, wantID, mocks.importID, "zone must be imported by the constructed ARM resource ID")
+	require.NotNil(t, mocks.zoneInputs, "zone resource must have been registered")
+	assert.Equal(t, "proj.example.com", mocks.zoneInputs["zoneName"].StringValue(), "imported zone must target the delegate domain")
+	assert.Equal(t, "global", mocks.zoneInputs["location"].StringValue(), "public DNS zones live at location global")
+}
+
+// TestDomainZoneID pins the ARM resource ID format, including the lowercase
+// "dnszones" segment that Azure's canonical ID uses — a casing mismatch can make
+// the import propose a replacement.
+func TestDomainZoneID(t *testing.T) {
+	got := domainZoneID("sub", "rg", "proj.example.com")
+	want := "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/dnszones/proj.example.com"
+	assert.Equal(t, want, got)
 }

--- a/provider/defangazure/azure/customdomain_zone_test.go
+++ b/provider/defangazure/azure/customdomain_zone_test.go
@@ -76,7 +76,8 @@ func TestEnsureDomainZoneImports(t *testing.T) {
 
 	assert.Equal(t, wantID, mocks.importID, "zone must be imported by the constructed ARM resource ID")
 	require.NotNil(t, mocks.zoneInputs, "zone resource must have been registered")
-	assert.Equal(t, "proj.example.com", mocks.zoneInputs["zoneName"].StringValue(), "imported zone must target the delegate domain")
+	assert.Equal(t, "proj.example.com", mocks.zoneInputs["zoneName"].StringValue(),
+		"imported zone must target the delegate domain")
 	assert.Equal(t, "global", mocks.zoneInputs["location"].StringValue(), "public DNS zones live at location global")
 }
 

--- a/provider/defangazure/azure/customdomain_zone_test.go
+++ b/provider/defangazure/azure/customdomain_zone_test.go
@@ -1,0 +1,60 @@
+package azure
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-azure-native-sdk/resources/v3"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// zoneLookupMocks answers the dns.LookupZone invoke with a concrete resource ID
+// so EnsureDomainZone has something to import; every other call/resource echoes
+// inputs like azureNoopMocks.
+type zoneLookupMocks struct{}
+
+func (zoneLookupMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+	return args.Name + "_id", args.Inputs, nil
+}
+
+func (zoneLookupMocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
+	out := args.Args.Copy()
+	out["id"] = resource.NewStringProperty(
+		"/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/dnszones/proj.example.com",
+	)
+	return out, nil
+}
+
+// TestEnsureDomainZoneNoDomain verifies the no-op path: a project without a
+// delegate domain imports nothing and returns (nil, nil), so infra.DomainZone
+// stays nil and CreateCustomDomain keeps its literal-domain fallback.
+func TestEnsureDomainZoneNoDomain(t *testing.T) {
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		zone, err := EnsureDomainZone(ctx, "proj", &SharedInfra{Domain: ""}, nil)
+		require.NoError(t, err)
+		assert.Nil(t, zone, "no delegate domain must import no zone")
+		return nil
+	}, pulumi.WithMocks("proj", "stack", azureNoopMocks{}))
+	require.NoError(t, err)
+}
+
+// TestEnsureDomainZoneImports verifies that with a delegate domain set, the
+// CLI-created zone is looked up and adopted into Pulumi state (no RetainOnDelete,
+// so teardown deletes it). Asserts a non-nil zone resource is returned.
+func TestEnsureDomainZoneImports(t *testing.T) {
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		rg, err := resources.NewResourceGroup(ctx, "rg", &resources.ResourceGroupArgs{
+			ResourceGroupName: pulumi.String("rg"),
+		})
+		require.NoError(t, err)
+
+		infra := &SharedInfra{ResourceGroup: rg, Domain: "proj.example.com"}
+		zone, err := EnsureDomainZone(ctx, "proj", infra, pulumi.Parent(rg))
+		require.NoError(t, err)
+		require.NotNil(t, zone, "a delegate domain must import the zone")
+		return nil
+	}, pulumi.WithMocks("proj", "stack", zoneLookupMocks{}))
+	require.NoError(t, err)
+}

--- a/provider/defangazure/project.go
+++ b/provider/defangazure/project.go
@@ -390,6 +390,15 @@ func setupSharedInfra(
 		infra.ConfigProvider = providerazure.NewConfigProvider(keyVaultURL)
 	}
 
+	// Adopt the CLI-created delegate-domain DNS zone into Pulumi state (no-op when
+	// the project has no domain) so `defang compose down` cleans it up along with
+	// the per-service records CreateCustomDomain writes into it.
+	domainZone, err := providerazure.EnsureDomainZone(ctx, projectName, infra, parentOpt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("importing domain DNS zone: %w", err)
+	}
+	infra.DomainZone = domainZone
+
 	if types.pgServiceName != "" || types.redisServiceName != "" {
 		networking, err := providerazure.CreateNetworking(ctx, projectName, infra, parentOpt)
 		if err != nil {


### PR DESCRIPTION
Fixes: #300 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public DNS zones can now be adopted into managed state for coordinated management of per-service records and certificate lifecycles.
  * Custom domain record sets will use the adopted DNS zone as the primary reference when available.
* **Bug Fixes**
  * Resource teardown now reliably removes the imported/managed DNS zone together with its associated records, avoiding orphaned resources.
  * Projects without a configured domain continue to skip DNS zone adoption.
* **Tests**
  * Added tests for DNS zone adoption, including the exact Azure import ID format and “no-domain” behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->