### PR TITLE
feat: compose-shape inputs for standalone Services and Build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
-          version: v2.7.2
+          version: v2.11.4
           args: --timeout=5m --config=.golangci.yaml ./provider/...
 
   build_sdks:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,24 +64,36 @@ Each cloud (AWS/GCP/Azure) follows the same structure:
 - `provider/defang{aws,gcp,azure}/redis.go` — Redis-compatible managed cache component
 - `provider/defang{aws,gcp,azure}/{aws,gcp,azure}/` — cloud-specific resource creation
 
-Components: **Project** (orchestrator), **Service** (container), **Postgres** (managed DB), **Redis** (managed cache), **Build** (AWS only, resource not component).
+Components: **Project** (orchestrator), **Service** (container), **Postgres** (managed DB), **Redis** (managed cache), **Build** (Pulumi *resource*, not component — registered by all three providers: CodeBuild on AWS, Cloud Build on GCP, ACR Task on Azure).
 
 ### Component Scopes: Project vs. Standalone
 
 Each managed-resource component has **one implementation**, invoked two ways:
 
-- **Standalone** — user instantiates `Service` / `Postgres` / `Redis` directly via the generated SDK. The component's `Construct` method runs with no shared project infrastructure by default. For GCP it builds a minimal `GlobalConfig` (region + project only) via `NewStandaloneGlobalConfig`; for AWS a nil `SharedInfra` is used. Callers in Go code may pass a richer `Infra` (AWS: `*SharedInfra`, GCP: `*GlobalConfig`) — these fields carry resource pointers and are **not** part of the SDK schema.
+- **Standalone** — user instantiates `Service` / `Postgres` / `Redis` directly via the generated SDK. The component's `Construct` method runs with no shared project infrastructure by default. All three providers now use a type named `SharedInfra`; how the standalone path obtains one differs:
+    - **AWS**: passes a nil `*SharedInfra` to the worker.
+    - **GCP**: builds a minimal `*SharedInfra` via `NewStandaloneGlobalConfig(ctx)` (the function name predates the `GlobalConfig` → `SharedInfra` type rename and was kept for back-compat).
+    - **Azure**: standalone `Service` builds a minimal `*SharedInfra` (resource group + managed environment, no VNet / DNS / Log Analytics / Key Vault) via `newStandaloneInfra`. Standalone `Postgres` / `Redis` create their own resource group inline.
+
+  Callers in Go code may pass a richer `Infra` (`*SharedInfra` in all three providers) — these fields carry resource pointers and Pulumi Outputs and are **not** part of the SDK schema.
 - **Project-owned** — `Project.Construct` runs `buildProject` / `newService`, which provisions shared infra (VPC, NAT, Artifact Registry, ALB/LB, DNS zones), then dispatches each service by registering the typed `*Outputs` component and calling the same internal worker (`createPostgres` / `createRedis` / `createECSService` / `createService`). Each component must be registered under the exact type token defined by the `<Component>ComponentType` constant so the SDK schema matches the runtime registration.
 
-**Build is a Project-only concern.** `Service` standalone is image-only — `ServiceInputs` does not carry a `Build` field. Build-from-source requires project-scope `BuildInfra` (Artifact Registry + Cloud Build on GCP, ECR + CodeBuild on AWS). Don't re-add `Build` to standalone Service inputs.
+**Build-from-source on a `Service` is a Project-only concern.** Although each provider registers a standalone `Build` *resource* (CodeBuild / Cloud Build / ACR Task), `ServiceInputs` deliberately does not carry a `Build` field on any provider: build-from-source wiring requires the project-scope build pipeline (ECR + CodeBuild on AWS, Artifact Registry + Cloud Build on GCP, ACR + ACR Task on Azure). Don't re-add `Build` to standalone Service inputs.
 
-**VPC-dependent features require infra** in GCP: Compute Engine (CE), VpcAccess on Cloud Run, and LLM bindings that cross VPC boundaries. Standalone Cloud Run skips `VpcAccess` when `infra.PublicIP == nil`; standalone routing forces Cloud Run regardless of port configuration since CE cannot run without a VPC.
+**VPC-dependent features require infra** in GCP: VpcAccess on Cloud Run, and LLM bindings that cross VPC boundaries. Standalone Cloud Run skips `VpcAccess` when `infra.PublicIP == nil`; standalone routing forces Cloud Run regardless of port configuration (legacy behavior, kept for schema stability) — *except* when the service uses CE-only features (sidecars, volumes, volumes_from), in which case a standalone Compute Engine MIG is created on the GCP **default network**. Sidecars/volumes on a single-ingress-port service (which must be Cloud Run) are an error.
 
-**Dependency handles on outputs.** Each managed `*Outputs` struct carries an internal, untagged handle used by the project dispatcher for ordering and load-balancer wiring:
-- AWS: `PostgresOutputs.Dependency`, `RedisOutputs.Dependency`, `ServiceOutputs.Dependency` — all `pulumi.Resource` (either the backing instance or a private-zone CNAME record).
+**Dependency handles on outputs.** AWS and GCP `*Outputs` structs carry an internal, untagged handle used by the project dispatcher for ordering and load-balancer wiring:
+- AWS: `PostgresOutputs.Dependency`, `RedisOutputs.Dependency`, `ServiceOutputs.Dependency` — all `pulumi.Resource` (either the backing instance or a private-zone CNAME record). AWS `PostgresOutputs` also exports `InstanceIdentifier` (the RDS `DBInstanceIdentifier`) as a *schema* field for downstream consumers.
 - GCP: `PostgresOutputs.Instance`, `RedisOutputs.Instance` (typed), `ServiceOutputs.LBEntry` (built inside the worker).
+- Azure: standalone `AzurePostgresOutputs` / `AzureRedisOutputs` / `ServiceOutputs` currently expose only `Endpoint` — no equivalent untagged dependency handle. Project-scope wiring on Azure flows through the shared `ManagedEnvironment` instead of per-component handles.
 
 Untagged fields are ignored by the Pulumi infer framework (`introspect.ParseTag` treats them as `Internal: true`), so they don't need `pulumi:"-"`.
+
+### Compose-shape parity across providers
+
+`compose.ServiceConfig` carries a growing set of compose-shaped fields — `containerName`, `workingDir`, `stopGracePeriod`, `volumes`, `volumesFrom`, `dependsOn`, `autoscaling`, per-port `listener` — plus the standalone-Service extras `sidecars`, `secrets`, `taskRoleArn` / `serviceAccountEmail`, `securityGroupIds`, `triggers`, `waitForSteadyState`. AWS `ServiceInputs` and GCP `ServiceInputs` expose these; the underlying workers (`CreateECSService`, `CreateComputeEngine`) implement them.
+
+**Azure is intentionally behind on parity.** `provider/defangazure/service.go` `ServiceInputs` does *not* expose these fields yet, and the Container Apps worker does not honor them. Rationale: no current Defang customer stack drives the Azure Service standalone path with these features, so the added surface area (multi-container Container App revisions, Managed Identity reuse, Container Apps native secret refs, etc.) is deferred until there is a concrete consumer. **TODO(azure-parity)** — when adding this, mirror the AWS/GCP inputs 1:1 for schema stability, and follow the same design as GCP for sidecars (a `sidecars: map[string]ServiceConfig` alongside the main container). Keep any implementation-gap surface behind explicit `unsupported on Azure` errors rather than silent no-ops.
 
 ### Pulumi inputs and outputs
 

--- a/cd/program/aws.go
+++ b/cd/program/aws.go
@@ -107,7 +107,7 @@ func toAWSServices(services compose.Services) awscompose.ServiceConfigMap {
 
 func toAWSServiceArgs(svc compose.ServiceConfig) awscompose.ServiceConfigArgs {
 	args := awscompose.ServiceConfigArgs{
-		Image:       pulumi.StringPtrFromPtr(svc.Image),
+		Image:       pulumi.StringPtrFromPtr(svc.StaticImage()),
 		Platform:    pulumi.StringPtrFromPtr(svc.Platform),
 		Environment: pulumi.ToStringMap(svc.ResolvedEnvironment()),
 		Command:     pulumi.ToStringArray(svc.Command),

--- a/cd/program/azure.go
+++ b/cd/program/azure.go
@@ -196,7 +196,7 @@ func toAzureServices(services compose.Services) azurecompose.ServiceConfigMap {
 
 func toAzureServiceArgs(svc compose.ServiceConfig) azurecompose.ServiceConfigArgs {
 	args := azurecompose.ServiceConfigArgs{
-		Image:       pulumi.StringPtrFromPtr(svc.Image),
+		Image:       pulumi.StringPtrFromPtr(svc.StaticImage()),
 		Platform:    pulumi.StringPtrFromPtr(svc.Platform),
 		Environment: pulumi.ToStringMap(svc.ResolvedEnvironment()),
 		Command:     pulumi.ToStringArray(svc.Command),

--- a/cd/program/gcp.go
+++ b/cd/program/gcp.go
@@ -87,7 +87,7 @@ func toGCPServices(services compose.Services) gcpcompose.ServiceConfigMap {
 
 func toGCPServiceArgs(svc compose.ServiceConfig) gcpcompose.ServiceConfigArgs {
 	args := gcpcompose.ServiceConfigArgs{
-		Image:       pulumi.StringPtrFromPtr(svc.Image),
+		Image:       pulumi.StringPtrFromPtr(svc.StaticImage()),
 		Platform:    pulumi.StringPtrFromPtr(svc.Platform),
 		Environment: pulumi.ToStringMap(svc.ResolvedEnvironment()),
 		Command:     pulumi.ToStringArray(svc.Command),

--- a/provider/cmd/pulumi-resource-defang-aws/schema.json
+++ b/provider/cmd/pulumi-resource-defang-aws/schema.json
@@ -250,6 +250,9 @@
         "llm": {
           "$ref": "#/types/defang-aws:compose:LlmConfig"
         },
+        "networkMode": {
+          "type": "string"
+        },
         "networks": {
           "type": "object",
           "additionalProperties": {
@@ -480,6 +483,9 @@
     },
     "defang-aws:index:Project": {
       "properties": {
+        "clusterName": {
+          "type": "string"
+        },
         "endpoints": {
           "type": "object",
           "additionalProperties": {
@@ -487,12 +493,36 @@
             "plain": true
           }
         },
+        "loadBalancerArn": {
+          "type": "string"
+        },
         "loadBalancerDns": {
           "type": "string"
+        },
+        "logGroupName": {
+          "type": "string"
+        },
+        "serviceNames": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "plain": true
+          }
+        },
+        "taskRoleArns": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "plain": true
+          }
         }
       },
       "required": [
-        "endpoints"
+        "endpoints",
+        "clusterName",
+        "logGroupName",
+        "serviceNames",
+        "taskRoleArns"
       ],
       "inputProperties": {
         "aws": {

--- a/provider/cmd/pulumi-resource-defang-aws/schema.json
+++ b/provider/cmd/pulumi-resource-defang-aws/schema.json
@@ -481,8 +481,7 @@
         "environment": {
           "type": "object",
           "additionalProperties": {
-            "type": "string",
-            "plain": true
+            "type": "string"
           }
         },
         "image": {
@@ -594,8 +593,7 @@
         "environment": {
           "type": "object",
           "additionalProperties": {
-            "type": "string",
-            "plain": true
+            "type": "string"
           }
         },
         "image": {

--- a/provider/cmd/pulumi-resource-defang-aws/schema.json
+++ b/provider/cmd/pulumi-resource-defang-aws/schema.json
@@ -34,22 +34,10 @@
   "types": {
     "defang-aws:aws:SharedInfra": {
       "properties": {
-        "albDnsName": {
-          "type": "string"
-        },
-        "albSecurityGroupId": {
-          "type": "string"
-        },
         "clusterArn": {
           "type": "string"
         },
         "executionRoleArn": {
-          "type": "string"
-        },
-        "httpListenerArn": {
-          "type": "string"
-        },
-        "httpsListenerArn": {
           "type": "string"
         },
         "logGroupName": {

--- a/provider/cmd/pulumi-resource-defang-aws/schema.json
+++ b/provider/cmd/pulumi-resource-defang-aws/schema.json
@@ -271,6 +271,12 @@
         "platform": {
           "type": "string"
         },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "ports": {
           "type": "array",
           "items": {
@@ -643,12 +649,18 @@
           "$ref": "#/types/defang-aws:compose:HealthCheckConfig"
         },
         "image": {
-          "type": "string",
-          "plain": true
+          "type": "string"
         },
         "platform": {
           "type": "string",
           "plain": true
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "plain": true
+          }
         },
         "ports": {
           "type": "array",

--- a/provider/cmd/pulumi-resource-defang-aws/schema.json
+++ b/provider/cmd/pulumi-resource-defang-aws/schema.json
@@ -369,10 +369,31 @@
     },
     "defang-aws:index:AWSConfig": {
       "properties": {
+        "albCertificateArn": {
+          "type": "string"
+        },
+        "dnsRoleArn": {
+          "type": "string"
+        },
+        "privateSubnetIDs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "projectDomain": {
           "type": "string"
         },
+        "publicSubnetIDs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "publicZoneId": {
+          "type": "string"
+        },
+        "vpcID": {
           "type": "string"
         }
       },
@@ -543,6 +564,10 @@
           "additionalProperties": {
             "$ref": "#/types/defang-aws:compose:ServiceConfig"
           }
+        },
+        "waitForSteadyState": {
+          "type": "boolean",
+          "plain": true
         }
       },
       "requiredInputs": [

--- a/provider/cmd/pulumi-resource-defang-aws/schema.json
+++ b/provider/cmd/pulumi-resource-defang-aws/schema.json
@@ -34,6 +34,27 @@
   "types": {
     "defang-aws:aws:SharedInfra": {
       "properties": {
+        "albDnsName": {
+          "type": "string"
+        },
+        "albSecurityGroupId": {
+          "type": "string"
+        },
+        "clusterArn": {
+          "type": "string"
+        },
+        "executionRoleArn": {
+          "type": "string"
+        },
+        "httpListenerArn": {
+          "type": "string"
+        },
+        "httpsListenerArn": {
+          "type": "string"
+        },
+        "logGroupName": {
+          "type": "string"
+        },
         "privateSgID": {
           "type": "string"
         },
@@ -69,11 +90,29 @@
             "type": "string"
           }
         },
+        "cacheFrom": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "cacheTo": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "context": {
           "type": "string"
         },
         "dockerfile": {
           "type": "string"
+        },
+        "platforms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "shmSize": {
           "type": "string"
@@ -175,6 +214,9 @@
     },
     "defang-aws:compose:ServiceConfig": {
       "properties": {
+        "autoscaling": {
+          "type": "boolean"
+        },
         "build": {
           "$ref": "#/types/defang-aws:compose:BuildConfig"
         },
@@ -183,6 +225,9 @@
           "items": {
             "type": "string"
           }
+        },
+        "containerName": {
+          "type": "string"
         },
         "dependsOn": {
           "type": "object",
@@ -240,6 +285,24 @@
         },
         "restart": {
           "type": "string"
+        },
+        "stopGracePeriod": {
+          "type": "string"
+        },
+        "volumes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/defang-aws:compose:ServiceVolumeConfig"
+          }
+        },
+        "volumesFrom": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "workingDir": {
+          "type": "string"
         }
       },
       "type": "object"
@@ -271,6 +334,9 @@
         "appProtocol": {
           "type": "string"
         },
+        "listener": {
+          "type": "string"
+        },
         "mode": {
           "type": "string"
         },
@@ -283,6 +349,24 @@
       },
       "type": "object",
       "required": [
+        "target"
+      ]
+    },
+    "defang-aws:compose:ServiceVolumeConfig": {
+      "properties": {
+        "readOnly": {
+          "type": "boolean"
+        },
+        "source": {
+          "type": "string"
+        },
+        "target": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "source",
         "target"
       ]
     },
@@ -490,14 +574,30 @@
     },
     "defang-aws:index:Service": {
       "properties": {
+        "clusterName": {
+          "type": "string"
+        },
         "endpoint": {
+          "type": "string"
+        },
+        "serviceName": {
+          "type": "string"
+        },
+        "taskRoleArn": {
           "type": "string"
         }
       },
       "required": [
-        "endpoint"
+        "endpoint",
+        "serviceName",
+        "clusterName",
+        "taskRoleArn"
       ],
       "inputProperties": {
+        "autoscaling": {
+          "type": "boolean",
+          "plain": true
+        },
         "aws": {
           "$ref": "#/types/defang-aws:aws:SharedInfra"
         },
@@ -506,6 +606,16 @@
           "items": {
             "type": "string",
             "plain": true
+          }
+        },
+        "containerName": {
+          "type": "string",
+          "plain": true
+        },
+        "dependsOn": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/types/defang-aws:compose:ServiceDependency"
           }
         },
         "deploy": {
@@ -547,6 +657,61 @@
           }
         },
         "projectName": {
+          "type": "string",
+          "plain": true
+        },
+        "secrets": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "plain": true
+          }
+        },
+        "securityGroupIds": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "plain": true
+          }
+        },
+        "sidecars": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/types/defang-aws:compose:ServiceConfig"
+          }
+        },
+        "stopGracePeriod": {
+          "type": "string",
+          "plain": true
+        },
+        "taskRoleArn": {
+          "type": "string"
+        },
+        "triggers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "plain": true
+          }
+        },
+        "volumes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/defang-aws:compose:ServiceVolumeConfig"
+          }
+        },
+        "volumesFrom": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "plain": true
+          }
+        },
+        "waitForSteadyState": {
+          "type": "boolean",
+          "plain": true
+        },
+        "workingDir": {
           "type": "string",
           "plain": true
         }

--- a/provider/cmd/pulumi-resource-defang-azure/schema.json
+++ b/provider/cmd/pulumi-resource-defang-azure/schema.json
@@ -220,6 +220,12 @@
         "platform": {
           "type": "string"
         },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "ports": {
           "type": "array",
           "items": {
@@ -589,8 +595,7 @@
           "$ref": "#/types/defang-azure:compose:HealthCheckConfig"
         },
         "image": {
-          "type": "string",
-          "plain": true
+          "type": "string"
         },
         "platform": {
           "type": "string",

--- a/provider/cmd/pulumi-resource-defang-azure/schema.json
+++ b/provider/cmd/pulumi-resource-defang-azure/schema.json
@@ -455,8 +455,7 @@
         "environment": {
           "type": "object",
           "additionalProperties": {
-            "type": "string",
-            "plain": true
+            "type": "string"
           }
         },
         "image": {
@@ -535,8 +534,7 @@
         "environment": {
           "type": "object",
           "additionalProperties": {
-            "type": "string",
-            "plain": true
+            "type": "string"
           }
         },
         "image": {
@@ -590,8 +588,7 @@
         "environment": {
           "type": "object",
           "additionalProperties": {
-            "type": "string",
-            "plain": true
+            "type": "string"
           }
         },
         "healthCheck": {

--- a/provider/cmd/pulumi-resource-defang-azure/schema.json
+++ b/provider/cmd/pulumi-resource-defang-azure/schema.json
@@ -39,11 +39,29 @@
             "type": "string"
           }
         },
+        "cacheFrom": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "cacheTo": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "context": {
           "type": "string"
         },
         "dockerfile": {
           "type": "string"
+        },
+        "platforms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "shmSize": {
           "type": "string"
@@ -145,6 +163,9 @@
     },
     "defang-azure:compose:ServiceConfig": {
       "properties": {
+        "autoscaling": {
+          "type": "boolean"
+        },
         "build": {
           "$ref": "#/types/defang-azure:compose:BuildConfig"
         },
@@ -153,6 +174,9 @@
           "items": {
             "type": "string"
           }
+        },
+        "containerName": {
+          "type": "string"
         },
         "dependsOn": {
           "type": "object",
@@ -210,6 +234,24 @@
         },
         "restart": {
           "type": "string"
+        },
+        "stopGracePeriod": {
+          "type": "string"
+        },
+        "volumes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/defang-azure:compose:ServiceVolumeConfig"
+          }
+        },
+        "volumesFrom": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "workingDir": {
+          "type": "string"
         }
       },
       "type": "object"
@@ -241,6 +283,9 @@
         "appProtocol": {
           "type": "string"
         },
+        "listener": {
+          "type": "string"
+        },
         "mode": {
           "type": "string"
         },
@@ -253,6 +298,24 @@
       },
       "type": "object",
       "required": [
+        "target"
+      ]
+    },
+    "defang-azure:compose:ServiceVolumeConfig": {
+      "properties": {
+        "readOnly": {
+          "type": "boolean"
+        },
+        "source": {
+          "type": "string"
+        },
+        "target": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "source",
         "target"
       ]
     }

--- a/provider/cmd/pulumi-resource-defang-azure/schema.json
+++ b/provider/cmd/pulumi-resource-defang-azure/schema.json
@@ -211,6 +211,9 @@
         "llm": {
           "$ref": "#/types/defang-azure:compose:LlmConfig"
         },
+        "networkMode": {
+          "type": "string"
+        },
         "networks": {
           "type": "object",
           "additionalProperties": {

--- a/provider/cmd/pulumi-resource-defang-gcp/schema.json
+++ b/provider/cmd/pulumi-resource-defang-gcp/schema.json
@@ -39,11 +39,29 @@
             "type": "string"
           }
         },
+        "cacheFrom": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "cacheTo": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "context": {
           "type": "string"
         },
         "dockerfile": {
           "type": "string"
+        },
+        "platforms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "shmSize": {
           "type": "string"
@@ -145,6 +163,9 @@
     },
     "defang-gcp:compose:ServiceConfig": {
       "properties": {
+        "autoscaling": {
+          "type": "boolean"
+        },
         "build": {
           "$ref": "#/types/defang-gcp:compose:BuildConfig"
         },
@@ -153,6 +174,9 @@
           "items": {
             "type": "string"
           }
+        },
+        "containerName": {
+          "type": "string"
         },
         "dependsOn": {
           "type": "object",
@@ -210,6 +234,24 @@
         },
         "restart": {
           "type": "string"
+        },
+        "stopGracePeriod": {
+          "type": "string"
+        },
+        "volumes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/defang-gcp:compose:ServiceVolumeConfig"
+          }
+        },
+        "volumesFrom": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "workingDir": {
+          "type": "string"
         }
       },
       "type": "object"
@@ -241,6 +283,9 @@
         "appProtocol": {
           "type": "string"
         },
+        "listener": {
+          "type": "string"
+        },
         "mode": {
           "type": "string"
         },
@@ -253,6 +298,24 @@
       },
       "type": "object",
       "required": [
+        "target"
+      ]
+    },
+    "defang-gcp:compose:ServiceVolumeConfig": {
+      "properties": {
+        "readOnly": {
+          "type": "boolean"
+        },
+        "source": {
+          "type": "string"
+        },
+        "target": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "source",
         "target"
       ]
     }
@@ -508,10 +571,14 @@
       "properties": {
         "endpoint": {
           "type": "string"
+        },
+        "serviceAccountEmail": {
+          "type": "string"
         }
       },
       "required": [
-        "endpoint"
+        "endpoint",
+        "serviceAccountEmail"
       ],
       "inputProperties": {
         "command": {
@@ -519,6 +586,16 @@
           "items": {
             "type": "string",
             "plain": true
+          }
+        },
+        "containerName": {
+          "type": "string",
+          "plain": true
+        },
+        "dependsOn": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/types/defang-gcp:compose:ServiceDependency"
           }
         },
         "deploy": {
@@ -563,6 +640,43 @@
           }
         },
         "projectName": {
+          "type": "string",
+          "plain": true
+        },
+        "serviceAccountEmail": {
+          "type": "string"
+        },
+        "sidecars": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/types/defang-gcp:compose:ServiceConfig"
+          }
+        },
+        "stopGracePeriod": {
+          "type": "string",
+          "plain": true
+        },
+        "triggers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "plain": true
+          }
+        },
+        "volumes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/defang-gcp:compose:ServiceVolumeConfig"
+          }
+        },
+        "volumesFrom": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "plain": true
+          }
+        },
+        "workingDir": {
           "type": "string",
           "plain": true
         }

--- a/provider/cmd/pulumi-resource-defang-gcp/schema.json
+++ b/provider/cmd/pulumi-resource-defang-gcp/schema.json
@@ -211,6 +211,9 @@
         "llm": {
           "$ref": "#/types/defang-gcp:compose:LlmConfig"
         },
+        "networkMode": {
+          "type": "string"
+        },
         "networks": {
           "type": "object",
           "additionalProperties": {

--- a/provider/cmd/pulumi-resource-defang-gcp/schema.json
+++ b/provider/cmd/pulumi-resource-defang-gcp/schema.json
@@ -220,6 +220,12 @@
         "platform": {
           "type": "string"
         },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "ports": {
           "type": "array",
           "items": {
@@ -623,8 +629,7 @@
           "$ref": "#/types/defang-gcp:compose:HealthCheckConfig"
         },
         "image": {
-          "type": "string",
-          "plain": true
+          "type": "string"
         },
         "llm": {
           "$ref": "#/types/defang-gcp:compose:LlmConfig"

--- a/provider/cmd/pulumi-resource-defang-gcp/schema.json
+++ b/provider/cmd/pulumi-resource-defang-gcp/schema.json
@@ -477,8 +477,7 @@
         "environment": {
           "type": "object",
           "additionalProperties": {
-            "type": "string",
-            "plain": true
+            "type": "string"
           }
         },
         "image": {
@@ -624,8 +623,7 @@
         "environment": {
           "type": "object",
           "additionalProperties": {
-            "type": "string",
-            "plain": true
+            "type": "string"
           }
         },
         "healthCheck": {

--- a/provider/common/build.go
+++ b/provider/common/build.go
@@ -70,9 +70,12 @@ func BuildTriggerHash(build *compose.BuildConfig) pulumi.StringOutput {
 	if build.Target != nil {
 		target = *build.Target
 	}
+	// cache_from/cache_to deliberately excluded: cache config affects build speed,
+	// not the image contents, so it shouldn't retrigger builds.
+	platforms := []byte(strings.Join(build.Platforms, ","))
 	return pulumi.StringOutput(pulumix.Apply(
 		pulumix.Output[string](build.Context.ToStringOutput()), func(ctx string) string {
 			contextEtag, _, _ := strings.Cut(ctx, "?") // remove sig query param; FIXME: get actual etag from URL, not path
-			return sha256hash([]byte(contextEtag), argsStr, []byte(dockerfile), []byte(target))[0:8]
+			return sha256hash([]byte(contextEtag), argsStr, []byte(dockerfile), []byte(target), platforms)[0:8]
 		}))
 }

--- a/provider/compose/helpers.go
+++ b/provider/compose/helpers.go
@@ -151,11 +151,15 @@ func GetConfigName(value string) string {
 	return ""
 }
 
-func GetConfigName2(key string, value *string) string {
-	if value == nil {
+func GetConfigName2(key string, value pulumi.StringInput) string {
+	sv, static := StaticEnvValue(value)
+	if !static {
+		return "" // dynamic values are passed as plaintext env, never secret refs
+	}
+	if sv == nil {
 		return key
 	}
-	return GetConfigName(*value)
+	return GetConfigName(*sv)
 }
 
 func GetConfigOrEnvValue(
@@ -167,11 +171,15 @@ func GetConfigOrEnvValue(
 	opts ...pulumi.InvokeOption,
 ) pulumi.StringOutput {
 	if v, ok := s.Environment[key]; ok {
-		var value string
-		if v == nil {
-			value = "${" + key + "}"
-		} else {
-			value = *v
+		sv, static := StaticEnvValue(v)
+		if !static {
+			// Dynamic (Output) values pass through as-is; interpolation and
+			// config resolution only apply to static text.
+			return v.ToStringOutput()
+		}
+		value := "${" + key + "}"
+		if sv != nil {
+			value = *sv
 		}
 		// Resolve any $VAR / ${VAR} interpolations; empty string passes through as-is.
 		return InterpolateEnvironmentVariable(ctx, configProvider, value, opts...)

--- a/provider/compose/helpers_test.go
+++ b/provider/compose/helpers_test.go
@@ -56,7 +56,7 @@ func TestToPulumiStringArray(t *testing.T) {
 func TestGetConfigOrEnvValue(t *testing.T) {
 	tests := []struct {
 		name         string
-		environment  map[string]*string
+		environment  Environment
 		key          string
 		defaultValue string
 		configs      map[string]string
@@ -71,26 +71,26 @@ func TestGetConfigOrEnvValue(t *testing.T) {
 		},
 		{
 			name:         "key absent returns default",
-			environment:  map[string]*string{},
+			environment:  Environment{},
 			key:          "MY_KEY",
 			defaultValue: "default",
 			expected:     "default",
 		},
 		{
 			name:        "empty string value is literal empty",
-			environment: map[string]*string{"MY_KEY": ptr("")},
+			environment: Environment{"MY_KEY": pulumi.String("")},
 			key:         "MY_KEY",
 			expected:    "",
 		},
 		{
 			name:        "plain string value returned as-is",
-			environment: map[string]*string{"MY_KEY": ptr("hello")},
+			environment: Environment{"MY_KEY": pulumi.String("hello")},
 			key:         "MY_KEY",
 			expected:    "hello",
 		},
 		{
 			name:        "interpolated value resolves variables from config provider",
-			environment: map[string]*string{"MY_KEY": ptr("prefix_${SECRET}_suffix")},
+			environment: Environment{"MY_KEY": pulumi.String("prefix_${SECRET}_suffix")},
 			key:         "MY_KEY",
 			configs:     map[string]string{"SECRET": "resolved"},
 			expected:    "prefix_resolved_suffix",
@@ -98,7 +98,7 @@ func TestGetConfigOrEnvValue(t *testing.T) {
 		{
 			// Compose spec: "KEY:" (no value) → resolve from config at runtime.
 			name:        "nil value resolves from config provider via ${KEY}",
-			environment: map[string]*string{"MY_KEY": nil},
+			environment: Environment{"MY_KEY": nil},
 			key:         "MY_KEY",
 			configs:     map[string]string{"MY_KEY": "from-config"},
 			expected:    "from-config",

--- a/provider/compose/types.go
+++ b/provider/compose/types.go
@@ -103,6 +103,12 @@ type ServiceConfig struct {
 	// Enable autoscaling. Matches the x-defang-autoscaling extension.
 	Autoscaling bool `pulumi:"autoscaling,optional" yaml:"x-defang-autoscaling,omitempty"`
 
+	// Extra IAM policies to attach to the task role created for this service;
+	// each entry is a full policy ARN or a customer-managed policy name.
+	// Matches the x-defang-policies extension. AWS-only: other providers
+	// reject it, and it cannot be combined with a caller-supplied task role.
+	Policies []string `pulumi:"policies,optional" yaml:"x-defang-policies,omitempty"`
+
 	// Models map[string]*ServiceModelConfig `pulumi:"models,optional" yaml:"models,omitempty"`
 }
 

--- a/provider/compose/types.go
+++ b/provider/compose/types.go
@@ -103,6 +103,11 @@ type ServiceConfig struct {
 	// Working directory inside the container
 	WorkingDir *string `pulumi:"workingDir,optional" yaml:"working_dir,omitempty"`
 
+	// Network mode; "service:<name>" folds this service into <name>'s task as
+	// a sidecar container instead of deploying it standalone. Other values are
+	// ignored.
+	NetworkMode string `pulumi:"networkMode,optional" yaml:"network_mode,omitempty"`
+
 	// Enable autoscaling. Matches the x-defang-autoscaling extension.
 	Autoscaling bool `pulumi:"autoscaling,optional" yaml:"x-defang-autoscaling,omitempty"`
 
@@ -139,6 +144,15 @@ func ImageFromPtr(p *string) pulumi.StringInput {
 		return nil
 	}
 	return pulumi.String(*p)
+}
+
+// SidecarParent returns the service name this config attaches to as a sidecar
+// (network_mode: "service:<name>"), or "" for a standalone service.
+func (s ServiceConfig) SidecarParent() string {
+	if parent, ok := strings.CutPrefix(s.NetworkMode, "service:"); ok {
+		return parent
+	}
+	return ""
 }
 
 // StaticImage returns the image as a literal string when it was set from a

--- a/provider/compose/types.go
+++ b/provider/compose/types.go
@@ -42,8 +42,11 @@ type ServiceConfig struct {
 	// Build configuration
 	Build *BuildConfig `pulumi:"build,optional" yaml:"build,omitempty"`
 
-	// Container image to deploy (required if no build config)
-	Image *string `pulumi:"image,optional" yaml:"image,omitempty"`
+	// Container image to deploy (required if no build config). An Input so
+	// callers can pass the Output of an image build; compose files always
+	// yield a literal pulumi.String (see StaticImage). yaml:"-" because the
+	// yaml decoder cannot populate an interface field — see UnmarshalYAML.
+	Image pulumi.StringInput `pulumi:"image,optional" yaml:"-"`
 
 	// Target platform: "linux/amd64" or "linux/arm64"
 	Platform *string `pulumi:"platform,optional" yaml:"platform,omitempty"`
@@ -110,6 +113,42 @@ type ServiceConfig struct {
 	Policies []string `pulumi:"policies,optional" yaml:"x-defang-policies,omitempty"`
 
 	// Models map[string]*ServiceModelConfig `pulumi:"models,optional" yaml:"models,omitempty"`
+}
+
+// UnmarshalYAML decodes a service, converting the literal "image" field into a
+// pulumi.String (the Image field is a pulumi.StringInput, which the yaml
+// decoder cannot populate directly).
+func (s *ServiceConfig) UnmarshalYAML(value *yaml.Node) error {
+	type raw ServiceConfig // methodless alias to avoid recursion
+	if err := value.Decode((*raw)(s)); err != nil {
+		return err
+	}
+	var img struct {
+		Image *string `yaml:"image"`
+	}
+	if err := value.Decode(&img); err != nil {
+		return err
+	}
+	s.Image = ImageFromPtr(img.Image)
+	return nil
+}
+
+// ImageFromPtr converts an optional literal image string to the Image input type.
+func ImageFromPtr(p *string) pulumi.StringInput {
+	if p == nil {
+		return nil
+	}
+	return pulumi.String(*p)
+}
+
+// StaticImage returns the image as a literal string when it was set from a
+// compose file or plain string (pulumi.String), or nil when unset or dynamic.
+func (s ServiceConfig) StaticImage() *string {
+	if img, ok := s.Image.(pulumi.String); ok {
+		v := string(img)
+		return &v
+	}
+	return nil
 }
 
 // ServiceVolumeConfig defines a named-volume mount (long syntax). Bind mounts
@@ -419,8 +458,8 @@ func (s ServiceConfig) ResolvePostgres(ctx *pulumi.Context, configProvider Confi
 	}
 
 	var version pulumi.StringPtrInput
-	if s.Image != nil {
-		version = pulumi.StringPtr(getPostgresVersion(*s.Image))
+	if img := s.StaticImage(); img != nil {
+		version = pulumi.StringPtr(getPostgresVersion(*img))
 	}
 
 	dbNameStr, ok := s.Environment["POSTGRES_DB"]

--- a/provider/compose/types.go
+++ b/provider/compose/types.go
@@ -84,7 +84,38 @@ type ServiceConfig struct {
 
 	LLM *LlmConfig `pulumi:"llm,optional" yaml:"x-defang-llm,omitempty"`
 
+	// Container name override (default: the service name)
+	ContainerName *string `pulumi:"containerName,optional" yaml:"container_name,omitempty"`
+
+	// Time to wait for the container to stop before killing it (Go duration, e.g. "120s")
+	StopGracePeriod *string `pulumi:"stopGracePeriod,optional" yaml:"stop_grace_period,omitempty"`
+
+	// Named volumes mounted into the container
+	Volumes []ServiceVolumeConfig `pulumi:"volumes,optional" yaml:"volumes,omitempty"`
+
+	// Mount all volumes from another service/container; entries are container
+	// names with an optional ":ro" or ":rw" suffix
+	VolumesFrom []string `pulumi:"volumesFrom,optional" yaml:"volumes_from,omitempty"`
+
+	// Working directory inside the container
+	WorkingDir *string `pulumi:"workingDir,optional" yaml:"working_dir,omitempty"`
+
+	// Enable autoscaling. Matches the x-defang-autoscaling extension.
+	Autoscaling bool `pulumi:"autoscaling,optional" yaml:"x-defang-autoscaling,omitempty"`
+
 	// Models map[string]*ServiceModelConfig `pulumi:"models,optional" yaml:"models,omitempty"`
+}
+
+// ServiceVolumeConfig defines a named-volume mount (long syntax). Bind mounts
+// are not supported.
+type ServiceVolumeConfig struct {
+	// Volume name
+	Source string `pulumi:"source" yaml:"source"`
+
+	// Mount path inside the container
+	Target string `pulumi:"target" yaml:"target"`
+
+	ReadOnly bool `pulumi:"readOnly,optional" yaml:"read_only,omitempty"`
 }
 
 type LlmConfig struct{}
@@ -155,7 +186,19 @@ type ServicePortConfig struct {
 
 	// Application protocol: "http", "http2", "grpc" (default: "http")
 	AppProtocol PortAppProtocol `pulumi:"appProtocol,optional" yaml:"app_protocol,omitempty"`
+
+	// Force the load-balancer listener protocol: "http" or "https" (default:
+	// derived from the port). Matches the x-defang-listener extension.
+	Listener PortListenerProtocol `pulumi:"listener,optional" yaml:"x-defang-listener,omitempty"`
 }
+
+type PortListenerProtocol string
+
+const (
+	PortListenerDefault PortListenerProtocol = ""
+	PortListenerHTTP    PortListenerProtocol = "http"
+	PortListenerHTTPS   PortListenerProtocol = "https"
+)
 
 // DeployConfig defines deployment parameters.
 // YAML tags match Docker Compose deploy spec.
@@ -204,6 +247,17 @@ type BuildConfig struct {
 
 	// Multi-stage build target
 	Target *string `pulumi:"target,optional" yaml:"target,omitempty"`
+
+	// Target platforms for multi-platform builds, e.g. ["linux/amd64", "linux/arm64"]
+	Platforms []string `pulumi:"platforms,optional" yaml:"platforms,omitempty"`
+
+	// External cache sources, passed through to `docker buildx build --cache-from`
+	// (e.g. "type=registry,ref=user/app:cache")
+	CacheFrom []string `pulumi:"cacheFrom,optional" yaml:"cache_from,omitempty"`
+
+	// External cache destinations, passed through to `docker buildx build --cache-to`
+	// (e.g. "type=registry,mode=max,ref=user/app:cache")
+	CacheTo []string `pulumi:"cacheTo,optional" yaml:"cache_to,omitempty"`
 }
 
 // UnmarshalYAML allows BuildConfig to be parsed from YAML, converting the
@@ -216,6 +270,9 @@ func (b *BuildConfig) UnmarshalYAML(value *yaml.Node) error {
 		Args       map[string]string `yaml:"args,omitempty"`
 		ShmSize    *string           `yaml:"shm_size,omitempty"`
 		Target     *string           `yaml:"target,omitempty"`
+		Platforms  []string          `yaml:"platforms,omitempty"`
+		CacheFrom  []string          `yaml:"cache_from,omitempty"`
+		CacheTo    []string          `yaml:"cache_to,omitempty"`
 	}
 	if err := value.Decode(&raw); err != nil {
 		return err
@@ -225,6 +282,9 @@ func (b *BuildConfig) UnmarshalYAML(value *yaml.Node) error {
 	b.Args = raw.Args
 	b.ShmSize = raw.ShmSize
 	b.Target = raw.Target
+	b.Platforms = raw.Platforms
+	b.CacheFrom = raw.CacheFrom
+	b.CacheTo = raw.CacheTo
 	return nil
 }
 
@@ -419,6 +479,22 @@ func (s ServiceConfig) GetMemoryMiB() int {
 		return ParseMemoryMiB(*s.Deploy.Resources.Reservations.Memory)
 	}
 	return 512
+}
+
+// GetContainerName returns the container name, defaulting to fallback (the service name).
+func (s ServiceConfig) GetContainerName(fallback string) string {
+	if s.ContainerName != nil && *s.ContainerName != "" {
+		return *s.ContainerName
+	}
+	return fallback
+}
+
+// GetStopGracePeriodSeconds returns the stop grace period in seconds, or 0 if unset.
+func (s ServiceConfig) GetStopGracePeriodSeconds() int {
+	if s.StopGracePeriod == nil {
+		return 0
+	}
+	return int(parseDurationSeconds(*s.StopGracePeriod))
 }
 
 // NeedsBuild returns true if the service has a build config.

--- a/provider/compose/types.go
+++ b/provider/compose/types.go
@@ -58,7 +58,7 @@ type ServiceConfig struct {
 	Deploy *DeployConfig `pulumi:"deploy,optional" yaml:"deploy,omitempty"`
 
 	// Environment variables
-	Environment map[string]*string `pulumi:"environment,optional" yaml:"environment,omitempty"`
+	Environment Environment `pulumi:"environment,optional" yaml:"environment,omitempty"`
 
 	// Command to run
 	Command []string `pulumi:"command,optional" yaml:"command,omitempty"`
@@ -144,6 +144,47 @@ func ImageFromPtr(p *string) pulumi.StringInput {
 		return nil
 	}
 	return pulumi.String(*p)
+}
+
+// Environment maps env var names to values. Values are Inputs so callers can
+// pass Outputs of other resources; compose files always yield literal
+// pulumi.String values, or nil for "KEY:" with no value (resolve from config
+// at deploy time). See StaticEnvValue.
+type Environment map[string]pulumi.StringInput
+
+// UnmarshalYAML decodes the compose map form, converting literal values into
+// pulumi.String (the yaml decoder cannot populate an interface value).
+func (e *Environment) UnmarshalYAML(value *yaml.Node) error {
+	var m map[string]*string
+	if err := value.Decode(&m); err != nil {
+		return err
+	}
+	if m == nil {
+		*e = nil
+		return nil
+	}
+	env := make(Environment, len(m))
+	for k, v := range m {
+		env[k] = ImageFromPtr(v)
+	}
+	*e = env
+	return nil
+}
+
+// StaticEnvValue returns the literal value of an environment entry and whether
+// it is static. A nil input (compose "KEY:" with no value, i.e. resolve from
+// config) is static with a nil pointer; Outputs of other resources are not
+// static and return (nil, false).
+func StaticEnvValue(v pulumi.StringInput) (*string, bool) {
+	switch t := v.(type) {
+	case nil:
+		return nil, true
+	case pulumi.String:
+		s := string(t)
+		return &s, true
+	default:
+		return nil, false
+	}
 }
 
 // SidecarParent returns the service name this config attaches to as a sidecar
@@ -476,8 +517,10 @@ func (s ServiceConfig) ResolvePostgres(ctx *pulumi.Context, configProvider Confi
 		version = pulumi.StringPtr(getPostgresVersion(*img))
 	}
 
-	dbNameStr, ok := s.Environment["POSTGRES_DB"]
-	if !ok || dbNameStr == nil || *dbNameStr == "" {
+	// POSTGRES_DB drives resource creation decisions, so it must be a static
+	// string; a dynamic (Output) value falls back to the default name.
+	dbNameStr, _ := StaticEnvValue(s.Environment["POSTGRES_DB"])
+	if dbNameStr == nil || *dbNameStr == "" {
 		dbNameStr = ptr(DEFAULT_POSTGRES_DB)
 	}
 	dbName := GetConfigOrEnvValue(ctx, configProvider, s, "POSTGRES_DB", DEFAULT_POSTGRES_DB)
@@ -577,9 +620,13 @@ func (s ServiceConfig) DefaultNetwork() ServiceNetworkConfig {
 func (s ServiceConfig) ResolvedEnvironment() map[string]string {
 	env := make(map[string]string, len(s.Environment))
 	for k, v := range s.Environment {
-		if v != nil {
-			env[k] = *v
-		} else {
+		sv, static := StaticEnvValue(v)
+		switch {
+		case !static:
+			// dynamic values never occur on this YAML-driven path
+		case sv != nil:
+			env[k] = *sv
+		default:
 			env[k] = "${" + k + "}" // preserve undefined env vars as placeholders
 		}
 	}

--- a/provider/compose/yaml_test.go
+++ b/provider/compose/yaml_test.go
@@ -67,6 +67,11 @@ services:
     image: postgres:16
     x-defang-postgres:
       allow-downtime: true
+  worker:
+    image: worker:latest
+    x-defang-policies:
+      - arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
+      - MyCustomPolicy
 networks:
   backend:
     internal: true
@@ -74,9 +79,10 @@ networks:
 	var p Project
 	require.NoError(t, yaml.Unmarshal([]byte(input), &p))
 
-	require.Len(t, p.Services, 2)
+	require.Len(t, p.Services, 3)
 	require.Contains(t, p.Services, "web")
 	require.Contains(t, p.Services, "db")
+	require.Contains(t, p.Services, "worker")
 
 	web := p.Services["web"]
 	assert.Equal(t, "nginx:latest", *web.Image)
@@ -99,6 +105,12 @@ networks:
 	assert.Equal(t, "postgres:16", *db.Image)
 	require.NotNil(t, db.Postgres)
 	assert.True(t, *db.Postgres.AllowDowntime)
+
+	worker := p.Services["worker"]
+	assert.Equal(t, []string{
+		"arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
+		"MyCustomPolicy",
+	}, worker.Policies)
 
 	require.Contains(t, p.Networks, NetworkID("backend"))
 	assert.True(t, p.Networks[NetworkID("backend")].Internal)

--- a/provider/compose/yaml_test.go
+++ b/provider/compose/yaml_test.go
@@ -85,7 +85,7 @@ networks:
 	require.Contains(t, p.Services, "worker")
 
 	web := p.Services["web"]
-	assert.Equal(t, "nginx:latest", *web.Image)
+	assert.Equal(t, pulumi.String("nginx:latest"), web.Image)
 	require.Len(t, web.Ports, 1)
 	assert.Equal(t, int32(80), web.Ports[0].Target)
 	assert.EqualValues(t, "ingress", web.Ports[0].Mode)
@@ -102,7 +102,7 @@ networks:
 	assert.Equal(t, "512Mi", *web.Deploy.Resources.Reservations.Memory)
 
 	db := p.Services["db"]
-	assert.Equal(t, "postgres:16", *db.Image)
+	assert.Equal(t, pulumi.String("postgres:16"), db.Image)
 	require.NotNil(t, db.Postgres)
 	assert.True(t, *db.Postgres.AllowDowntime)
 

--- a/provider/compose/yaml_test.go
+++ b/provider/compose/yaml_test.go
@@ -92,8 +92,7 @@ networks:
 	require.NotNil(t, web.Build)
 	assert.Implements(t, (*pulumi.StringInput)(nil), web.Build.Context)
 	assert.Equal(t, "Dockerfile", *web.Build.Dockerfile)
-	port := "8080"
-	assert.Equal(t, map[string]*string{"PORT": &port, "CONFIG": nil}, web.Environment)
+	assert.Equal(t, Environment{"PORT": pulumi.String("8080"), "CONFIG": nil}, web.Environment)
 	require.NotNil(t, web.Deploy)
 	assert.Equal(t, int32(2), *web.Deploy.Replicas)
 	require.NotNil(t, web.Deploy.Resources)

--- a/provider/defangaws/aws/cert.go
+++ b/provider/defangaws/aws/cert.go
@@ -38,7 +38,10 @@ func groupHostnamesByCert(hostnames []string) map[string][]string {
 
 type CertificateDnsArgs struct {
 	CaaIssuer []string
-	// Route53Provider aws.Provider
+	// Route53Provider, when set, is used for the Route53 record operations
+	// (CAA and validation records) in case the zone lives in another account.
+	// The ACM certificate and its validation stay on the default provider.
+	Route53Provider   pulumi.ProviderResource
 	Tags              pulumi.StringMapInput
 	ValidationRecords map[string]pulumi.StringOutput
 	ZoneId            pulumi.StringInput
@@ -71,19 +74,17 @@ func CreateCertificateDNS(
 	// TODO: filter out RetainOnDelete from opts
 	resourceOpts := opts
 
-	// var route53Opts []pulumi.ResourceOption
-	// if args != nil && args.Route53Provider != nil {
-	// 	route53Opts = append(append([]pulumi.ResourceOption{}, resourceOpts...), pulumi.Provider(args.Route53Provider))
-	// } else {
-	// 	route53Opts = resourceOpts
-	// }
+	route53Opts := resourceOpts
+	if args.Route53Provider != nil {
+		route53Opts = common.MergeOptions(resourceOpts, pulumi.Provider(args.Route53Provider))
+	}
 
 	// NOTE: creation of CAA can fail with "RRSet of type CAA with DNS name sub.example.com. is not permitted
 	// because a conflicting RRSet of type CNAME with the same DNS name already exists in zone example.com"
 	var caaRecords []pulumi.Resource
 	if len(args.CaaIssuer) != 0 {
 		for _, hostname := range hostnames {
-			rec, err := createCaaDnsRecord(ctx, hostname, args.ZoneId, args.CaaIssuer, opts...)
+			rec, err := createCaaDnsRecord(ctx, hostname, args.ZoneId, args.CaaIssuer, route53Opts...)
 			if err != nil {
 				return pulumi.StringOutput{}, err
 			}
@@ -117,7 +118,7 @@ func CreateCertificateDNS(
 				if existing, ok := args.ValidationRecords[*dvo.ResourceRecordName]; ok {
 					fqdns[i] = existing
 				} else {
-					record, err := createValidationDnsRecord(ctx, dvo, args.ZoneId, opts...)
+					record, err := createValidationDnsRecord(ctx, dvo, args.ZoneId, route53Opts...)
 					if err != nil {
 						return pulumi.StringArrayOutput{}, err
 					}
@@ -201,17 +202,27 @@ func createCertsAndRoute53Dns(
 		},
 	}
 
+	// Route53 operations (zone lookup, validation/CAA/alias records) may need
+	// the role-assuming DNS provider when the zone lives in another account.
+	zoneLookupOpts := []pulumi.InvokeOption{opt}
+	dnsOpts := []pulumi.ResourceOption{opt}
+	if infra.DnsProvider != nil {
+		zoneLookupOpts = append(zoneLookupOpts, pulumi.Provider(infra.DnsProvider))
+		dnsOpts = append(dnsOpts, pulumi.Provider(infra.DnsProvider))
+	}
+
 	// Iterate groups in sorted order for deterministic resource names
 	for base, group := range certGroups {
 		// Look up the Route53 hosted zone for this domain
-		zone, err := GetHostedZoneForHost(ctx, base, opt)
+		zone, err := GetHostedZoneForHost(ctx, base, zoneLookupOpts...)
 		if err != nil {
 			return fmt.Errorf("finding hosted zone for %s: %w", base, err)
 		}
 
 		certArn, err := CreateCertificateDNS(ctx, group, CertificateDnsArgs{
-			CaaIssuer: []string{"amazon.com", "letsencrypt.org"},
-			ZoneId:    pulumi.String(zone.Id),
+			CaaIssuer:       []string{"amazon.com", "letsencrypt.org"},
+			Route53Provider: infra.DnsProvider,
+			ZoneId:          pulumi.String(zone.Id),
 			Tags: pulumi.StringMap{
 				"defang:service": pulumi.String(serviceName),
 			},
@@ -234,7 +245,7 @@ func createCertsAndRoute53Dns(
 			_, err = CreateRecord(ctx, hostname, common.RecordTypeA, &route53.RecordArgs{
 				Aliases: albAliases,
 				ZoneId:  zoneId,
-			}, opt)
+			}, dnsOpts...)
 			if err != nil {
 				return fmt.Errorf("creating DNS record for %s: %w", hostname, err)
 			}

--- a/provider/defangaws/aws/codebuild.go
+++ b/provider/defangaws/aws/codebuild.go
@@ -76,14 +76,29 @@ func getBuildSpec(build compose.BuildConfig, destination string) (string, error)
 		targetArg = "--target " + target
 	}
 
+	// Matches TS prepareBuildSteps: --platform on both buildx create and buildx build,
+	// cache_from/cache_to passed through verbatim.
+	var platformArg string
+	if len(build.Platforms) > 0 {
+		platformArg = "--platform " + strings.Join(build.Platforms, ",")
+	}
+	cacheArgs := make([]string, 0, len(build.CacheFrom)+len(build.CacheTo))
+	for _, c := range build.CacheFrom {
+		cacheArgs = append(cacheArgs, "--cache-from="+c)
+	}
+	for _, c := range build.CacheTo {
+		cacheArgs = append(cacheArgs, "--cache-to="+c)
+	}
+
 	preBuildCommands := []string{
 		"aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $(aws sts get-caller-identity --query Account --output text).dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com", //nolint:lll
 		"aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws",
-		"docker buildx create --use --driver=docker-container --use",
+		strings.TrimSpace("docker buildx create --use --driver=docker-container --use " + platformArg),
 	}
 
-	buildCmd := fmt.Sprintf("docker buildx build -t %s -f %s --push %s %s $CODEBUILD_SRC_DIR",
-		destination, dockerfile, buildArgsStr, targetArg)
+	buildCmd := fmt.Sprintf("docker buildx build %s %s -t %s -f %s --push %s %s $CODEBUILD_SRC_DIR",
+		platformArg, strings.Join(cacheArgs, " "), destination, dockerfile, buildArgsStr, targetArg)
+	buildCmd = strings.Join(strings.Fields(buildCmd), " ") // collapse empty args
 
 	spec := map[string]interface{}{
 		"version": 0.2,
@@ -120,7 +135,16 @@ func createCodeBuildProject(
 	region string,
 	opts ...pulumi.ResourceOption,
 ) (*codeBuildResult, error) {
+	// build.platforms takes precedence over the service platform. Matches TS:
+	// ARM_CONTAINER only when building for exactly one platform and it's arm64
+	// (multi-platform builds emulate via buildx, so run on the x86 fleet).
 	arch := platformToArch(platform)
+	if len(build.Platforms) > 0 {
+		arch = X86_64
+		if len(build.Platforms) == 1 {
+			arch = platformToArch(build.Platforms[0])
+		}
+	}
 
 	envType := "LINUX_CONTAINER"
 	if arch == Arm64 {

--- a/provider/defangaws/aws/codebuild_test.go
+++ b/provider/defangaws/aws/codebuild_test.go
@@ -1,0 +1,56 @@
+package aws
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/DefangLabs/pulumi-defang/provider/compose"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func buildSpecCommands(t *testing.T, build compose.BuildConfig) []string {
+	t.Helper()
+	spec, err := getBuildSpec(build, "123.dkr.ecr.us-test-2.amazonaws.com/repo:latest")
+	require.NoError(t, err)
+	var parsed struct {
+		Phases struct {
+			PreBuild struct {
+				Commands []string `json:"commands"`
+			} `json:"pre_build"`
+			Build struct {
+				Commands []string `json:"commands"`
+			} `json:"build"`
+		} `json:"phases"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(spec), &parsed))
+	return append(parsed.Phases.PreBuild.Commands, parsed.Phases.Build.Commands...)
+}
+
+func TestGetBuildSpecDefault(t *testing.T) {
+	cmds := buildSpecCommands(t, compose.BuildConfig{Context: pulumi.String("s3://bucket/ctx")})
+	joined := strings.Join(cmds, "\n")
+	assert.NotContains(t, joined, "--platform")
+	assert.NotContains(t, joined, "--cache-from")
+	assert.NotContains(t, joined, "--cache-to")
+	assert.Contains(t, joined,
+		"docker buildx build -t 123.dkr.ecr.us-test-2.amazonaws.com/repo:latest -f Dockerfile --push $CODEBUILD_SRC_DIR")
+}
+
+func TestGetBuildSpecPlatformsAndCache(t *testing.T) {
+	cmds := buildSpecCommands(t, compose.BuildConfig{
+		Context:   pulumi.String("s3://bucket/ctx"),
+		Platforms: []string{"linux/arm64", "linux/amd64"},
+		CacheFrom: []string{"type=registry,ref=my/app:cache"},
+		CacheTo:   []string{"type=registry,mode=max,ref=my/app:cache"},
+	})
+	joined := strings.Join(cmds, "\n")
+	assert.Contains(t, joined,
+		"buildx create --use --driver=docker-container --use --platform linux/arm64,linux/amd64")
+	assert.Contains(t, joined,
+		"buildx build --platform linux/arm64,linux/amd64"+
+			" --cache-from=type=registry,ref=my/app:cache"+
+			" --cache-to=type=registry,mode=max,ref=my/app:cache -t ")
+}

--- a/provider/defangaws/aws/config.go
+++ b/provider/defangaws/aws/config.go
@@ -5,4 +5,26 @@ import "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 type AWSConfig struct {
 	ProjectDomain string                `pulumi:"projectDomain,optional" yaml:"projectDomain,omitempty"`
 	PublicZoneId  pulumi.StringPtrInput `pulumi:"publicZoneId,optional"  yaml:"publicZoneId,omitempty"`
+
+	// DnsRoleArn is an IAM role to assume for public Route53 operations (zone
+	// lookup and record management) when the DNS zone lives in a different
+	// account. ACM certificates and listener attachments stay in the service
+	// account.
+	DnsRoleArn pulumi.StringInput `pulumi:"dnsRoleArn,optional" yaml:"dnsRoleArn,omitempty"`
+
+	// AlbCertificateArn is the default certificate for the ALB's HTTPS
+	// listener when the project doesn't manage its own domain (i.e. no
+	// projectDomain/publicZoneId). Services can still bring their own domain
+	// via domainname, which attaches additional certificates to the listener.
+	AlbCertificateArn pulumi.StringInput `pulumi:"albCertificateArn,optional" yaml:"albCertificateArn,omitempty"`
+
+	// VpcID adopts an existing VPC instead of creating one. PublicSubnetIDs is
+	// required when set. PrivateSubnetIDs must have outbound connectivity (NAT
+	// or equivalent) and are used for services without public ingress; when
+	// omitted, all services run in the public subnets with public IPs. The
+	// project still creates its own private hosted zone, attached to the
+	// adopted VPC; the VPC itself (DHCP options, routing) is left untouched.
+	VpcID            pulumi.StringInput      `pulumi:"vpcID,optional"            yaml:"vpcID,omitempty"`
+	PublicSubnetIDs  pulumi.StringArrayInput `pulumi:"publicSubnetIDs,optional"  yaml:"publicSubnetIDs,omitempty"`
+	PrivateSubnetIDs pulumi.StringArrayInput `pulumi:"privateSubnetIDs,optional" yaml:"privateSubnetIDs,omitempty"`
 }

--- a/provider/defangaws/aws/container.go
+++ b/provider/defangaws/aws/container.go
@@ -23,8 +23,10 @@ type ContainerDefinition struct {
 	Name             string                `json:"name"`
 	PortMappings     []PortMapping         `json:"portMappings"`
 	Secrets          []Secret              `json:"secrets,omitempty"`
+	StopTimeout      *int32                `json:"stopTimeout,omitempty"`
 	SystemControls   []SystemControl       `json:"systemControls"`
 	VolumesFrom      []VolumeFrom          `json:"volumesFrom"`
+	WorkingDirectory *string               `json:"workingDirectory,omitempty"`
 }
 
 // PortMapping defines a port mapping for a container.

--- a/provider/defangaws/aws/ecs.go
+++ b/provider/defangaws/aws/ecs.go
@@ -345,7 +345,7 @@ var composeToEcsConditions = map[string]awsecs.ContainerCondition{
 func buildDependsOn(
 	dependsOn compose.DependsOnConfig, sidecars map[string]compose.ServiceConfig,
 ) []ContainerDependency {
-	var deps []ContainerDependency
+	deps := make([]ContainerDependency, 0, len(dependsOn))
 	for depName, dep := range common.Sorted(dependsOn) {
 		sc, ok := sidecars[depName]
 		if !ok {
@@ -632,7 +632,7 @@ func CreateECSService(
 		secrets    []Secret
 		imageIdx   int // index into allInputs where the resolved image URI will be
 	}
-	var sidecarDatas []sidecarData
+	sidecarDatas := make([]sidecarData, 0, len(args.Sidecars))
 	for scName, sc := range common.Sorted(args.Sidecars) {
 		if sc.Image == nil {
 			return nil, fmt.Errorf("sidecar %q: %w", scName, errSidecarImageRequired)

--- a/provider/defangaws/aws/ecs.go
+++ b/provider/defangaws/aws/ecs.go
@@ -24,7 +24,10 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
-var errSidecarImageRequired = errors.New("image is required")
+var (
+	errSidecarImageRequired = errors.New("image is required")
+	errPoliciesWithTaskRole = errors.New("policies cannot be combined with taskRoleArn")
+)
 
 type Policies struct {
 	bedrockPolicy *iam.Policy
@@ -494,6 +497,26 @@ func CreateECSService(
 			}
 			lbDependsOn = append(lbDependsOn, dep)
 		}
+
+		// Attach caller-specified policies (x-defang-policies)
+		for _, policy := range svc.Policies {
+			policyArn, err := resolvePolicyArn(ctx, policy)
+			if err != nil {
+				return nil, fmt.Errorf("resolving policy %q: %w", policy, err)
+			}
+			attachmentName := serviceName + "-task-role-" + policyName(policy)
+			dep, err := iam.NewRolePolicyAttachment(ctx, attachmentName, &iam.RolePolicyAttachmentArgs{
+				Role:      taskRole.Name,
+				PolicyArn: policyArn,
+			}, parentOpt)
+			if err != nil {
+				return nil, fmt.Errorf("attaching policy %q: %w", policy, err)
+			}
+			lbDependsOn = append(lbDependsOn, dep)
+		}
+	} else if len(svc.Policies) > 0 {
+		// A caller-supplied task role's policies are owned by the caller.
+		return nil, fmt.Errorf("service %s: %w", serviceName, errPoliciesWithTaskRole)
 	}
 
 	// Build container definition

--- a/provider/defangaws/aws/ecs.go
+++ b/provider/defangaws/aws/ecs.go
@@ -505,7 +505,7 @@ func CreateECSService(
 
 		// Attach caller-specified policies (x-defang-policies)
 		for _, policy := range svc.Policies {
-			policyArn, err := resolvePolicyArn(ctx, policy)
+			policyArn, err := resolvePolicyArn(ctx, policy, parentOpt)
 			if err != nil {
 				return nil, fmt.Errorf("resolving policy %q: %w", policy, err)
 			}

--- a/provider/defangaws/aws/ecs.go
+++ b/provider/defangaws/aws/ecs.go
@@ -611,7 +611,7 @@ func CreateECSService(
 				}
 				secrets = append(secrets, Secret{Name: k, ValueFrom: ref})
 			} else {
-				resolved := compose.GetConfigOrEnvValue(ctx, configProvider, svc, k, *v, parentOpt)
+				resolved := compose.GetConfigOrEnvValue(ctx, configProvider, svc, k, "", parentOpt)
 				entries = append(entries, envEntry{name: k, idx: len(allInputs)})
 				allInputs = append(allInputs, resolved)
 			}
@@ -673,7 +673,7 @@ func CreateECSService(
 			// Same bare-${VAR} split as resolveEnv, but on already-resolved
 			// values (GetSecretRef only does invokes, safe inside ApplyT).
 			for k, v := range common.Sorted(all[envInputIdx].(map[string]string)) {
-				if secretVar := compose.GetConfigName2(k, &v); secretVar != "" && configProvider != nil {
+				if secretVar := compose.GetConfigName2(k, pulumi.String(v)); secretVar != "" && configProvider != nil {
 					ref, err := configProvider.GetSecretRef(ctx, secretVar, parentOpt)
 					if err != nil {
 						return "", fmt.Errorf("getting secret ref for %q: %w", k, err)

--- a/provider/defangaws/aws/ecs.go
+++ b/provider/defangaws/aws/ecs.go
@@ -66,6 +66,9 @@ type SharedInfra struct {
 	BuildInfra     *BuildInfra       // nil if no builds needed
 	PublicEcrCache *PullThroughCache // ECR public pull-through cache
 	SkipNatGW      bool
+	// DnsProvider is a role-assuming AWS provider for public Route53
+	// operations when the DNS zone lives in another account; nil otherwise.
+	DnsProvider pulumi.ProviderResource
 	// Etag is the deployment ID supplied by the CD program; empty for
 	// standalone Service callers.
 	Etag string
@@ -834,22 +837,32 @@ func CreateECSService(
 		serviceLabel := common.ServiceLabel(serviceName)
 
 		firstIngress := true
+		var prevRule pulumi.Resource // serializes rule creation so ALB priorities follow port order
 		for _, port := range svc.Ports {
 			var endpoints []string
 
 			if infra.ProjectDomain != "" {
 				endpoints = append(endpoints, fmt.Sprintf("%s--%d.%s", serviceLabel, port.Target, infra.ProjectDomain))
 			}
-			if port.IsIngress() && firstIngress {
-				if svc.DomainName != "" {
+			if port.IsIngress() {
+				// The service's public FQDN matches every ingress port's rule:
+				// rules on the same listener are disambiguated by protocol
+				// conditions (gRPC content-type) or target a different
+				// listener (x-defang-listener: http).
+				switch {
+				case svc.DomainName != "":
 					endpoints = append(endpoints, svc.DomainName)
-				} else if infra.ProjectDomain != "" {
-					publicFqdn := fmt.Sprintf("%s.%s", serviceLabel, infra.ProjectDomain)
-					// FIXME: which service should listen on the project domain?
-					endpoints = append(endpoints, publicFqdn, infra.ProjectDomain)
+				case infra.ProjectDomain != "":
+					endpoints = append(endpoints, fmt.Sprintf("%s.%s", serviceLabel, infra.ProjectDomain))
+					if firstIngress {
+						// FIXME: which service should listen on the project domain?
+						endpoints = append(endpoints, infra.ProjectDomain)
+					}
 				}
-				endpoints = append(endpoints, svc.Networks[compose.DefaultNetwork].Aliases...)
-				firstIngress = false
+				if firstIngress {
+					endpoints = append(endpoints, svc.Networks[compose.DefaultNetwork].Aliases...)
+					firstIngress = false
+				}
 			}
 
 			listenerArn := defaultListenerArn
@@ -859,6 +872,14 @@ func CreateECSService(
 				}
 			}
 
+			// Rules for different ports may match the same host (e.g. the
+			// service's domainname), disambiguated by protocol conditions.
+			// AWS assigns rule priorities in creation order, so serialize:
+			// earlier ports get higher-priority (more specific) rules.
+			tgLrOpt := pulumi.ResourceOption(parentOpt)
+			if prevRule != nil {
+				tgLrOpt = pulumi.Composite(tgLrOpt, pulumi.DependsOn([]pulumi.Resource{prevRule}))
+			}
 			tg, lr, err := createTgLrPair(
 				ctx,
 				serviceName,
@@ -868,13 +889,14 @@ func CreateECSService(
 				svc.HealthCheck,
 				endpoints,
 				infra.albDnsName(),
-				parentOpt)
+				tgLrOpt)
 			if err != nil {
 				return nil, fmt.Errorf("creating TG/LR pair for port %d: %w", port.Target, err)
 			}
 			if tg == nil || lr == nil {
 				continue
 			}
+			prevRule = lr
 
 			loadBalancers = append(loadBalancers, &ecs.ServiceLoadBalancerArgs{
 				ContainerName:  pulumi.String(containerName),

--- a/provider/defangaws/aws/ecs.go
+++ b/provider/defangaws/aws/ecs.go
@@ -3,15 +3,18 @@ package aws
 import (
 	"cmp"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/DefangLabs/pulumi-defang/provider/common"
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
 	awsecs "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/aws/smithy-go/ptr"
+	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/appautoscaling"
 	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/cloudwatch"
 	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/ec2"
 	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/ecs"
@@ -21,6 +24,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
+var errSidecarImageRequired = errors.New("image is required")
+
 type Policies struct {
 	bedrockPolicy *iam.Policy
 	// codeBuildPolicy      *iam.RolePoliciesExclusive
@@ -28,6 +33,15 @@ type Policies struct {
 }
 
 // SharedInfra holds project-level AWS resources shared across all services.
+//
+// Fields come in two flavors:
+//   - internal typed resource pointers (Cluster, ExecRole, LogGroup, …) set by
+//     the project-scope orchestrator; untagged, so not part of the SDK schema.
+//   - schema-tagged string inputs (ClusterArn, ExecutionRoleArn, …) so
+//     standalone SDK users can reuse hand-provisioned infrastructure.
+//
+// The accessor methods below prefer the typed resource when set and fall back
+// to the schema input.
 type SharedInfra struct {
 	Cluster          *ecs.Cluster
 	ExecRole         *iam.Role
@@ -53,6 +67,68 @@ type SharedInfra struct {
 	// standalone Service callers.
 	Etag string
 	Policies
+
+	// Schema-exposed handles to pre-existing infrastructure, for standalone
+	// SDK callers that manage their own cluster/ALB/log group.
+	ClusterArn         pulumi.StringInput `pulumi:"clusterArn,optional"`
+	ExecutionRoleArn   pulumi.StringInput `pulumi:"executionRoleArn,optional"`
+	LogGroupName       pulumi.StringInput `pulumi:"logGroupName,optional"`
+	HttpListenerArn    pulumi.StringInput `pulumi:"httpListenerArn,optional"`
+	HttpsListenerArn   pulumi.StringInput `pulumi:"httpsListenerArn,optional"`
+	AlbDnsName         pulumi.StringInput `pulumi:"albDnsName,optional"`
+	AlbSecurityGroupId pulumi.StringInput `pulumi:"albSecurityGroupId,optional"`
+}
+
+func (i *SharedInfra) clusterArn() pulumi.StringInput {
+	if i.Cluster != nil {
+		return i.Cluster.Arn
+	}
+	return i.ClusterArn
+}
+
+func (i *SharedInfra) executionRoleArn() pulumi.StringPtrInput {
+	if i.ExecRole != nil {
+		return i.ExecRole.Arn
+	}
+	if i.ExecutionRoleArn != nil {
+		return i.ExecutionRoleArn.ToStringOutput()
+	}
+	return nil
+}
+
+func (i *SharedInfra) logGroupName() pulumi.StringInput {
+	if i.LogGroup != nil {
+		return i.LogGroup.Name
+	}
+	return i.LogGroupName
+}
+
+func (i *SharedInfra) httpListenerArn() pulumi.StringInput {
+	if i.HttpListener != nil {
+		return i.HttpListener.Arn
+	}
+	return i.HttpListenerArn
+}
+
+func (i *SharedInfra) httpsListenerArn() pulumi.StringInput {
+	if i.HttpsListener != nil {
+		return i.HttpsListener.Arn
+	}
+	return i.HttpsListenerArn
+}
+
+func (i *SharedInfra) albDnsName() pulumi.StringInput {
+	if i.Alb != nil {
+		return i.Alb.DnsName
+	}
+	return i.AlbDnsName
+}
+
+func (i *SharedInfra) albSecurityGroupId() pulumi.StringInput {
+	if i.AlbSG != nil {
+		return i.AlbSG.ID().ToStringOutput()
+	}
+	return i.AlbSecurityGroupId
 }
 
 // ECSServiceArgs holds per-service arguments for CreateECSService.
@@ -61,12 +137,29 @@ type ECSServiceArgs struct {
 	ImageURI           pulumi.StringInput // container image URI (built or pre-built)
 	Networks           compose.Networks   // from project
 	WaitForSteadyState bool               // true if another service depends on this one with condition: service_healthy
+	// TaskRoleArn, when set, is used as the task role instead of creating a
+	// fresh per-service role. Provider-managed policy attachments (route53
+	// sidecar, bedrock) are skipped — the caller owns the role's policies.
+	TaskRoleArn pulumi.StringInput
+	// SecurityGroupIds are extra security groups attached to the service's ENI
+	// in addition to the per-service SG and the shared private SG.
+	SecurityGroupIds pulumi.StringArrayInput
+	// Secrets maps container environment variable names to SSM parameter or
+	// Secrets Manager ARNs, injected via the ECS-native secrets mechanism.
+	Secrets pulumi.StringMapInput
+	// Sidecars are additional containers deployed in the same task definition.
+	// Keyed by service name; volumesFrom/dependsOn on the main service may
+	// reference these names.
+	Sidecars map[string]compose.ServiceConfig
+	// Triggers force a service redeployment when any value changes.
+	Triggers pulumi.StringMapInput
 }
 
 type EcsServiceResult struct {
-	Service    *ecs.Service
-	Endpoint   pulumix.Output[string]
-	HasIngress bool
+	Service     *ecs.Service
+	Endpoint    pulumix.Output[string]
+	HasIngress  bool
+	TaskRoleArn pulumi.StringInput // the created or caller-supplied task role
 }
 
 // clampInt clamps v to [minimum, maximum]. Returns fallback if v is 0.
@@ -152,11 +245,114 @@ func portProtocol(p compose.ServicePortConfig) awsecs.TransportProtocol {
 	return awsecs.TransportProtocolTcp
 }
 
-func roleArn(r *iam.Role) pulumi.StringOutput {
-	if r == nil {
-		return pulumi.StringOutput{}
+// parseVolumesFrom parses a compose volumes_from entry ("container[:ro|rw]" or
+// "container:service:ro") into the source container name and read-only flag.
+// Matches the TS parseVolumesFrom helper.
+func parseVolumesFrom(ref string) (string, bool) {
+	parts := strings.Split(ref, ":")
+	switch len(parts) {
+	case 1:
+		return parts[0], false
+	case 2:
+		return parts[0], parts[1] == "ro"
+	case 3:
+		return parts[1], parts[2] == "ro"
+	default:
+		return ref, false
 	}
-	return r.Arn
+}
+
+// buildMountPoints converts compose volume entries to ECS mount points.
+func buildMountPoints(volumes []compose.ServiceVolumeConfig) []MountPoint {
+	mountPoints := make([]MountPoint, 0, len(volumes))
+	for _, v := range volumes {
+		mountPoints = append(mountPoints, MountPoint{
+			ContainerPath: ptr.String(v.Target),
+			SourceVolume:  ptr.String(v.Source),
+			ReadOnly:      ptr.Bool(v.ReadOnly),
+		})
+	}
+	return mountPoints
+}
+
+// buildVolumesFrom converts compose volumes_from entries to ECS volumesFrom,
+// resolving service names to their container names via the sidecar map.
+func buildVolumesFrom(refs []string, sidecars map[string]compose.ServiceConfig) []VolumeFrom {
+	volumesFrom := make([]VolumeFrom, 0, len(refs))
+	for _, ref := range refs {
+		source, readOnly := parseVolumesFrom(ref)
+		if sc, ok := sidecars[source]; ok {
+			source = sc.GetContainerName(source)
+		}
+		volumesFrom = append(volumesFrom, VolumeFrom{
+			SourceContainer: ptr.String(source),
+			ReadOnly:        ptr.Bool(readOnly),
+		})
+	}
+	return volumesFrom
+}
+
+// buildHealthCheck converts a compose health check to an ECS container health
+// check with clamped values (matches TS clamp ranges).
+func buildHealthCheck(hc *compose.HealthCheckConfig) *HealthCheck {
+	if hc == nil || len(hc.Test) == 0 {
+		return nil
+	}
+	healthCheck := &HealthCheck{
+		Command:  hc.Test,
+		Interval: ptr.Int32(clampInt(hc.IntervalSeconds, 5, 300, 30)),
+		Timeout:  ptr.Int32(clampInt(hc.TimeoutSeconds, 2, 60, 5)),
+		Retries:  ptr.Int32(clampInt(hc.Retries, 1, 10, 3)),
+	}
+	if startPeriod := clampInt(hc.StartPeriodSeconds, 0, 300, 0); startPeriod > 0 {
+		healthCheck.StartPeriod = ptr.Int32(startPeriod)
+	}
+	return healthCheck
+}
+
+// buildStopTimeout converts a compose stop_grace_period to an ECS stopTimeout
+// (nil if unset; ECS caps Fargate stopTimeout at 120s).
+func buildStopTimeout(svc compose.ServiceConfig) *int32 {
+	secs := svc.GetStopGracePeriodSeconds()
+	if secs <= 0 {
+		return nil
+	}
+	if secs > 120 {
+		secs = 120
+	}
+	return ptr.Int32(int32(secs))
+}
+
+// composeToEcsConditions maps compose depends_on conditions to ECS container
+// dependency conditions.
+var composeToEcsConditions = map[string]awsecs.ContainerCondition{
+	"service_started":                awsecs.ContainerConditionStart,
+	"service_healthy":                awsecs.ContainerConditionHealthy,
+	"service_completed_successfully": awsecs.ContainerConditionSuccess,
+}
+
+// buildDependsOn converts compose depends_on entries to ECS container
+// dependencies. Only dependencies on sidecar containers in the same task are
+// supported; others are dropped (matches the TS behaviour).
+func buildDependsOn(
+	dependsOn compose.DependsOnConfig, sidecars map[string]compose.ServiceConfig,
+) []ContainerDependency {
+	var deps []ContainerDependency
+	for depName, dep := range common.Sorted(dependsOn) {
+		sc, ok := sidecars[depName]
+		if !ok {
+			continue // ECS only supports dependsOn between containers in the same task
+		}
+		condition := composeToEcsConditions[dep.Condition]
+		if condition == "" {
+			condition = awsecs.ContainerConditionStart
+		}
+		deps = append(deps, ContainerDependency{
+			ContainerName: ptr.String(sc.GetContainerName(depName)),
+			Condition:     condition,
+		})
+	}
+	return deps
 }
 
 // createServiceSG creates a per-service security group with port-specific ingress rules.
@@ -189,9 +385,9 @@ func createServiceSG(
 		}
 
 		switch {
-		case port.IsIngress() && infra.AlbSG != nil:
+		case port.IsIngress() && infra.albSecurityGroupId() != nil:
 			// LB-backed port: allow from ALB SG (matches TS: VPC CIDR for ingress ports)
-			rule.SecurityGroups = pulumi.StringArray{infra.AlbSG.ID()}
+			rule.SecurityGroups = pulumi.StringArray{infra.albSecurityGroupId()}
 		case isPrivate && infra.PrivateSgID != nil:
 			// Private port: allow from privateSG as source SG
 			rule.SecurityGroups = pulumi.StringArray{infra.PrivateSgID.ToStringPtrOutput().Elem()}
@@ -263,44 +459,58 @@ func CreateECSService(
 		infra = &SharedInfra{} // allow standalone usage without shared infra
 	}
 
-	// Create task role
-	taskRole, err := createTaskRole(ctx, serviceName, parentOpt)
-	if err != nil {
-		return nil, fmt.Errorf("creating task role: %w", err)
-	}
-
-	// Attach route53 sidecar policy if service has host ports (private DNS)
+	// Use the caller-supplied task role, or create one per service. Provider-
+	// managed policy attachments only apply to roles we create — an external
+	// role's policies are owned by the caller.
 	var lbDependsOn []pulumi.Resource
-	if svc.HasHostPorts() && infra.route53SidecarPolicy != nil {
-		dep, err := iam.NewRolePolicyAttachment(ctx, serviceName+"-AllowRoute53Sidecar", &iam.RolePolicyAttachmentArgs{
-			Role:      taskRole.Name,
-			PolicyArn: infra.route53SidecarPolicy.Arn,
-		}, parentOpt)
+	taskRoleArn := args.TaskRoleArn
+	if taskRoleArn == nil {
+		taskRole, err := createTaskRole(ctx, serviceName, parentOpt)
 		if err != nil {
-			return nil, fmt.Errorf("attaching route53 sidecar policy: %w", err)
+			return nil, fmt.Errorf("creating task role: %w", err)
 		}
-		lbDependsOn = append(lbDependsOn, dep)
-	}
+		taskRoleArn = taskRole.Arn
 
-	// Attach bedrock policy if service uses LLM (x-defang-llm)
-	if svc.LLM != nil && infra.bedrockPolicy != nil {
-		dep, err := iam.NewRolePolicyAttachment(ctx, serviceName+"-BedrockPolicy", &iam.RolePolicyAttachmentArgs{
-			Role:      taskRole.Name,
-			PolicyArn: infra.bedrockPolicy.Arn,
-		}, parentOpt)
-		if err != nil {
-			return nil, fmt.Errorf("attaching bedrock policy: %w", err)
+		// Attach route53 sidecar policy if service has host ports (private DNS)
+		if svc.HasHostPorts() && infra.route53SidecarPolicy != nil {
+			dep, err := iam.NewRolePolicyAttachment(ctx, serviceName+"-AllowRoute53Sidecar", &iam.RolePolicyAttachmentArgs{
+				Role:      taskRole.Name,
+				PolicyArn: infra.route53SidecarPolicy.Arn,
+			}, parentOpt)
+			if err != nil {
+				return nil, fmt.Errorf("attaching route53 sidecar policy: %w", err)
+			}
+			lbDependsOn = append(lbDependsOn, dep)
 		}
-		lbDependsOn = append(lbDependsOn, dep)
+
+		// Attach bedrock policy if service uses LLM (x-defang-llm)
+		if svc.LLM != nil && infra.bedrockPolicy != nil {
+			dep, err := iam.NewRolePolicyAttachment(ctx, serviceName+"-BedrockPolicy", &iam.RolePolicyAttachmentArgs{
+				Role:      taskRole.Name,
+				PolicyArn: infra.bedrockPolicy.Arn,
+			}, parentOpt)
+			if err != nil {
+				return nil, fmt.Errorf("attaching bedrock policy: %w", err)
+			}
+			lbDependsOn = append(lbDependsOn, dep)
+		}
 	}
 
 	// Build container definition
 	cpus := svc.GetCPUs()
 	memMiB := svc.GetMemoryMiB()
 
-	// Build port mappings (protocol normalized to tcp/udp, hostPort = containerPort)
+	// Build port mappings (protocol normalized to tcp/udp, hostPort = containerPort).
+	// Multiple compose ports can share a target port (e.g. http + grpc listeners
+	// on the same port), so dedupe (matches TS dedup by containerPort/protocol).
 	portMappings := make([]PortMapping, 0, len(svc.Ports))
+	seenPorts := map[string]bool{}
 	for _, p := range svc.Ports {
+		key := fmt.Sprintf("%d/%s", p.Target, portProtocol(p))
+		if seenPorts[key] {
+			continue
+		}
+		seenPorts[key] = true
 		portMappings = append(portMappings, PortMapping{
 			ContainerPort: ptr.Int32(p.Target),
 			HostPort:      ptr.Int32(p.Target), // awsvpc mode: AWS normalizes hostPort = containerPort
@@ -308,20 +518,7 @@ func CreateECSService(
 		})
 	}
 
-	// Build health check with clamped values (matches TS clamp ranges)
-	var healthCheck *HealthCheck
-	if svc.HealthCheck != nil && len(svc.HealthCheck.Test) > 0 {
-		healthCheck = &HealthCheck{
-			Command:  svc.HealthCheck.Test,
-			Interval: ptr.Int32(clampInt(svc.HealthCheck.IntervalSeconds, 5, 300, 30)),
-			Timeout:  ptr.Int32(clampInt(svc.HealthCheck.TimeoutSeconds, 2, 60, 5)),
-			Retries:  ptr.Int32(clampInt(svc.HealthCheck.Retries, 1, 10, 3)),
-		}
-		startPeriod := clampInt(svc.HealthCheck.StartPeriodSeconds, 0, 300, 0)
-		if startPeriod > 0 {
-			healthCheck.StartPeriod = ptr.Int32(startPeriod)
-		}
-	}
+	healthCheck := buildHealthCheck(svc.HealthCheck)
 
 	// Build environment variable names and resolve values via ConfigProvider interpolation
 	// (matches GCP's use of compose.GetConfigOrEnvValue)
@@ -329,7 +526,6 @@ func CreateECSService(
 		name string
 		idx  int // index into allInputs where the resolved value will be
 	}
-	var envEntries []envEntry
 	staticEnvVars := []KeyValuePair{
 		{Name: "DEFANG_SERVICE", Value: serviceName},
 	}
@@ -348,36 +544,72 @@ func CreateECSService(
 
 	// Resolve outputs (image URI, log group name, env vars) before building the container
 	// definitions JSON. The ECS ContainerDefinitions field is a plain JSON string,
-	// so all values must be concrete before marshaling.
-	containerName := serviceName
+	// so all values must be concrete before marshaling. Each optional input's
+	// index into allInputs is tracked explicitly.
+	containerName := svc.GetContainerName(serviceName)
 
 	allInputs := []interface{}{args.ImageURI}
-	hasLogGroup := infra != nil && infra.LogGroup != nil
-	if hasLogGroup {
-		allInputs = append(allInputs, infra.LogGroup.Name)
+	logGroupIdx := -1
+	if logGroupName := infra.logGroupName(); logGroupName != nil {
+		logGroupIdx = len(allInputs)
+		allInputs = append(allInputs, logGroupName)
 	}
-	hasPrivateZone := infra != nil && infra.PrivateZoneID != nil
-	if hasPrivateZone {
+	privateZoneIdx := -1
+	if infra.PrivateZoneID != nil {
+		privateZoneIdx = len(allInputs)
 		allInputs = append(allInputs, infra.PrivateZoneID)
+	}
+	secretsIdx := -1
+	if args.Secrets != nil {
+		secretsIdx = len(allInputs)
+		allInputs = append(allInputs, args.Secrets)
 	}
 
 	// Split env vars: bare ${VAR} references go to ECS Secrets (SSM ARN),
 	// all others go to Environment (resolved plaintext).
-	var secretEntries []Secret
-
-	for k, v := range common.Sorted(svc.Environment) {
-		if secretVar := compose.GetConfigName2(k, v); secretVar != "" && configProvider != nil {
-			ref, err := configProvider.GetSecretRef(ctx, secretVar, parentOpt)
-			if err != nil {
-				return nil, fmt.Errorf("getting secret ref for %q: %w", k, err)
+	resolveEnv := func(svc compose.ServiceConfig) ([]envEntry, []Secret, error) {
+		var entries []envEntry
+		var secrets []Secret
+		for k, v := range common.Sorted(svc.Environment) {
+			if secretVar := compose.GetConfigName2(k, v); secretVar != "" && configProvider != nil {
+				ref, err := configProvider.GetSecretRef(ctx, secretVar, parentOpt)
+				if err != nil {
+					return nil, nil, fmt.Errorf("getting secret ref for %q: %w", k, err)
+				}
+				secrets = append(secrets, Secret{Name: k, ValueFrom: ref})
+			} else {
+				resolved := compose.GetConfigOrEnvValue(ctx, configProvider, svc, k, *v, parentOpt)
+				entries = append(entries, envEntry{name: k, idx: len(allInputs)})
+				allInputs = append(allInputs, resolved)
 			}
-			secretEntries = append(secretEntries, Secret{Name: k, ValueFrom: ref})
-		} else {
-			resolved := compose.GetConfigOrEnvValue(ctx, configProvider, svc, k, *v, parentOpt)
-			entry := envEntry{name: k, idx: len(allInputs)}
-			envEntries = append(envEntries, entry)
-			allInputs = append(allInputs, resolved)
 		}
+		return entries, secrets, nil
+	}
+
+	envEntries, secretEntries, err := resolveEnv(svc)
+	if err != nil {
+		return nil, err
+	}
+
+	// Resolve sidecar container env vars the same way as the main container.
+	type sidecarData struct {
+		name       string
+		cfg        compose.ServiceConfig
+		envEntries []envEntry
+		secrets    []Secret
+	}
+	var sidecarDatas []sidecarData
+	for scName, sc := range common.Sorted(args.Sidecars) {
+		if sc.Image == nil || *sc.Image == "" {
+			return nil, fmt.Errorf("sidecar %q: %w", scName, errSidecarImageRequired)
+		}
+		scEnvEntries, scSecrets, err := resolveEnv(sc)
+		if err != nil {
+			return nil, fmt.Errorf("sidecar %q: %w", scName, err)
+		}
+		sidecarDatas = append(sidecarDatas, sidecarData{
+			name: scName, cfg: sc, envEntries: scEnvEntries, secrets: scSecrets,
+		})
 	}
 
 	containerDefsJSON := pulumi.All(allInputs...).ApplyT(func(all []any) (string, error) {
@@ -393,16 +625,27 @@ func CreateECSService(
 			return cmp.Compare(a.Name, b.Name)
 		})
 
-		var logConfiguration *LogConfiguration
-		if hasLogGroup {
-			logGroupName := all[1].(string)
-			logConfiguration = &LogConfiguration{
+		logConfigurationFor := func(streamPrefix string) *LogConfiguration {
+			if logGroupIdx < 0 {
+				return nil
+			}
+			return &LogConfiguration{
 				LogDriver: awsecs.LogDriverAwslogs,
 				Options: map[LogOption]string{
-					LogOptionAwslogsGroup:        logGroupName,
+					LogOptionAwslogsGroup:        all[logGroupIdx].(string),
 					LogOptionAwslogsRegion:       infra.Region,
-					LogOptionAwslogsStreamPrefix: containerName,
+					LogOptionAwslogsStreamPrefix: streamPrefix,
 				},
+			}
+		}
+		logConfiguration := logConfigurationFor(containerName)
+
+		// Merge ECS-native secrets from the Secrets input with the ones derived
+		// from bare ${VAR} environment references.
+		mainSecrets := append([]Secret{}, secretEntries...)
+		if secretsIdx >= 0 {
+			for name, valueFrom := range common.Sorted(all[secretsIdx].(map[string]string)) {
+				mainSecrets = append(mainSecrets, Secret{Name: name, ValueFrom: valueFrom})
 			}
 		}
 
@@ -414,20 +657,52 @@ func CreateECSService(
 			Essential:        ptr.Bool(true),
 			PortMappings:     portMappings,
 			Environment:      envVars,
-			Secrets:          secretEntries,
+			Secrets:          mainSecrets,
 			Command:          svc.Command,
 			EntryPoint:       svc.Entrypoint,
+			DependsOn:        buildDependsOn(svc.DependsOn, args.Sidecars),
 			HealthCheck:      healthCheck,
 			Image:            imageUri,
 			LogConfiguration: logConfiguration,
+			StopTimeout:      buildStopTimeout(svc),
+			WorkingDirectory: svc.WorkingDir,
 			// AWS normalizes these to [] on read; use empty slices to avoid null vs [] diffs
-			MountPoints:    []MountPoint{},
+			MountPoints:    buildMountPoints(svc.Volumes),
 			SystemControls: []SystemControl{},
-			VolumesFrom:    []VolumeFrom{},
+			VolumesFrom:    buildVolumesFrom(svc.VolumesFrom, args.Sidecars),
 		}}
 
-		if svc.HasHostPorts() && hasPrivateZone {
-			privateZoneID := all[2].(string)                                         // FIXME: this is [1] if there's no loggroup
+		for _, sd := range sidecarDatas {
+			scEnvVars := []KeyValuePair{}
+			for _, e := range sd.envEntries {
+				scEnvVars = append(scEnvVars, KeyValuePair{Name: e.name, Value: all[e.idx].(string)})
+			}
+			slices.SortFunc(scEnvVars, func(a, b KeyValuePair) int {
+				return cmp.Compare(a.Name, b.Name)
+			})
+			scContainerName := sd.cfg.GetContainerName(sd.name)
+			containerDefs = append(containerDefs, ContainerDefinition{
+				Name:             scContainerName,
+				Essential:        ptr.Bool(sd.cfg.Restart != "no"),
+				PortMappings:     []PortMapping{},
+				Environment:      scEnvVars,
+				Secrets:          sd.secrets,
+				Command:          sd.cfg.Command,
+				EntryPoint:       sd.cfg.Entrypoint,
+				DependsOn:        buildDependsOn(sd.cfg.DependsOn, args.Sidecars),
+				HealthCheck:      buildHealthCheck(sd.cfg.HealthCheck),
+				Image:            *sd.cfg.Image,
+				LogConfiguration: logConfigurationFor(scContainerName),
+				StopTimeout:      buildStopTimeout(sd.cfg),
+				WorkingDirectory: sd.cfg.WorkingDir,
+				MountPoints:      buildMountPoints(sd.cfg.Volumes),
+				SystemControls:   []SystemControl{},
+				VolumesFrom:      buildVolumesFrom(sd.cfg.VolumesFrom, args.Sidecars),
+			})
+		}
+
+		if svc.HasHostPorts() && privateZoneIdx >= 0 {
+			privateZoneID := all[privateZoneIdx].(string)
 			privateFqdn := common.ServiceLabel(serviceName) + "." + infra.PrivateDomain // route53 sidecar needs FQDN
 			sidecarDef := ContainerDefinition{
 				Name:      "route53-sidecar",
@@ -475,9 +750,10 @@ func CreateECSService(
 		RequiresCompatibilities: pulumi.StringArray{pulumi.String("FARGATE")},
 		Cpu:                     pulumi.String(fargateCPU),
 		Memory:                  pulumi.String(fargateMemory),
-		ExecutionRoleArn:        roleArn(infra.ExecRole),
-		TaskRoleArn:             taskRole.Arn,
+		ExecutionRoleArn:        infra.executionRoleArn(),
+		TaskRoleArn:             taskRoleArn.ToStringOutput(),
 		ContainerDefinitions:    containerDefsJSON,
+		Volumes:                 buildTaskVolumes(svc, args.Sidecars),
 		RuntimePlatform: &ecs.TaskDefinitionRuntimePlatformArgs{
 			CpuArchitecture:       pulumi.String(string(cpuArch)),
 			OperatingSystemFamily: pulumi.String("LINUX"),
@@ -496,13 +772,14 @@ func CreateECSService(
 	var loadBalancers ecs.ServiceLoadBalancerArray
 	var endpointOutput pulumix.Output[string]
 
-	listener := infra.HttpListener
-	if infra.HttpsListener != nil {
-		// If HTTPS listener exists, use it instead of HTTP (matches TS createTgLrPair)
-		listener = infra.HttpsListener
+	// If an HTTPS listener exists, prefer it over HTTP (matches TS createTgLrPair).
+	// A port may force the plain HTTP listener via x-defang-listener: http.
+	defaultListenerArn := infra.httpsListenerArn()
+	if defaultListenerArn == nil {
+		defaultListenerArn = infra.httpListenerArn()
 	}
 
-	if svc.HasIngressPorts() && listener != nil {
+	if svc.HasIngressPorts() && defaultListenerArn != nil {
 		serviceLabel := common.ServiceLabel(serviceName)
 
 		firstIngress := true
@@ -524,15 +801,22 @@ func CreateECSService(
 				firstIngress = false
 			}
 
+			listenerArn := defaultListenerArn
+			if port.Listener == compose.PortListenerHTTP {
+				if httpArn := infra.httpListenerArn(); httpArn != nil {
+					listenerArn = httpArn
+				}
+			}
+
 			tg, lr, err := createTgLrPair(
 				ctx,
 				serviceName,
 				infra.VpcID,
-				listener,
+				listenerArn,
 				port,
 				svc.HealthCheck,
 				endpoints,
-				infra.Alb.DnsName,
+				infra.albDnsName(),
 				parentOpt)
 			if err != nil {
 				return nil, fmt.Errorf("creating TG/LR pair for port %d: %w", port.Target, err)
@@ -565,23 +849,30 @@ func CreateECSService(
 		return nil, err
 	}
 
-	// Create ECS service with circuit breaker and managed tags (matches TS createEcsService)
-	var clusterArn pulumi.StringInput
-	if infra.Cluster != nil {
-		clusterArn = infra.Cluster.Arn
-	}
-	// Attach both per-service SG and shared privateSG (matches TS: [privateSg])
+	// Attach per-service SG, shared privateSG (matches TS: [privateSg]), and any
+	// caller-supplied extra security groups.
 	securityGroups := pulumi.StringArray{serviceSG.ID()}
 	if infra.PrivateSgID != nil {
 		securityGroups = append(securityGroups, infra.PrivateSgID.ToStringPtrOutput().Elem())
 	}
+	var serviceSecurityGroups pulumi.StringArrayInput = securityGroups
+	if args.SecurityGroupIds != nil {
+		serviceSecurityGroups = pulumi.All(securityGroups, args.SecurityGroupIds).
+			ApplyT(func(all []any) []string {
+				//nolint:forcetypeassert // pulumi.All resolves string arrays
+				return append(all[0].([]string), all[1].([]string)...)
+			}).(pulumi.StringArrayOutput)
+	}
+
+	// Create ECS service with circuit breaker and managed tags (matches TS createEcsService)
 	ecsServiceArgs := &ecs.ServiceArgs{
-		Cluster:        clusterArn,
+		Cluster:        infra.clusterArn(),
 		TaskDefinition: taskDef.Arn,
 		DesiredCount:   pulumi.Int(replicas),
+		Triggers:       args.Triggers,
 		NetworkConfiguration: &ecs.ServiceNetworkConfigurationArgs{
 			Subnets:        subnetIds,
-			SecurityGroups: securityGroups,
+			SecurityGroups: serviceSecurityGroups,
 			AssignPublicIp: pulumi.Bool(assignPublicIp),
 		},
 		LoadBalancers: loadBalancers,
@@ -625,18 +916,18 @@ func CreateECSService(
 		return nil, fmt.Errorf("creating ECS service: %w", err)
 	}
 
-	hasIngress := svc.HasIngressPorts() && infra.HttpListener != nil
+	hasIngress := svc.HasIngressPorts() && defaultListenerArn != nil
 	serviceLabel := common.ServiceLabel(serviceName)
 	switch {
 	case hasIngress && infra.ProjectDomain != "":
 		// HTTP listener redirects to HTTPS when a cert is bound, so advertise https://.
 		endpointOutput = pulumix.Val(fmt.Sprintf("https://%s.%s", serviceLabel, infra.ProjectDomain))
-	case hasIngress:
+	case hasIngress && infra.albDnsName() != nil:
 		// No ProjectDomain: reach the service via the raw ALB DNS. createTgLrPair
-		// sets the listener-rule HostHeader to infra.Alb.DnsName when no hostnames
+		// sets the listener-rule HostHeader to the ALB DNS name when no hostnames
 		// are configured, so routing works for http://<alb-dns-name>.
 		endpointOutput = pulumix.Apply(
-			pulumix.Output[string](infra.Alb.DnsName),
+			pulumix.Output[string](infra.albDnsName().ToStringOutput()),
 			func(dns string) string { return "http://" + dns },
 		)
 	case svc.HasHostPorts() && infra.PrivateDomain != "":
@@ -651,9 +942,92 @@ func CreateECSService(
 		return nil, fmt.Errorf("creating certs and Route53 DNS: %w", err)
 	}
 
+	// CPU-based target-tracking autoscaling (x-defang-autoscaling), replicas..2x
+	// replicas (matches TS createFargateScalingTarget/PolicyCPU).
+	if svc.Autoscaling {
+		if err := createCPUAutoscaling(ctx, serviceName, infra, ecsService, replicas, parentOpt); err != nil {
+			return nil, err
+		}
+	}
+
 	return &EcsServiceResult{
-		Service:    ecsService,
-		Endpoint:   endpointOutput,
-		HasIngress: hasIngress,
+		Service:     ecsService,
+		Endpoint:    endpointOutput,
+		HasIngress:  hasIngress,
+		TaskRoleArn: taskRoleArn,
 	}, nil
+}
+
+// createCPUAutoscaling registers the ECS service as an Application Auto Scaling
+// target with a CPU target-tracking policy (85% average utilization).
+func createCPUAutoscaling(
+	ctx *pulumi.Context,
+	serviceName string,
+	infra *SharedInfra,
+	ecsService *ecs.Service,
+	replicas int32,
+	parentOpt pulumi.ResourceOrInvokeOption,
+) error {
+	clusterName := pulumi.String("default").ToStringOutput()
+	if clusterArn := infra.clusterArn(); clusterArn != nil {
+		clusterName = clusterArn.ToStringOutput().ApplyT(func(arn string) string {
+			// arn:aws:ecs:region:account:cluster/NAME → NAME
+			return arn[strings.LastIndexByte(arn, '/')+1:]
+		}).(pulumi.StringOutput)
+	}
+	resourceID := pulumi.Sprintf("service/%s/%s", clusterName, ecsService.Name)
+
+	target, err := appautoscaling.NewTarget(ctx, serviceName+"-scaling", &appautoscaling.TargetArgs{
+		MinCapacity:       pulumi.Int(replicas),
+		MaxCapacity:       pulumi.Int(replicas * 2),
+		ResourceId:        resourceID,
+		ScalableDimension: pulumi.String("ecs:service:DesiredCount"),
+		ServiceNamespace:  pulumi.String("ecs"),
+	}, parentOpt)
+	if err != nil {
+		return fmt.Errorf("creating autoscaling target: %w", err)
+	}
+
+	metricSpec := &appautoscaling.PolicyTargetTrackingScalingPolicyConfigurationPredefinedMetricSpecificationArgs{
+		PredefinedMetricType: pulumi.String("ECSServiceAverageCPUUtilization"),
+	}
+	_, err = appautoscaling.NewPolicy(ctx, serviceName+"-scaling-cpu", &appautoscaling.PolicyArgs{
+		PolicyType:        pulumi.String("TargetTrackingScaling"),
+		ResourceId:        target.ResourceId,
+		ScalableDimension: target.ScalableDimension,
+		ServiceNamespace:  target.ServiceNamespace,
+		TargetTrackingScalingPolicyConfiguration: &appautoscaling.PolicyTargetTrackingScalingPolicyConfigurationArgs{
+			PredefinedMetricSpecification: metricSpec,
+			TargetValue:                   pulumi.Float64(85),
+		},
+	}, parentOpt)
+	if err != nil {
+		return fmt.Errorf("creating autoscaling policy: %w", err)
+	}
+	return nil
+}
+
+// buildTaskVolumes collects the distinct volume names referenced by the main
+// service's and sidecars' compose volumes into task-definition volumes.
+func buildTaskVolumes(
+	svc compose.ServiceConfig, sidecars map[string]compose.ServiceConfig,
+) ecs.TaskDefinitionVolumeArray {
+	var volumes ecs.TaskDefinitionVolumeArray
+	seen := map[string]bool{}
+	add := func(vols []compose.ServiceVolumeConfig) {
+		for _, v := range vols {
+			if seen[v.Source] {
+				continue
+			}
+			seen[v.Source] = true
+			volumes = append(volumes, &ecs.TaskDefinitionVolumeArgs{
+				Name: pulumi.String(v.Source),
+			})
+		}
+	}
+	add(svc.Volumes)
+	for _, sc := range common.Sorted(sidecars) {
+		add(sc.Volumes)
+	}
+	return volumes
 }

--- a/provider/defangaws/aws/ecs.go
+++ b/provider/defangaws/aws/ecs.go
@@ -72,14 +72,12 @@ type SharedInfra struct {
 	Policies
 
 	// Schema-exposed handles to pre-existing infrastructure, for standalone
-	// SDK callers that manage their own cluster/ALB/log group.
-	ClusterArn         pulumi.StringInput `pulumi:"clusterArn,optional"`
-	ExecutionRoleArn   pulumi.StringInput `pulumi:"executionRoleArn,optional"`
-	LogGroupName       pulumi.StringInput `pulumi:"logGroupName,optional"`
-	HttpListenerArn    pulumi.StringInput `pulumi:"httpListenerArn,optional"`
-	HttpsListenerArn   pulumi.StringInput `pulumi:"httpsListenerArn,optional"`
-	AlbDnsName         pulumi.StringInput `pulumi:"albDnsName,optional"`
-	AlbSecurityGroupId pulumi.StringInput `pulumi:"albSecurityGroupId,optional"`
+	// SDK callers that manage their own cluster/exec role/log group. ALB
+	// attachment is deliberately not exposed: ingress-bearing services
+	// belong in a Project, which owns its own ALB.
+	ClusterArn       pulumi.StringInput `pulumi:"clusterArn,optional"`
+	ExecutionRoleArn pulumi.StringInput `pulumi:"executionRoleArn,optional"`
+	LogGroupName     pulumi.StringInput `pulumi:"logGroupName,optional"`
 }
 
 func (i *SharedInfra) clusterArn() pulumi.StringInput {
@@ -110,28 +108,28 @@ func (i *SharedInfra) httpListenerArn() pulumi.StringInput {
 	if i.HttpListener != nil {
 		return i.HttpListener.Arn
 	}
-	return i.HttpListenerArn
+	return nil
 }
 
 func (i *SharedInfra) httpsListenerArn() pulumi.StringInput {
 	if i.HttpsListener != nil {
 		return i.HttpsListener.Arn
 	}
-	return i.HttpsListenerArn
+	return nil
 }
 
 func (i *SharedInfra) albDnsName() pulumi.StringInput {
 	if i.Alb != nil {
 		return i.Alb.DnsName
 	}
-	return i.AlbDnsName
+	return nil
 }
 
 func (i *SharedInfra) albSecurityGroupId() pulumi.StringInput {
 	if i.AlbSG != nil {
 		return i.AlbSG.ID().ToStringOutput()
 	}
-	return i.AlbSecurityGroupId
+	return nil
 }
 
 // ECSServiceArgs holds per-service arguments for CreateECSService.

--- a/provider/defangaws/aws/ecs.go
+++ b/provider/defangaws/aws/ecs.go
@@ -150,6 +150,10 @@ type ECSServiceArgs struct {
 	// Secrets maps container environment variable names to SSM parameter or
 	// Secrets Manager ARNs, injected via the ECS-native secrets mechanism.
 	Secrets pulumi.StringMapInput
+	// Environment holds extra env vars for the main container; values may be
+	// Outputs. Bare ${VAR} values become ECS secret refs (like the
+	// compose-shaped ServiceConfig.Environment); other values stay plaintext.
+	Environment pulumi.StringMapInput
 	// Sidecars are additional containers deployed in the same task definition.
 	// Keyed by service name; volumesFrom/dependsOn on the main service may
 	// reference these names.
@@ -587,6 +591,11 @@ func CreateECSService(
 		secretsIdx = len(allInputs)
 		allInputs = append(allInputs, args.Secrets)
 	}
+	envInputIdx := -1
+	if args.Environment != nil {
+		envInputIdx = len(allInputs)
+		allInputs = append(allInputs, args.Environment)
+	}
 
 	// Split env vars: bare ${VAR} references go to ECS Secrets (SSM ARN),
 	// all others go to Environment (resolved plaintext).
@@ -620,29 +629,59 @@ func CreateECSService(
 		cfg        compose.ServiceConfig
 		envEntries []envEntry
 		secrets    []Secret
+		imageIdx   int // index into allInputs where the resolved image URI will be
 	}
 	var sidecarDatas []sidecarData
 	for scName, sc := range common.Sorted(args.Sidecars) {
-		if sc.Image == nil || *sc.Image == "" {
+		if sc.Image == nil {
+			return nil, fmt.Errorf("sidecar %q: %w", scName, errSidecarImageRequired)
+		}
+		if img := sc.StaticImage(); img != nil && *img == "" {
 			return nil, fmt.Errorf("sidecar %q: %w", scName, errSidecarImageRequired)
 		}
 		scEnvEntries, scSecrets, err := resolveEnv(sc)
 		if err != nil {
 			return nil, fmt.Errorf("sidecar %q: %w", scName, err)
 		}
+		imageIdx := len(allInputs)
+		allInputs = append(allInputs, sc.Image)
 		sidecarDatas = append(sidecarDatas, sidecarData{
-			name: scName, cfg: sc, envEntries: scEnvEntries, secrets: scSecrets,
+			name: scName, cfg: sc, envEntries: scEnvEntries, secrets: scSecrets, imageIdx: imageIdx,
 		})
 	}
 
 	containerDefsJSON := pulumi.All(allInputs...).ApplyT(func(all []any) (string, error) {
 		imageUri := all[0].(string)
 
+		// Merge ECS-native secrets from the Secrets input with the ones derived
+		// from bare ${VAR} environment references.
+		mainSecrets := append([]Secret{}, secretEntries...)
+		if secretsIdx >= 0 {
+			for name, valueFrom := range common.Sorted(all[secretsIdx].(map[string]string)) {
+				mainSecrets = append(mainSecrets, Secret{Name: name, ValueFrom: valueFrom})
+			}
+		}
+
 		// Build env vars from resolved outputs
 		envVars := append([]KeyValuePair{}, staticEnvVars...)
 		for _, e := range envEntries {
 			val := all[e.idx].(string)
 			envVars = append(envVars, KeyValuePair{Name: e.name, Value: val})
+		}
+		if envInputIdx >= 0 {
+			// Same bare-${VAR} split as resolveEnv, but on already-resolved
+			// values (GetSecretRef only does invokes, safe inside ApplyT).
+			for k, v := range common.Sorted(all[envInputIdx].(map[string]string)) {
+				if secretVar := compose.GetConfigName2(k, &v); secretVar != "" && configProvider != nil {
+					ref, err := configProvider.GetSecretRef(ctx, secretVar, parentOpt)
+					if err != nil {
+						return "", fmt.Errorf("getting secret ref for %q: %w", k, err)
+					}
+					mainSecrets = append(mainSecrets, Secret{Name: k, ValueFrom: ref})
+					continue
+				}
+				envVars = append(envVars, KeyValuePair{Name: k, Value: v})
+			}
 		}
 		slices.SortFunc(envVars, func(a, b KeyValuePair) int {
 			return cmp.Compare(a.Name, b.Name)
@@ -662,15 +701,6 @@ func CreateECSService(
 			}
 		}
 		logConfiguration := logConfigurationFor(containerName)
-
-		// Merge ECS-native secrets from the Secrets input with the ones derived
-		// from bare ${VAR} environment references.
-		mainSecrets := append([]Secret{}, secretEntries...)
-		if secretsIdx >= 0 {
-			for name, valueFrom := range common.Sorted(all[secretsIdx].(map[string]string)) {
-				mainSecrets = append(mainSecrets, Secret{Name: name, ValueFrom: valueFrom})
-			}
-		}
 
 		// NOTE: dnsSearchDomains is NOT supported on Fargate with awsvpc network mode.
 		// Instead, we rewrite environment variables to use FQDNs at the provider level.
@@ -714,7 +744,7 @@ func CreateECSService(
 				EntryPoint:       sd.cfg.Entrypoint,
 				DependsOn:        buildDependsOn(sd.cfg.DependsOn, args.Sidecars),
 				HealthCheck:      buildHealthCheck(sd.cfg.HealthCheck),
-				Image:            *sd.cfg.Image,
+				Image:            all[sd.imageIdx].(string),
 				LogConfiguration: logConfigurationFor(scContainerName),
 				StopTimeout:      buildStopTimeout(sd.cfg),
 				WorkingDirectory: sd.cfg.WorkingDir,

--- a/provider/defangaws/aws/elasticache.go
+++ b/provider/defangaws/aws/elasticache.go
@@ -195,21 +195,15 @@ func CreateElasticache(
 		return nil, ErrRedisConfigNil
 	}
 
-	// Detect engine (redis vs valkey) from image name.
-	var engine string
+	// Detect engine (redis vs valkey) and version from the image name;
+	// default to "redis" when the image is unset or a dynamic Output.
+	engine := "redis"
+	var engineVersion string
 	if img := svc.StaticImage(); img != nil {
 		if strings.Contains(strings.ToLower(*img), "valkey") {
 			engine = "valkey"
-		} else {
-			engine = "redis"
 		}
-	}
-
-	// Parse version from image tag (e.g. "7.2" from "redis:7.2").
-	var engineVersion string
-	if img := svc.StaticImage(); img != nil {
-		parts := strings.Split(*img, ":")
-		if len(parts) == 2 {
+		if parts := strings.Split(*img, ":"); len(parts) == 2 {
 			engineVersion = parts[1]
 		}
 	}
@@ -298,7 +292,6 @@ func CreateElasticache(
 		AutoMinorVersionUpgrade:  pulumi.Bool(true),
 		Description:              pulumi.String(common.DefangComment),
 		Engine:                   pulumi.String(engine),
-		EngineVersion:            pulumi.String(engineVersion),
 		FinalSnapshotIdentifier:  finalSnapshotIdentifier,
 		MultiAzEnabled:           pulumi.Bool(replicas > 1),
 		NodeType:                 pulumi.String(nodeType),
@@ -308,6 +301,9 @@ func CreateElasticache(
 		SubnetGroupName:          subnetGroupName,
 		Tags:                     tags,
 		TransitEncryptionEnabled: pulumi.Bool(transitEncryption),
+	}
+	if engineVersion != "" {
+		rgArgs.EngineVersion = pulumi.String(engineVersion)
 	}
 	if replicas > 1 && deletionProtection {
 		rgArgs.ClusterMode = pulumi.String("compatible")

--- a/provider/defangaws/aws/elasticache.go
+++ b/provider/defangaws/aws/elasticache.go
@@ -197,8 +197,8 @@ func CreateElasticache(
 
 	// Detect engine (redis vs valkey) from image name.
 	var engine string
-	if svc.Image != nil {
-		if strings.Contains(strings.ToLower(*svc.Image), "valkey") {
+	if img := svc.StaticImage(); img != nil {
+		if strings.Contains(strings.ToLower(*img), "valkey") {
 			engine = "valkey"
 		} else {
 			engine = "redis"
@@ -207,8 +207,8 @@ func CreateElasticache(
 
 	// Parse version from image tag (e.g. "7.2" from "redis:7.2").
 	var engineVersion string
-	if svc.Image != nil {
-		parts := strings.Split(*svc.Image, ":")
+	if img := svc.StaticImage(); img != nil {
+		parts := strings.Split(*img, ":")
 		if len(parts) == 2 {
 			engineVersion = parts[1]
 		}

--- a/provider/defangaws/aws/iam.go
+++ b/provider/defangaws/aws/iam.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/iam"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -143,6 +144,29 @@ func attachPullThroughCachePolicy(
 		Policy: policyJson,
 	}, opts...)
 	return err
+}
+
+// resolvePolicyArn turns an x-defang-policies entry into a policy ARN. Full
+// ARNs pass through; bare names resolve to a customer-managed policy in the
+// caller's account (matches makeArn in defang-mvp: partition "aws", no region).
+func resolvePolicyArn(ctx *pulumi.Context, policy string) (pulumi.StringInput, error) {
+	if strings.HasPrefix(policy, "arn:") {
+		return pulumi.String(policy), nil
+	}
+	accountID, err := getCallerAccountId(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting caller account ID: %w", err)
+	}
+	return pulumi.String("arn:aws:iam::" + accountID + ":policy/" + policy), nil
+}
+
+// policyName returns the name segment of a policy ARN, or the input unchanged
+// if it's already a bare name. Used for stable child-resource names.
+func policyName(policy string) string {
+	if i := strings.LastIndexByte(policy, '/'); i >= 0 {
+		return policy[i+1:]
+	}
+	return policy
 }
 
 // createTaskRole creates a per-service ECS task role.

--- a/provider/defangaws/aws/iam.go
+++ b/provider/defangaws/aws/iam.go
@@ -149,11 +149,11 @@ func attachPullThroughCachePolicy(
 // resolvePolicyArn turns an x-defang-policies entry into a policy ARN. Full
 // ARNs pass through; bare names resolve to a customer-managed policy in the
 // caller's account (matches makeArn in defang-mvp: partition "aws", no region).
-func resolvePolicyArn(ctx *pulumi.Context, policy string) (pulumi.StringInput, error) {
+func resolvePolicyArn(ctx *pulumi.Context, policy string, opts ...pulumi.InvokeOption) (pulumi.StringInput, error) {
 	if strings.HasPrefix(policy, "arn:") {
 		return pulumi.String(policy), nil
 	}
-	accountID, err := getCallerAccountId(ctx)
+	accountID, err := getCallerAccountId(ctx, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("getting caller account ID: %w", err)
 	}

--- a/provider/defangaws/aws/iam_test.go
+++ b/provider/defangaws/aws/iam_test.go
@@ -1,0 +1,14 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPolicyName(t *testing.T) {
+	assert.Equal(t, "MyPolicy", policyName("MyPolicy"))
+	assert.Equal(t, "AmazonS3ReadOnlyAccess", policyName("arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"))
+	assert.Equal(t, "MyPolicy", policyName("arn:aws:iam::123456789012:policy/MyPolicy"))
+	assert.Equal(t, "MyPolicy", policyName("arn:aws:iam::123456789012:policy/path/MyPolicy"))
+}

--- a/provider/defangaws/aws/image.go
+++ b/provider/defangaws/aws/image.go
@@ -153,5 +153,5 @@ func GetServiceImage(
 	}
 
 	// Use pre-built image (either service.image or default)
-	return pulumi.String(*svc.Image).ToStringOutput(), nil
+	return svc.Image.ToStringOutput(), nil
 }

--- a/provider/defangaws/aws/infra.go
+++ b/provider/defangaws/aws/infra.go
@@ -16,7 +16,7 @@ import (
 
 // CreateProjectInfra creates shared AWS infrastructure for a multi-service project.
 //
-//nolint:funlen // sequential infra setup is clearer as one function
+//nolint:funlen,maintidx // sequential infra setup is clearer as one function
 func CreateProjectInfra(
 	ctx *pulumi.Context,
 	projectName string,
@@ -29,7 +29,7 @@ func CreateProjectInfra(
 		return nil, fmt.Errorf("getting AWS region: %w", err)
 	}
 
-	net, err := ResolveNetworking(ctx, projectName, opt)
+	net, err := ResolveNetworking(ctx, projectName, awsConfig, opt)
 	if err != nil {
 		return nil, fmt.Errorf("resolving networking: %w", err)
 	}
@@ -93,25 +93,47 @@ func CreateProjectInfra(
 		return nil, fmt.Errorf("attaching pull-through cache policy: %w", err)
 	}
 
+	// Role-assuming provider for public Route53 operations in another account
+	var dnsProvider pulumi.ProviderResource
+	if awsConfig != nil && awsConfig.DnsRoleArn != nil {
+		dnsProvider, err = aws.NewProvider(ctx, "route53", &aws.ProviderArgs{
+			Region: pulumi.String(region.Region), // required for STS
+			AssumeRoles: aws.ProviderAssumeRoleArray{
+				&aws.ProviderAssumeRoleArgs{
+					RoleArn: awsConfig.DnsRoleArn.ToStringOutput().ToStringPtrOutput(),
+				},
+			},
+		}, opt)
+		if err != nil {
+			return nil, fmt.Errorf("creating Route53 provider: %w", err)
+		}
+	}
+	dnsOpts := []pulumi.ResourceOption{opt}
+	if dnsProvider != nil {
+		dnsOpts = append(dnsOpts, pulumi.Provider(dnsProvider))
+	}
+
 	var projectDomain string
 	var albRes *AlbResult
 	if common.NeedIngress(services) {
 		var certArn pulumi.StringPtrInput
+		var domains []string
+		var publicZoneId pulumi.StringInput
 
-		// Create wildcard cert + DNS if a public zone is provided
+		// Create wildcard cert if a public zone is provided
 		if awsConfig != nil && awsConfig.PublicZoneId != nil && awsConfig.ProjectDomain != "" {
-			publicZoneId := awsConfig.PublicZoneId.ToStringPtrOutput().Elem() // TODO: look up?
+			publicZoneId = awsConfig.PublicZoneId.ToStringPtrOutput().Elem() // TODO: look up?
 			projectDomain = awsConfig.ProjectDomain
 
-			wildcardDomain := "*." + awsConfig.ProjectDomain
-			domains := []string{wildcardDomain}
+			domains = []string{"*." + projectDomain}
 			if CreateApexRecord.Get(ctx) {
-				domains = append(domains, awsConfig.ProjectDomain)
+				domains = append(domains, projectDomain)
 			}
 
 			certArn, err = CreateCertificateDNS(ctx, domains, CertificateDnsArgs{
-				CaaIssuer: []string{"amazon.com", "letsencrypt.org"}, // FIXME: only pick CAs that we need
-				ZoneId:    publicZoneId,
+				CaaIssuer:       []string{"amazon.com", "letsencrypt.org"}, // FIXME: only pick CAs that we need
+				ZoneId:          publicZoneId,
+				Route53Provider: dnsProvider,
 				Tags: pulumi.StringMap{
 					"defang:scope": pulumi.String("pub"),
 				},
@@ -119,34 +141,31 @@ func CreateProjectInfra(
 			if err != nil {
 				return nil, fmt.Errorf("creating certificate: %w", err)
 			}
+		} else if awsConfig != nil && awsConfig.AlbCertificateArn != nil {
+			// Caller-provided default certificate for the HTTPS listener
+			certArn = awsConfig.AlbCertificateArn.ToStringOutput().ToStringPtrOutput()
+		}
 
-			albRes, err = CreateALB(ctx, net.VpcID, net.PublicSubnetIDs, certArn, opt)
-			if err != nil {
-				return nil, fmt.Errorf("creating ALB: %w", err)
-			}
+		albRes, err = CreateALB(ctx, net.VpcID, net.PublicSubnetIDs, certArn, opt)
+		if err != nil {
+			return nil, fmt.Errorf("creating ALB: %w", err)
+		}
 
-			// Create ALIAS DNS records for the ALB
-			aliases := route53.RecordAliasArray{
-				&route53.RecordAliasArgs{
-					EvaluateTargetHealth: pulumi.Bool(true),
-					Name:                 albRes.Alb.DnsName,
-					ZoneId:               albRes.Alb.ZoneId,
-				},
-			}
-			for _, hostname := range domains {
-				_, err := CreateRecord(ctx, hostname, common.RecordTypeA, &route53.RecordArgs{
-					Aliases: aliases,
-					ZoneId:  publicZoneId,
-				}, opt)
-				if err != nil {
-					return nil, fmt.Errorf("creating DNS record for %s: %w", hostname, err)
-				}
-			}
-		} else {
-			// No public zone: HTTP-only ALB
-			albRes, err = CreateALB(ctx, net.VpcID, net.PublicSubnetIDs, nil, opt)
+		// Create ALIAS DNS records for the ALB
+		aliases := route53.RecordAliasArray{
+			&route53.RecordAliasArgs{
+				EvaluateTargetHealth: pulumi.Bool(true),
+				Name:                 albRes.Alb.DnsName,
+				ZoneId:               albRes.Alb.ZoneId,
+			},
+		}
+		for _, hostname := range domains {
+			_, err := CreateRecord(ctx, hostname, common.RecordTypeA, &route53.RecordArgs{
+				Aliases: aliases,
+				ZoneId:  publicZoneId,
+			}, dnsOpts...)
 			if err != nil {
-				return nil, fmt.Errorf("creating ALB: %w", err)
+				return nil, fmt.Errorf("creating DNS record for %s: %w", hostname, err)
 			}
 		}
 	}
@@ -170,6 +189,7 @@ func CreateProjectInfra(
 			route53SidecarPolicy: route53SidecarePolicy,
 		},
 		Cluster:          cluster,
+		DnsProvider:      dnsProvider,
 		ExecRole:         execRole,
 		LogGroup:         logGroup,
 		VpcID:            net.VpcID,

--- a/provider/defangaws/aws/lb.go
+++ b/provider/defangaws/aws/lb.go
@@ -119,7 +119,7 @@ func createTgLrPair(
 	ctx *pulumi.Context,
 	serviceName string,
 	vpcId pulumi.StringInput,
-	listener *lb.Listener,
+	listenerArn pulumi.StringInput,
 	port compose.ServicePortConfig,
 	healthCheck *compose.HealthCheckConfig,
 	endpoints []string,
@@ -136,7 +136,7 @@ func createTgLrPair(
 		return nil, nil, nil // skip
 	}
 
-	tgName := targetGroupName(serviceName, int(port.Target), appProto)
+	tgName := targetGroupName(serviceName, int(port.Target), appProto, port.Listener)
 
 	// Target group health check (matches TS createTargetGroup in lb.ts)
 	defaultInterval := HealthCheckInterval.Get(ctx)
@@ -246,7 +246,7 @@ func createTgLrPair(
 	}
 
 	lr, lrErr := lb.NewListenerRule(ctx, tgName+"-rule", &lb.ListenerRuleArgs{
-		ListenerArn: listener.Arn,
+		ListenerArn: listenerArn,
 		Actions: lb.ListenerRuleActionArray{
 			&lb.ListenerRuleActionArgs{
 				Type:           pulumi.String("forward"),

--- a/provider/defangaws/aws/naming.go
+++ b/provider/defangaws/aws/naming.go
@@ -12,10 +12,17 @@ const tgMaxNameLen = 32
 // targetGroupName builds a logical Pulumi resource name for a TargetGroup.
 // The physical name (with its 32-char AWS limit) is handled by autonaming config.
 // We keep the logical name short enough that autonaming stays within budget.
-func targetGroupName(service string, port int, appProtocol compose.PortAppProtocol) string {
+func targetGroupName(
+	service string, port int, appProtocol compose.PortAppProtocol, listener compose.PortListenerProtocol,
+) string {
 	suffix := fmt.Sprintf("-%d", port)
 	if appProtocol != "" && appProtocol != "http" {
 		suffix += string(appProtocol)
+	}
+	// HTTPS is the default listener, so only non-default listeners get a suffix
+	// (matches TS targetGroupName's listenerProtocol handling).
+	if listener != compose.PortListenerDefault && listener != compose.PortListenerHTTPS {
+		suffix += "-" + string(listener)
 	}
 
 	maxService := tgMaxNameLen - autonamingSuffixLen - len(suffix)

--- a/provider/defangaws/aws/networking.go
+++ b/provider/defangaws/aws/networking.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/DefangLabs/pulumi-defang/provider/common"
@@ -10,6 +11,8 @@ import (
 	awsxec2 "github.com/pulumi/pulumi-awsx/sdk/v3/go/awsx/ec2"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
+
+var errMissingPublicSubnets = errors.New("aws.publicSubnetIDs is required when adopting an existing VPC via aws.vpcID")
 
 type NetworkingResult struct {
 	VpcID            pulumi.StringOutput
@@ -21,36 +24,20 @@ type NetworkingResult struct {
 	UseNatGW         bool                     // whether to use NAT Gateways (vs. public subnets for outbound)
 }
 
-// ResolveNetworking creates a new VPC using awsx or uses provided VPC/subnet IDs.
+// ResolveNetworking creates a new VPC using awsx, or adopts the VPC/subnets
+// provided via AWSConfig. In both cases the project's private hosted zone is
+// created and attached to the VPC.
 func ResolveNetworking(
-	ctx *pulumi.Context, projectName string, opt pulumi.ResourceOrInvokeOption,
+	ctx *pulumi.Context, projectName string, cfg *AWSConfig, opt pulumi.ResourceOrInvokeOption,
 ) (*NetworkingResult, error) {
 	privateDomain := common.SafeLabel(projectName) + ".internal"
 
+	if cfg != nil && cfg.VpcID != nil {
+		return adoptVpc(ctx, privateDomain, cfg, opt)
+	}
+
 	strategy := awsxec2.NatGatewayStrategy(NatGatewayStrategy.Get(ctx)) // TODO: missing type checking
 	numberOfAZs := NumberOfAvailabilityZones.Get(ctx)
-
-	// if cfg != nil && cfg.VpcID != "" {
-	// 	// Use provided VPC and subnet IDs
-	// 	subnetIDs := make(pulumi.StringArray, len(cfg.PublicSubnetIDs))
-	// 	for i, id := range cfg.PublicSubnetIDs {
-	// 		subnetIDs[i] = pulumi.String(id)
-	// 	}
-	// 	privateSubnetIDs := make(pulumi.StringArray, len(cfg.PrivateSubnetIDs))
-	// 	for i, id := range cfg.PrivateSubnetIDs {
-	// 		privateSubnetIDs[i] = pulumi.String(id)
-	// 	}
-	// 	if len(privateSubnetIDs) == 0 {
-	// 		privateSubnetIDs = subnetIDs
-	// 	}
-	// 	return &NetworkingResult{
-	// 		VpcID:            pulumi.String(cfg.VpcID).ToStringOutput(),
-	// 		PublicSubnetIDs:  subnetIDs.ToStringArrayOutput(),
-	// 		PrivateSubnetIDs: privateSubnetIDs.ToStringArrayOutput(),
-	// 		UseNatGW:         strategy != awsxec2.NatGatewayStrategyNone,
-	// 		// PrivateZoneID:    pulumi.IDPtrOutput{},  no private hosted zone since we didn't create the VPC
-	// 	}, nil
-	// }
 
 	region, err := aws.GetRegion(ctx, nil, opt)
 	if err != nil {
@@ -101,26 +88,9 @@ func ResolveNetworking(
 		return nil, err
 	}
 
-	// TODO: make this optional, so we can save $$
-	privateZone, err := route53.NewZone(ctx, privateDomain, &route53.ZoneArgs{
-		Comment:      pulumi.String(common.DefangComment),
-		Name:         pulumi.String(privateDomain),
-		ForceDestroy: pulumi.Bool(ForceDestroyHostedzone.Get(ctx)),
-		Vpcs: route53.ZoneVpcArray{
-			route53.ZoneVpcArgs{VpcId: vpc.VpcId},
-		},
-	}, opt)
+	privateZone, err := createPrivateZone(ctx, privateDomain, vpc.VpcId, opt)
 	if err != nil {
-		return nil, fmt.Errorf("creating Route53 private hosted zone: %w", err)
-	}
-
-	// Lower the negative caching TTL to 15 seconds
-	_, err = createSoaRecord(ctx, privateDomain, privateZone.ToZoneOutput(), SoaRecordArgs{
-		Serial:  pulumi.Int(2023022101),
-		Minimum: pulumi.Int(15),
-	}, opt)
-	if err != nil {
-		return nil, fmt.Errorf("creating SOA record: %w", err)
+		return nil, err
 	}
 
 	options, err := ec2.NewVpcDhcpOptions(ctx, "dhcp-options", &ec2.VpcDhcpOptionsArgs{
@@ -156,4 +126,69 @@ func ResolveNetworking(
 		PublicNatIPs:     publicNatIps,
 		UseNatGW:         strategy != awsxec2.NatGatewayStrategyNone,
 	}, nil
+}
+
+// adoptVpc uses the caller-provided VPC and subnets instead of creating a VPC.
+// The project's private hosted zone is still created (managed Redis/Postgres
+// CNAMEs live there) and attached to the adopted VPC, but the VPC itself —
+// DHCP options, route tables, NAT — is left untouched. Private subnets, when
+// provided, are assumed to have outbound connectivity (NAT or equivalent);
+// when omitted, all workloads run in the public subnets with public IPs.
+func adoptVpc(
+	ctx *pulumi.Context, privateDomain string, cfg *AWSConfig, opt pulumi.ResourceOrInvokeOption,
+) (*NetworkingResult, error) {
+	if cfg.PublicSubnetIDs == nil {
+		return nil, errMissingPublicSubnets
+	}
+
+	privateZone, err := createPrivateZone(ctx, privateDomain, cfg.VpcID, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	privateSubnetIDs := cfg.PrivateSubnetIDs
+	useNatGW := privateSubnetIDs != nil
+	if privateSubnetIDs == nil {
+		privateSubnetIDs = cfg.PublicSubnetIDs
+	}
+
+	return &NetworkingResult{
+		VpcID:            cfg.VpcID.ToStringOutput(),
+		PublicSubnetIDs:  cfg.PublicSubnetIDs.ToStringArrayOutput(),
+		PrivateSubnetIDs: privateSubnetIDs.ToStringArrayOutput(),
+		PrivateDomain:    privateDomain,
+		PrivateZone:      privateZone,
+		PublicNatIPs:     pulumi.StringArray{}.ToStringArrayOutput(),
+		UseNatGW:         useNatGW,
+	}, nil
+}
+
+// createPrivateZone creates the project's Route53 private hosted zone attached
+// to the given VPC, with a low negative-caching TTL.
+func createPrivateZone(
+	ctx *pulumi.Context, privateDomain string, vpcID pulumi.StringInput, opt pulumi.ResourceOrInvokeOption,
+) (*route53.Zone, error) {
+	// TODO: make this optional, so we can save $$
+	privateZone, err := route53.NewZone(ctx, privateDomain, &route53.ZoneArgs{
+		Comment:      pulumi.String(common.DefangComment),
+		Name:         pulumi.String(privateDomain),
+		ForceDestroy: pulumi.Bool(ForceDestroyHostedzone.Get(ctx)),
+		Vpcs: route53.ZoneVpcArray{
+			route53.ZoneVpcArgs{VpcId: vpcID},
+		},
+	}, opt)
+	if err != nil {
+		return nil, fmt.Errorf("creating Route53 private hosted zone: %w", err)
+	}
+
+	// Lower the negative caching TTL to 15 seconds
+	_, err = createSoaRecord(ctx, privateDomain, privateZone.ToZoneOutput(), SoaRecordArgs{
+		Serial:  pulumi.Int(2023022101),
+		Minimum: pulumi.Int(15),
+	}, opt)
+	if err != nil {
+		return nil, fmt.Errorf("creating SOA record: %w", err)
+	}
+
+	return privateZone, nil
 }

--- a/provider/defangaws/postgres.go
+++ b/provider/defangaws/postgres.go
@@ -51,7 +51,7 @@ func (*Postgres) Construct(
 
 	svc := compose.ServiceConfig{
 		Postgres:    inputs.Postgres,
-		Image:       inputs.Image,
+		Image:       compose.ImageFromPtr(inputs.Image),
 		Deploy:      inputs.Deploy,
 		Environment: inputs.Environment,
 	}

--- a/provider/defangaws/postgres.go
+++ b/provider/defangaws/postgres.go
@@ -20,7 +20,7 @@ type PostgresInputs struct {
 	Postgres    *compose.PostgresConfig  `pulumi:"postgres,optional"`
 	Image       *string                  `pulumi:"image,optional"`
 	Deploy      *compose.DeployConfig    `pulumi:"deploy,optional"`
-	Environment map[string]*string       `pulumi:"environment,optional"`
+	Environment compose.Environment          `pulumi:"environment,optional"`
 	Infra       *provideraws.SharedInfra `pulumi:"aws,optional"`
 }
 

--- a/provider/defangaws/project.go
+++ b/provider/defangaws/project.go
@@ -11,7 +11,44 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
-var errDependencyNotFound = errors.New("service not found in dependencies map")
+var (
+	errDependencyNotFound     = errors.New("service not found in dependencies map")
+	errSidecarParentNotFound  = errors.New("sidecar parent service not found")
+	errSidecarParentIsSidecar = errors.New("sidecar parent is itself a sidecar")
+	errSidecarParentManaged   = errors.New("sidecar parent must be a container service, not managed Postgres/Redis")
+)
+
+// partitionSidecars splits services into standalone services and sidecar
+// groups. A service with network_mode "service:<name>" is folded into
+// <name>'s task definition as an additional container instead of being
+// deployed as its own ECS service.
+func partitionSidecars(
+	services compose.Services,
+) (compose.Services, map[string]map[string]compose.ServiceConfig, error) {
+	standalone := compose.Services{}
+	sidecars := map[string]map[string]compose.ServiceConfig{}
+	for name, svc := range services {
+		parent := svc.SidecarParent()
+		if parent == "" {
+			standalone[name] = svc
+			continue
+		}
+		parentSvc, ok := services[parent]
+		switch {
+		case !ok:
+			return nil, nil, fmt.Errorf("service %s: %w: %q", name, errSidecarParentNotFound, parent)
+		case parentSvc.SidecarParent() != "":
+			return nil, nil, fmt.Errorf("service %s: parent %q: %w", name, parent, errSidecarParentIsSidecar)
+		case parentSvc.Postgres != nil || parentSvc.Redis != nil:
+			return nil, nil, fmt.Errorf("service %s: parent %q: %w", name, parent, errSidecarParentManaged)
+		}
+		if sidecars[parent] == nil {
+			sidecars[parent] = map[string]compose.ServiceConfig{}
+		}
+		sidecars[parent][name] = svc
+	}
+	return standalone, sidecars, nil
+}
 
 // Project is the controller struct for the defang-aws:index:Project component.
 type Project struct{}
@@ -41,6 +78,23 @@ type ProjectOutputs struct {
 
 	// Load balancer DNS name (AWS ALB)
 	LoadBalancerDNS pulumix.Output[*string] `pulumi:"loadBalancerDns,optional"`
+
+	// Load balancer ARN, for attaching externally managed resources (e.g. a
+	// WAF web ACL). Unset when no service has ingress.
+	LoadBalancerArn pulumix.Output[*string] `pulumi:"loadBalancerArn,optional"`
+
+	// ECS cluster name, for externally managed alarms and dashboards.
+	ClusterName pulumix.Output[string] `pulumi:"clusterName"`
+
+	// CloudWatch log group name shared by all services.
+	LogGroupName pulumix.Output[string] `pulumi:"logGroupName"`
+
+	// ECS service names by compose service name (container services only).
+	ServiceNames pulumix.Output[map[string]string] `pulumi:"serviceNames"`
+
+	// Task role ARNs by compose service name (container services only), for
+	// resource-based policies (e.g. KMS key policies) that must name the role.
+	TaskRoleArns pulumix.Output[map[string]string] `pulumi:"taskRoleArns"`
 }
 
 // Construct implements the ComponentResource interface for Project.
@@ -60,15 +114,36 @@ func (*Project) Construct(
 
 	comp.Endpoints = pulumix.Output[map[string]string](result.Endpoints)
 	comp.LoadBalancerDNS = pulumix.Output[*string](result.LoadBalancerDNS)
+	comp.LoadBalancerArn = pulumix.Output[*string](result.LoadBalancerArn)
+	comp.ClusterName = pulumix.Output[string](result.ClusterName)
+	comp.LogGroupName = pulumix.Output[string](result.LogGroupName)
+	comp.ServiceNames = pulumix.Output[map[string]string](result.ServiceNames)
+	comp.TaskRoleArns = pulumix.Output[map[string]string](result.TaskRoleArns)
 
 	if err := ctx.RegisterResourceOutputs(comp, pulumi.Map{
 		"endpoints":       result.Endpoints,
 		"loadBalancerDns": result.LoadBalancerDNS,
+		"loadBalancerArn": result.LoadBalancerArn,
+		"clusterName":     result.ClusterName,
+		"logGroupName":    result.LogGroupName,
+		"serviceNames":    result.ServiceNames,
+		"taskRoleArns":    result.TaskRoleArns,
 	}); err != nil {
 		return nil, err
 	}
 
 	return comp, nil
+}
+
+// projectResult extends the cross-provider BuildResult with AWS-specific
+// infrastructure handles surfaced as Project outputs.
+type projectResult struct {
+	common.BuildResult
+	LoadBalancerArn pulumi.StringPtrOutput
+	ClusterName     pulumi.StringOutput
+	LogGroupName    pulumi.StringOutput
+	ServiceNames    pulumi.StringMapOutput
+	TaskRoleArns    pulumi.StringMapOutput
 }
 
 // buildProject creates all AWS resources for the project.
@@ -78,7 +153,7 @@ func buildProject(
 	projectName string,
 	args ProjectInputs,
 	parentOpt pulumi.ResourceOrInvokeOption,
-) (*common.BuildResult, error) {
+) (*projectResult, error) {
 	awsConfig := (*provideraws.AWSConfig)(args.AWS)
 	infra, err := provideraws.CreateProjectInfra(ctx, projectName, awsConfig, args.Services, parentOpt)
 	if err != nil {
@@ -87,12 +162,16 @@ func buildProject(
 	infra.Etag = args.Etag
 
 	albDNS := pulumix.Val[*string](nil).Untyped().(pulumi.StringPtrOutput)
+	albArn := pulumix.Val[*string](nil).Untyped().(pulumi.StringPtrOutput)
 	if infra.Alb != nil {
 		albDNS = infra.Alb.DnsName.ToStringPtrOutput()
+		albArn = infra.Alb.Arn.ToStringPtrOutput()
 	}
 
 	// Deploy each service, wrapped in a component resource for tree organization
 	endpoints := pulumi.StringMap{}
+	serviceNames := pulumi.StringMap{}
+	taskRoleArns := pulumi.StringMap{}
 	dependencies := map[string]pulumi.Resource{} // service name → dependency resource for dependees
 
 	var configProvider compose.ConfigProvider
@@ -102,10 +181,15 @@ func buildProject(
 		configProvider = provideraws.NewConfigProvider(projectName)
 	}
 
+	standalone, sidecars, err := partitionSidecars(args.Services)
+	if err != nil {
+		return nil, err
+	}
+
 	// Pre-compute which services need waitForSteadyState: true if any other
 	// service depends on them with condition: service_healthy (matches TS tenant_stack.ts)
 	waitForSteady := map[string]bool{}
-	for _, other := range args.Services {
+	for _, other := range standalone {
 		for dep, val := range other.DependsOn {
 			if val.Condition == "service_healthy" {
 				waitForSteady[dep] = true
@@ -113,13 +197,18 @@ func buildProject(
 		}
 	}
 
-	serviceNames := common.TopologicalSort(args.Services)
-	for _, svcName := range serviceNames {
-		svc := args.Services[svcName]
+	sortedNames := common.TopologicalSort(standalone)
+	for _, svcName := range sortedNames {
+		svc := standalone[svcName]
 
-		// Collect dependency resources from services this one depends on
+		// Collect dependency resources from services this one depends on;
+		// depends_on entries naming this service's own sidecars are handled
+		// as container dependencies inside the task definition.
 		var deps []pulumi.Resource
 		for dep, val := range svc.DependsOn {
+			if _, isOwnSidecar := sidecars[svcName][dep]; isOwnSidecar {
+				continue
+			}
 			if r, ok := dependencies[dep]; ok {
 				deps = append(deps, r)
 			} else if val.Required {
@@ -128,21 +217,32 @@ func buildProject(
 		}
 
 		waitForHealthy := waitForSteady[svcName]
-		endpoint, dependency, err := newService(
-			ctx, configProvider, svcName, svc, args.Networks, infra, waitForHealthy, deps, parentOpt)
+		endpoint, dependency, svcComp, err := newService(
+			ctx, configProvider, svcName, svc, args.Networks, infra, sidecars[svcName], waitForHealthy, deps, parentOpt)
 		if err != nil {
 			return nil, fmt.Errorf("building service %s: %w", svcName, err)
 		}
 
 		endpoints[svcName] = endpoint
+		if svcComp != nil {
+			serviceNames[svcName] = svcComp.ServiceName.Untyped().(pulumi.StringOutput)
+			taskRoleArns[svcName] = svcComp.TaskRoleArn.Untyped().(pulumi.StringOutput)
+		}
 		if dependency != nil {
 			dependencies[svcName] = dependency
 		}
 	}
 
-	return &common.BuildResult{
-		Endpoints:       endpoints.ToStringMapOutput(),
-		LoadBalancerDNS: albDNS,
+	return &projectResult{
+		BuildResult: common.BuildResult{
+			Endpoints:       endpoints.ToStringMapOutput(),
+			LoadBalancerDNS: albDNS,
+		},
+		LoadBalancerArn: albArn,
+		ClusterName:     infra.Cluster.Name,
+		LogGroupName:    infra.LogGroup.Name,
+		ServiceNames:    serviceNames.ToStringMapOutput(),
+		TaskRoleArns:    taskRoleArns.ToStringMapOutput(),
 	}, nil
 }
 
@@ -153,19 +253,21 @@ func newService(
 	svc compose.ServiceConfig,
 	networks compose.Networks,
 	infra *provideraws.SharedInfra,
+	sidecars map[string]compose.ServiceConfig,
 	waitForSteadyState bool,
 	deps []pulumi.Resource,
 	parentOpt pulumi.ResourceOrInvokeOption,
-) (pulumi.StringOutput, pulumi.Resource, error) {
+) (pulumi.StringOutput, pulumi.Resource, *ServiceOutputs, error) {
 	var endpoint pulumi.StringOutput
 	var dependency pulumi.Resource
+	var svcComp *ServiceOutputs
 	var err error
 	switch {
 	case svc.Postgres != nil:
 		// Managed Postgres → RDS
 		pgComp := &PostgresOutputs{}
 		if regErr := ctx.RegisterComponentResource(PostgresComponentType, svcName, pgComp, parentOpt); regErr != nil {
-			return pulumi.StringOutput{}, nil, fmt.Errorf("registering postgres component %s: %w", svcName, regErr)
+			return pulumi.StringOutput{}, nil, nil, fmt.Errorf("registering postgres component %s: %w", svcName, regErr)
 		}
 		if err = createPostgres(ctx, pgComp, configProvider, svcName, svc, infra, deps); err == nil {
 			endpoint = pgComp.Endpoint
@@ -175,31 +277,28 @@ func newService(
 		// Managed Redis → ElastiCache
 		redisComp := &RedisOutputs{}
 		if regErr := ctx.RegisterComponentResource(RedisComponentType, svcName, redisComp, parentOpt); regErr != nil {
-			return pulumi.StringOutput{}, nil, fmt.Errorf("registering redis component %s: %w", svcName, regErr)
+			return pulumi.StringOutput{}, nil, nil, fmt.Errorf("registering redis component %s: %w", svcName, regErr)
 		}
 		if err = createRedis(ctx, redisComp, svcName, svc, infra, deps); err == nil {
 			endpoint = redisComp.Endpoint
 			dependency = redisComp.Dependency
 		}
 	default:
-		// TODO: detect sidecar services (network_mode: "service:<name>", volumes_from)
-		// and add them as additional containers in the parent's task definition
-		// instead of creating a separate ECS service.
-
 		// Container service → ECS
-		svcComp := &ServiceOutputs{}
+		svcComp = &ServiceOutputs{}
 		if regErr := ctx.RegisterComponentResource(ServiceComponentType, svcName, svcComp, parentOpt); regErr != nil {
-			return pulumi.StringOutput{}, nil, fmt.Errorf("registering service component %s: %w", svcName, regErr)
+			return pulumi.StringOutput{}, nil, nil, fmt.Errorf("registering service component %s: %w", svcName, regErr)
 		}
 		imageURI, imgErr := provideraws.GetServiceImage(ctx, svcName, svc, infra.BuildInfra, pulumi.Parent(svcComp))
 		if imgErr != nil {
-			return pulumi.StringOutput{}, nil, fmt.Errorf("resolving image for %s: %w", svcName, imgErr)
+			return pulumi.StringOutput{}, nil, nil, fmt.Errorf("resolving image for %s: %w", svcName, imgErr)
 		}
 		args := &provideraws.ECSServiceArgs{
 			Infra:              infra,
 			ImageURI:           imageURI,
 			Networks:           networks,
 			WaitForSteadyState: waitForSteadyState,
+			Sidecars:           sidecars,
 		}
 		if err = createECSService(ctx, svcComp, configProvider, svcName, svc, args, deps); err == nil {
 			endpoint = pulumi.StringOutput(svcComp.Endpoint)
@@ -207,7 +306,7 @@ func newService(
 		}
 	}
 	if err != nil {
-		return pulumi.StringOutput{}, nil, err
+		return pulumi.StringOutput{}, nil, nil, err
 	}
-	return endpoint, dependency, nil
+	return endpoint, dependency, svcComp, nil
 }

--- a/provider/defangaws/project.go
+++ b/provider/defangaws/project.go
@@ -61,6 +61,11 @@ type ProjectInputs struct {
 
 	AWS *AWSConfig `pulumi:"aws,optional" yaml:"x-defang-aws,omitempty"`
 
+	// WaitForSteadyState makes every ECS service deployment wait until the
+	// service reaches a steady state (in addition to services other services
+	// depend on with condition: service_healthy, which always wait).
+	WaitForSteadyState bool `pulumi:"waitForSteadyState,optional" yaml:"waitForSteadyState,omitempty"`
+
 	// Etag is the deployment identifier supplied by the CD program; the
 	// provider injects it as a DEFANG_ETAG env var on every service container
 	// so application logs can be correlated with a specific deployment.
@@ -216,7 +221,7 @@ func buildProject(
 			}
 		}
 
-		waitForHealthy := waitForSteady[svcName]
+		waitForHealthy := waitForSteady[svcName] || args.WaitForSteadyState
 		endpoint, dependency, svcComp, err := newService(
 			ctx, configProvider, svcName, svc, args.Networks, infra, sidecars[svcName], waitForHealthy, deps, parentOpt)
 		if err != nil {

--- a/provider/defangaws/redis.go
+++ b/provider/defangaws/redis.go
@@ -21,7 +21,7 @@ type RedisInputs struct {
 	Image       *string                     `pulumi:"image,optional"`
 	Ports       []compose.ServicePortConfig `pulumi:"ports,optional"`
 	Deploy      *compose.DeployConfig       `pulumi:"deploy,optional"`
-	Environment map[string]*string          `pulumi:"environment,optional"`
+	Environment compose.Environment             `pulumi:"environment,optional"`
 	AWS         *provideraws.SharedInfra    `pulumi:"aws,optional"`
 }
 

--- a/provider/defangaws/redis.go
+++ b/provider/defangaws/redis.go
@@ -54,7 +54,7 @@ func (*Redis) Construct(
 
 	svc := compose.ServiceConfig{
 		Redis:       redis,
-		Image:       inputs.Image,
+		Image:       compose.ImageFromPtr(inputs.Image),
 		Ports:       inputs.Ports,
 		Deploy:      inputs.Deploy,
 		Environment: inputs.Environment,

--- a/provider/defangaws/service.go
+++ b/provider/defangaws/service.go
@@ -15,10 +15,10 @@ import (
 type Service struct{}
 
 // ServiceInputs defines the inputs for a standalone AWS ECS service.
-// Scalar fields use pulumi.String / *pulumi.String so the generated SDK
-// wraps them in pulumi.Input (matching the Node.js SDK behaviour).
 type ServiceInputs struct {
-	Image       string                      `pulumi:"image"`
+	// Image is the pre-built container image URI; it may be an Output of an
+	// image build (e.g. a Build resource or a caller-side pipeline).
+	Image       pulumi.StringInput          `pulumi:"image"`
 	Platform    *string                     `pulumi:"platform,optional"`
 	ProjectName string                      `pulumi:"projectName"`
 	Ports       []compose.ServicePortConfig `pulumi:"ports,optional"`
@@ -37,6 +37,10 @@ type ServiceInputs struct {
 	VolumesFrom     []string                      `pulumi:"volumesFrom,optional"`
 	DependsOn       compose.DependsOnConfig       `pulumi:"dependsOn,optional"`
 	Autoscaling     bool                          `pulumi:"autoscaling,optional"`
+	// Policies are extra IAM policies (full ARN or customer-managed policy
+	// name) attached to the task role created for this service. Cannot be
+	// combined with TaskRoleArn — the caller owns that role's policies.
+	Policies []string `pulumi:"policies,optional"`
 
 	// Sidecars are additional containers deployed in the same ECS task.
 	// volumesFrom / dependsOn may reference sidecar names.
@@ -87,11 +91,10 @@ func (*Service) Construct(
 	}
 
 	// Standalone Service is image-only — build belongs to Project.
-	if inputs.Image == "" {
+	if inputs.Image == nil {
 		return nil, fmt.Errorf("service %s: %w", name, common.ErrStandaloneServiceRequiresImage)
 	}
 	svc := compose.ServiceConfig{
-		Image:           &inputs.Image,
 		Platform:        inputs.Platform,
 		Ports:           inputs.Ports,
 		Deploy:          inputs.Deploy,
@@ -107,6 +110,7 @@ func (*Service) Construct(
 		VolumesFrom:     inputs.VolumesFrom,
 		DependsOn:       inputs.DependsOn,
 		Autoscaling:     inputs.Autoscaling,
+		Policies:        inputs.Policies,
 	}
 
 	var configProvider compose.ConfigProvider
@@ -116,11 +120,10 @@ func (*Service) Construct(
 		configProvider = provideraws.NewConfigProvider(inputs.ProjectName)
 	}
 	infra := inputs.AWS
-	imageURI := pulumi.String(inputs.Image).ToStringOutput()
 
 	args := &provideraws.ECSServiceArgs{
 		Infra:              infra,
-		ImageURI:           imageURI,
+		ImageURI:           inputs.Image,
 		WaitForSteadyState: inputs.WaitForSteadyState,
 		TaskRoleArn:        inputs.TaskRoleArn,
 		SecurityGroupIds:   inputs.SecurityGroupIds,

--- a/provider/defangaws/service.go
+++ b/provider/defangaws/service.go
@@ -23,7 +23,9 @@ type ServiceInputs struct {
 	ProjectName string                      `pulumi:"projectName"`
 	Ports       []compose.ServicePortConfig `pulumi:"ports,optional"`
 	Deploy      *compose.DeployConfig       `pulumi:"deploy,optional"`
-	Environment map[string]*string          `pulumi:"environment,optional"`
+	// Environment holds env vars; values may be Outputs. Bare ${VAR} values
+	// become ECS secret refs to defang config (SSM); others stay plaintext.
+	Environment pulumi.StringMapInput `pulumi:"environment,optional"`
 	Command     []string                    `pulumi:"command,optional"`
 	Entrypoint  []string                    `pulumi:"entrypoint,optional"`
 	HealthCheck *compose.HealthCheckConfig  `pulumi:"healthCheck,optional"`
@@ -98,7 +100,6 @@ func (*Service) Construct(
 		Platform:        inputs.Platform,
 		Ports:           inputs.Ports,
 		Deploy:          inputs.Deploy,
-		Environment:     inputs.Environment,
 		Command:         inputs.Command,
 		Entrypoint:      inputs.Entrypoint,
 		HealthCheck:     inputs.HealthCheck,
@@ -128,6 +129,7 @@ func (*Service) Construct(
 		TaskRoleArn:        inputs.TaskRoleArn,
 		SecurityGroupIds:   inputs.SecurityGroupIds,
 		Secrets:            inputs.Secrets,
+		Environment:        inputs.Environment,
 		Sidecars:           inputs.Sidecars,
 		Triggers:           inputs.Triggers,
 	}

--- a/provider/defangaws/service.go
+++ b/provider/defangaws/service.go
@@ -2,6 +2,7 @@ package defangaws
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/DefangLabs/pulumi-defang/provider/common"
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
@@ -28,6 +29,31 @@ type ServiceInputs struct {
 	HealthCheck *compose.HealthCheckConfig  `pulumi:"healthCheck,optional"`
 	DomainName  string                      `pulumi:"domainName,optional"`
 
+	// Compose-shaped container settings
+	ContainerName   *string                       `pulumi:"containerName,optional"`
+	WorkingDir      *string                       `pulumi:"workingDir,optional"`
+	StopGracePeriod *string                       `pulumi:"stopGracePeriod,optional"`
+	Volumes         []compose.ServiceVolumeConfig `pulumi:"volumes,optional"`
+	VolumesFrom     []string                      `pulumi:"volumesFrom,optional"`
+	DependsOn       compose.DependsOnConfig       `pulumi:"dependsOn,optional"`
+	Autoscaling     bool                          `pulumi:"autoscaling,optional"`
+
+	// Sidecars are additional containers deployed in the same ECS task.
+	// volumesFrom / dependsOn may reference sidecar names.
+	Sidecars map[string]compose.ServiceConfig `pulumi:"sidecars,optional"`
+	// Secrets maps container environment variable names to SSM parameter or
+	// Secrets Manager ARNs, injected via the ECS-native secrets mechanism.
+	Secrets pulumi.StringMapInput `pulumi:"secrets,optional"`
+	// TaskRoleArn reuses an existing IAM task role instead of creating one
+	// per service; its policies are owned by the caller.
+	TaskRoleArn pulumi.StringInput `pulumi:"taskRoleArn,optional"`
+	// SecurityGroupIds are extra security groups attached to the service's ENI.
+	SecurityGroupIds pulumi.StringArrayInput `pulumi:"securityGroupIds,optional"`
+	// Triggers force a service redeployment when any value changes.
+	Triggers pulumi.StringMapInput `pulumi:"triggers,optional"`
+	// WaitForSteadyState makes the deployment wait until the ECS service is stable.
+	WaitForSteadyState bool `pulumi:"waitForSteadyState,optional"`
+
 	AWS *provideraws.SharedInfra `pulumi:"aws,optional"`
 }
 
@@ -35,6 +61,14 @@ type ServiceInputs struct {
 type ServiceOutputs struct {
 	pulumi.ResourceState
 	Endpoint pulumix.Output[string] `pulumi:"endpoint"`
+	// ServiceName is the physical ECS service name — e.g. for wiring external
+	// autoscaling policies.
+	ServiceName pulumix.Output[string] `pulumi:"serviceName"`
+	// ClusterName is the ECS cluster name the service runs in.
+	ClusterName pulumix.Output[string] `pulumi:"clusterName"`
+	// TaskRoleArn is the ARN of the task role (created or caller-supplied) —
+	// e.g. for attaching extra IAM policies.
+	TaskRoleArn pulumix.Output[string] `pulumi:"taskRoleArn"`
 	// Dependency is an internal-only handle (the ECS service) used by downstream
 	// services for ordering. Untagged — not part of the SDK schema.
 	Dependency pulumi.Resource
@@ -57,15 +91,22 @@ func (*Service) Construct(
 		return nil, fmt.Errorf("service %s: %w", name, common.ErrStandaloneServiceRequiresImage)
 	}
 	svc := compose.ServiceConfig{
-		Image:       &inputs.Image,
-		Platform:    inputs.Platform,
-		Ports:       inputs.Ports,
-		Deploy:      inputs.Deploy,
-		Environment: inputs.Environment,
-		Command:     inputs.Command,
-		Entrypoint:  inputs.Entrypoint,
-		HealthCheck: inputs.HealthCheck,
-		DomainName:  inputs.DomainName,
+		Image:           &inputs.Image,
+		Platform:        inputs.Platform,
+		Ports:           inputs.Ports,
+		Deploy:          inputs.Deploy,
+		Environment:     inputs.Environment,
+		Command:         inputs.Command,
+		Entrypoint:      inputs.Entrypoint,
+		HealthCheck:     inputs.HealthCheck,
+		DomainName:      inputs.DomainName,
+		ContainerName:   inputs.ContainerName,
+		WorkingDir:      inputs.WorkingDir,
+		StopGracePeriod: inputs.StopGracePeriod,
+		Volumes:         inputs.Volumes,
+		VolumesFrom:     inputs.VolumesFrom,
+		DependsOn:       inputs.DependsOn,
+		Autoscaling:     inputs.Autoscaling,
 	}
 
 	var configProvider compose.ConfigProvider
@@ -78,8 +119,14 @@ func (*Service) Construct(
 	imageURI := pulumi.String(inputs.Image).ToStringOutput()
 
 	args := &provideraws.ECSServiceArgs{
-		Infra:    infra,
-		ImageURI: imageURI,
+		Infra:              infra,
+		ImageURI:           imageURI,
+		WaitForSteadyState: inputs.WaitForSteadyState,
+		TaskRoleArn:        inputs.TaskRoleArn,
+		SecurityGroupIds:   inputs.SecurityGroupIds,
+		Secrets:            inputs.Secrets,
+		Sidecars:           inputs.Sidecars,
+		Triggers:           inputs.Triggers,
 	}
 	if err := createECSService(ctx, comp, configProvider, name, svc, args, nil); err != nil {
 		return nil, err
@@ -110,7 +157,22 @@ func createECSService(
 	comp.Endpoint = pulumix.Output[string](endpoint)
 	comp.Dependency = ecsResult.Service
 
-	if err := ctx.RegisterResourceOutputs(comp, pulumi.Map{"endpoint": endpoint}); err != nil {
+	ecsServiceName := ecsResult.Service.Name
+	clusterName := ecsResult.Service.Cluster.ApplyT(func(arn string) string {
+		// arn:aws:ecs:region:account:cluster/NAME → NAME
+		return arn[strings.LastIndexByte(arn, '/')+1:]
+	}).(pulumi.StringOutput)
+	taskRoleArn := ecsResult.TaskRoleArn.ToStringOutput()
+	comp.ServiceName = pulumix.Output[string](ecsServiceName)
+	comp.ClusterName = pulumix.Output[string](clusterName)
+	comp.TaskRoleArn = pulumix.Output[string](taskRoleArn)
+
+	if err := ctx.RegisterResourceOutputs(comp, pulumi.Map{
+		"endpoint":    endpoint,
+		"serviceName": ecsServiceName,
+		"clusterName": clusterName,
+		"taskRoleArn": taskRoleArn,
+	}); err != nil {
 		return fmt.Errorf("registering outputs for %s: %w", serviceName, err)
 	}
 	return nil

--- a/provider/defangazure/azure/containerapp.go
+++ b/provider/defangazure/azure/containerapp.go
@@ -190,14 +190,14 @@ func buildEnvVars(
 				Name:      pulumi.String(k),
 				SecretRef: pulumi.String(appSecretName),
 			})
-		} else {
-			// v is guaranteed non-nil here: GetConfigName2(k, nil) returns k,
+		} else if sv, static := compose.StaticEnvValue(v); static {
+			// sv is guaranteed non-nil here: GetConfigName2(k, nil) returns k,
 			// which took the secret-ref branch above when a ConfigProvider is
-			// available. The only way to land here with nil v is
+			// available. The only way to land here with nil sv is
 			// ConfigProvider == nil — treat as empty literal.
 			var raw string
-			if v != nil {
-				raw = *v
+			if sv != nil {
+				raw = *sv
 			}
 			var value pulumi.StringInput
 			if ep, ok := redisURLEndpoint(raw, serviceEndpoints); ok {
@@ -214,6 +214,13 @@ func buildEnvVars(
 			envs = append(envs, app.EnvironmentVarArgs{
 				Name:  pulumi.String(k),
 				Value: value,
+			})
+		} else {
+			// Dynamic (Output) values pass through as-is; endpoint substitution
+			// and interpolation only apply to static text.
+			envs = append(envs, app.EnvironmentVarArgs{
+				Name:  pulumi.String(k),
+				Value: v,
 			})
 		}
 	}

--- a/provider/defangazure/azure/containerapp_test.go
+++ b/provider/defangazure/azure/containerapp_test.go
@@ -3,7 +3,6 @@ package azure
 import (
 	"testing"
 
-	"github.com/DefangLabs/pulumi-defang/provider/common"
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
 	"github.com/pulumi/pulumi-azure-native-sdk/app/v3"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -50,11 +49,11 @@ func TestBuildEnvVarsEmitsSecretRefs(t *testing.T) {
 			KeyVaultIdentityID: pulumi.String(identityID).ToStringPtrOutput(),
 		}
 		svc := compose.ServiceConfig{
-			Environment: map[string]*string{
-				"LITERAL": common.Ptr("plain-value"),
-				"SECRET":  common.Ptr("${CONFIG}"),             // bare ref → secret entry + SecretRef
-				"OTHER":   common.Ptr("${CONFIG}"),             // same secret, second env var → shared entry
-				"MIXED":   common.Ptr("prefix${CONFIG}suffix"), // not bare → plain Value, no Secret entry
+			Environment: compose.Environment{
+				"LITERAL": pulumi.String("plain-value"),
+				"SECRET":  pulumi.String("${CONFIG}"),             // bare ref → secret entry + SecretRef
+				"OTHER":   pulumi.String("${CONFIG}"),             // same secret, second env var → shared entry
+				"MIXED":   pulumi.String("prefix${CONFIG}suffix"), // not bare → plain Value, no Secret entry
 			},
 		}
 

--- a/provider/defangazure/azure/image.go
+++ b/provider/defangazure/azure/image.go
@@ -233,5 +233,5 @@ func GetServiceImage(
 		return pulumi.StringOutput{}, fmt.Errorf("service %s: %w", serviceName, ErrNoImageOrBuildConfig)
 	}
 
-	return pulumi.String(*svc.Image).ToStringOutput(), nil
+	return svc.Image.ToStringOutput(), nil
 }

--- a/provider/defangazure/postgres.go
+++ b/provider/defangazure/postgres.go
@@ -38,7 +38,7 @@ func (*Postgres) Construct(
 
 	childOpt := pulumi.Parent(comp)
 	svc := compose.ServiceConfig{
-		Image:       inputs.Image,
+		Image:       compose.ImageFromPtr(inputs.Image),
 		Postgres:    inputs.Postgres,
 		Deploy:      inputs.Deploy,
 		Environment: inputs.Environment,

--- a/provider/defangazure/postgres.go
+++ b/provider/defangazure/postgres.go
@@ -18,7 +18,7 @@ type AzurePostgresInputs struct {
 	Image       *string                 `pulumi:"image,optional"`
 	Postgres    *compose.PostgresConfig `pulumi:"postgres,optional"`
 	Deploy      *compose.DeployConfig   `pulumi:"deploy,optional"`
-	Environment map[string]*string      `pulumi:"environment,optional"`
+	Environment compose.Environment         `pulumi:"environment,optional"`
 }
 
 // AzurePostgresOutputs holds the outputs of an Postgres component.

--- a/provider/defangazure/project.go
+++ b/provider/defangazure/project.go
@@ -534,8 +534,8 @@ func (*Project) Construct(
 func llmModelAlias(svcName string, services compose.Services) string {
 	envKey := strings.ToUpper(svcName) + "_MODEL"
 	for _, svc := range services {
-		if v, ok := svc.Environment[envKey]; ok && v != nil && *v != "" {
-			return *v
+		if sv, _ := compose.StaticEnvValue(svc.Environment[envKey]); sv != nil && *sv != "" {
+			return *sv
 		}
 	}
 	return svcName // fallback: use service name as deployment name

--- a/provider/defangazure/redis.go
+++ b/provider/defangazure/redis.go
@@ -44,7 +44,7 @@ func (*Redis) Construct(
 	}
 
 	svc := compose.ServiceConfig{
-		Image:       inputs.Image,
+		Image:       compose.ImageFromPtr(inputs.Image),
 		Redis:       redis,
 		Deploy:      inputs.Deploy,
 		Environment: inputs.Environment,

--- a/provider/defangazure/redis.go
+++ b/provider/defangazure/redis.go
@@ -18,7 +18,7 @@ type AzureRedisInputs struct {
 	Image       *string               `pulumi:"image,optional"`
 	Redis       *compose.RedisConfig  `pulumi:"redis,optional"`
 	Deploy      *compose.DeployConfig `pulumi:"deploy,optional"`
-	Environment map[string]*string    `pulumi:"environment,optional"`
+	Environment compose.Environment       `pulumi:"environment,optional"`
 }
 
 // AzureRedisOutputs holds the outputs of an Azure Redis component.

--- a/provider/defangazure/service.go
+++ b/provider/defangazure/service.go
@@ -1,6 +1,7 @@
 package defangazure
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/DefangLabs/pulumi-defang/provider/common"
@@ -10,6 +11,8 @@ import (
 	"github.com/pulumi/pulumi-azure-native-sdk/resources/v3"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
+
+var errPoliciesUnsupported = errors.New("x-defang-policies is not supported on Azure")
 
 // Service is the controller struct for the defang-azure:index:Service component.
 type Service struct{}
@@ -23,7 +26,9 @@ type Service struct{}
 // inputs added in feat/defang-on-defang-inputs. Deferred until there is a
 // concrete consumer — see CLAUDE.md § Compose-shape parity across providers.
 type ServiceInputs struct {
-	Image       string                      `pulumi:"image"`
+	// Image is the pre-built container image URI; it may be an Output of an
+	// image build (e.g. a Build resource or a caller-side pipeline).
+	Image       pulumi.StringInput          `pulumi:"image"`
 	Platform    *string                     `pulumi:"platform,optional"`
 	ProjectName string                      `pulumi:"projectName,optional"`
 	Ports       []compose.ServicePortConfig `pulumi:"ports,optional"`
@@ -62,11 +67,10 @@ func (*Service) Construct(
 	}
 
 	// Standalone Service is image-only — build belongs to Project.
-	if inputs.Image == "" {
+	if inputs.Image == nil {
 		return nil, fmt.Errorf("service %s: %w", name, common.ErrStandaloneServiceRequiresImage)
 	}
 	svc := compose.ServiceConfig{
-		Image:       &inputs.Image,
 		Platform:    inputs.Platform,
 		Ports:       inputs.Ports,
 		Deploy:      inputs.Deploy,
@@ -89,8 +93,7 @@ func (*Service) Construct(
 		}
 	}
 
-	imageURI := pulumi.String(inputs.Image).ToStringOutput()
-	if err := createContainerApp(ctx, comp, name, svc, infra, imageURI, nil, nil); err != nil {
+	if err := createContainerApp(ctx, comp, name, svc, infra, inputs.Image, nil, nil); err != nil {
 		return nil, err
 	}
 	return comp, nil
@@ -130,6 +133,9 @@ func createContainerApp(
 	managedEndpoints map[string]pulumi.StringOutput,
 	serviceHosts map[string]pulumi.StringOutput,
 ) error {
+	if len(svc.Policies) > 0 {
+		return fmt.Errorf("service %s: %w", serviceName, errPoliciesUnsupported)
+	}
 	caResult, err := azure.CreateContainerApp(
 		ctx, serviceName, svc, infra, imageURI, managedEndpoints, serviceHosts, pulumi.Parent(comp),
 	)

--- a/provider/defangazure/service.go
+++ b/provider/defangazure/service.go
@@ -17,6 +17,11 @@ type Service struct{}
 // ServiceInputs defines the inputs for a standalone Azure Container App.
 // Build-from-source is deliberately unsupported — images must be pre-built and supplied
 // via Image. Build orchestration belongs to the Project component.
+//
+// TODO(azure-parity): mirror the AWS/GCP compose-shape / sidecars / triggers /
+// taskRoleArn / secrets / securityGroupIds / waitForSteadyState / autoscaling
+// inputs added in feat/defang-on-defang-inputs. Deferred until there is a
+// concrete consumer — see CLAUDE.md § Compose-shape parity across providers.
 type ServiceInputs struct {
 	Image       string                      `pulumi:"image"`
 	Platform    *string                     `pulumi:"platform,optional"`

--- a/provider/defangazure/service.go
+++ b/provider/defangazure/service.go
@@ -33,7 +33,7 @@ type ServiceInputs struct {
 	ProjectName string                      `pulumi:"projectName,optional"`
 	Ports       []compose.ServicePortConfig `pulumi:"ports,optional"`
 	Deploy      *compose.DeployConfig       `pulumi:"deploy,optional"`
-	Environment map[string]*string          `pulumi:"environment,optional"`
+	Environment compose.Environment             `pulumi:"environment,optional"`
 	Command     []string                    `pulumi:"command,optional"`
 	Entrypoint  []string                    `pulumi:"entrypoint,optional"`
 	HealthCheck *compose.HealthCheckConfig  `pulumi:"healthCheck,optional"`

--- a/provider/defanggcp/gcp/artifact_registry.go
+++ b/provider/defanggcp/gcp/artifact_registry.go
@@ -42,10 +42,11 @@ func collectExternalRegistries(services map[string]compose.ServiceConfig) []stri
 	seen := map[string]bool{}
 	var result []string
 	for _, svc := range services {
-		if svc.Image == nil || svc.Build != nil {
+		img := svc.StaticImage()
+		if img == nil || svc.Build != nil {
 			continue
 		}
-		info := common.ParseImage(*svc.Image)
+		info := common.ParseImage(*img)
 		if info.Registry != "" && !isCloudRunSupportedRegistry(info.Registry) && !seen[info.Registry] {
 			seen[info.Registry] = true
 			result = append(result, info.Registry)

--- a/provider/defanggcp/gcp/cloudrun.go
+++ b/provider/defanggcp/gcp/cloudrun.go
@@ -7,7 +7,6 @@ import (
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/cloudrunv2"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/secretmanager"
-	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/serviceaccount"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -39,7 +38,7 @@ func CreateCloudRunService(
 	serviceName string,
 	image pulumi.StringInput,
 	svc compose.ServiceConfig,
-	sa *serviceaccount.Account,
+	sa *ServiceIdentity,
 	gcpConfig *SharedInfra,
 	parentOpt pulumi.ResourceOrInvokeOption,
 ) (*CloudRunResult, error) {
@@ -48,14 +47,12 @@ func CreateCloudRunService(
 	// Grant the service account access to each referenced secret
 	iamDeps := make([]pulumi.Resource, 0, len(secretIds))
 	for _, sid := range secretIds {
+		opts := append([]pulumi.ResourceOption{parentOpt}, sa.deleteOpts()...)
 		member, err := secretmanager.NewSecretIamMember(ctx, serviceName+"-secret-"+sid, &secretmanager.SecretIamMemberArgs{
 			SecretId: pulumi.String(sid),
 			Role:     pulumi.String("roles/secretmanager.secretAccessor"),
 			Member:   pulumi.Sprintf("serviceAccount:%v", sa.Email),
-		}, parentOpt,
-			pulumi.DeletedWith(sa),
-			pulumi.DeleteBeforeReplace(true),
-		)
+		}, opts...)
 		if err != nil {
 			return nil, fmt.Errorf("granting secret access for %s: %w", sid, err)
 		}
@@ -159,7 +156,7 @@ func buildTemplate(
 	serviceName string,
 	image pulumi.StringInput,
 	svc compose.ServiceConfig,
-	sa *serviceaccount.Account,
+	sa *ServiceIdentity,
 	gcpConfig *SharedInfra,
 	opts ...pulumi.InvokeOption,
 ) (*cloudrunv2.ServiceTemplateArgs, []string) {
@@ -236,7 +233,7 @@ func buildTemplate(
 			},
 		},
 		MaxInstanceRequestConcurrency: pulumi.Int(80),
-		ServiceAccount:                sa.Email,
+		ServiceAccount:                sa.Email.ToStringOutput(),
 		Scaling: &cloudrunv2.ServiceTemplateScalingArgs{
 			MaxInstanceCount: pulumi.Int(maxInstances),
 		},

--- a/provider/defanggcp/gcp/cloudrun.go
+++ b/provider/defanggcp/gcp/cloudrun.go
@@ -130,18 +130,25 @@ func buildEnvVars(
 				seenSecretIds[secretId] = struct{}{}
 				secretIds = append(secretIds, secretId)
 			}
-		} else {
-			// v is guaranteed non-nil here: GetConfigName2(k, nil) returns k,
+		} else if sv, static := compose.StaticEnvValue(v); static {
+			// sv is guaranteed non-nil here: GetConfigName2(k, nil) returns k,
 			// which would have taken the secret-ref branch above when a
 			// configProvider is available.
 			var raw string
-			if v != nil {
-				raw = *v
+			if sv != nil {
+				raw = *sv
 			}
 			value := compose.InterpolateEnvironmentVariable(ctx, configProvider, raw, opts...)
 			envs = append(envs, &cloudrunv2.ServiceTemplateContainerEnvArgs{
 				Name:  pulumi.String(k),
 				Value: value,
+			})
+		} else {
+			// Dynamic (Output) values pass through as-is; interpolation and
+			// secret detection only apply to static text.
+			envs = append(envs, &cloudrunv2.ServiceTemplateContainerEnvArgs{
+				Name:  pulumi.String(k),
+				Value: v.ToStringOutput(),
 			})
 		}
 	}

--- a/provider/defanggcp/gcp/cloudsql.go
+++ b/provider/defanggcp/gcp/cloudsql.go
@@ -150,10 +150,11 @@ func CreateCloudSQL(
 	}
 
 	// Create user only if a password is explicitly provided as a literal.
-	// A nil *string (YAML "POSTGRES_PASSWORD:" with no value) means "resolve
-	// at runtime from config" — at this point we can't tell if a password
-	// exists, so skip custom user creation and let the default path handle it.
-	if pw := svc.Environment["POSTGRES_PASSWORD"]; pw != nil && *pw != "" {
+	// A nil value (YAML "POSTGRES_PASSWORD:" with no value) means "resolve
+	// at runtime from config", and a dynamic (Output) value can't be inspected
+	// here — in both cases skip custom user creation and let the default path
+	// handle it.
+	if pw, _ := compose.StaticEnvValue(svc.Environment["POSTGRES_PASSWORD"]); pw != nil && *pw != "" {
 		_, err := sql.NewUser(ctx, serviceName+"-user", &sql.UserArgs{
 			Name:           pg.Username,
 			Instance:       instance.Name,
@@ -167,9 +168,10 @@ func CreateCloudSQL(
 	}
 
 	// Create database only if explicitly set to a non-default literal name.
-	// Same rationale as POSTGRES_PASSWORD above: nil (*string zero) is "resolve
+	// Same rationale as POSTGRES_PASSWORD above: nil or dynamic is "resolve
 	// at runtime", which we treat as "no custom DB requested" for scheduling.
-	if rawDB := svc.Environment["POSTGRES_DB"]; rawDB != nil && *rawDB != "" && *rawDB != compose.DEFAULT_POSTGRES_DB {
+	rawDB, _ := compose.StaticEnvValue(svc.Environment["POSTGRES_DB"])
+	if rawDB != nil && *rawDB != "" && *rawDB != compose.DEFAULT_POSTGRES_DB {
 		_, err := sql.NewDatabase(ctx, serviceName+"-db", &sql.DatabaseArgs{
 			Name:           pg.DBName,
 			Instance:       instance.Name,

--- a/provider/defanggcp/gcp/compute.go
+++ b/provider/defanggcp/gcp/compute.go
@@ -472,24 +472,33 @@ func dockerRunFlags(
 }
 
 // flattenEnvFlags renders `-e "K=V"` docker flags for the given static env
-// pairs followed by the service's compose environment.
-func flattenEnvFlags(staticEnv [][2]string, env map[string]*string) string {
-	var envFlags strings.Builder
+// pairs followed by the service's compose environment. Dynamic (Output)
+// values are threaded through a Sprintf so they resolve at apply time.
+func flattenEnvFlags(staticEnv [][2]string, env compose.Environment) pulumi.StringInput {
+	var format strings.Builder
+	var args []any
 	for _, kv := range staticEnv {
-		fmt.Fprintf(&envFlags, "-e %q ", fmt.Sprintf("%s=%s", kv[0], kv[1]))
+		format.WriteString(escapePercent(fmt.Sprintf("-e %q ", kv[0]+"="+kv[1])))
 	}
 	for k, v := range common.Sorted(env) {
-		// Compute/VM deploys embed concrete values into the `docker run -e` cmd
-		// string — no runtime config-provider resolution is available here, so
-		// a nil *string (YAML "KEY:" with no value) flattens to an empty value.
-		var val string
-		if v != nil {
-			val = *v
+		if sv, static := compose.StaticEnvValue(v); static {
+			// Compute/VM deploys embed concrete values into the `docker run -e`
+			// cmd string — no runtime config-provider resolution is available
+			// here, so a nil value (YAML "KEY:" with no value) flattens to an
+			// empty value.
+			var val string
+			if sv != nil {
+				val = *sv
+			}
+			// FIXME: provide all environment (and secrets) as env instead of flattening into the command line.
+			format.WriteString(escapePercent(fmt.Sprintf("-e %q ", k+"="+val)))
+		} else {
+			fmt.Fprintf(&format, "-e \"%s=%%s\" ", escapePercent(k))
+			args = append(args, v)
 		}
-		// FIXME: provide all environment (and secrets) as env instead of flattening into the command line.
-		fmt.Fprintf(&envFlags, "-e %q ", fmt.Sprintf("%s=%s", k, val))
 	}
-	return envFlags.String()
+	// Always go through Sprintf: the static text above was %%-escaped for it.
+	return pulumi.Sprintf(format.String(), args...)
 }
 
 // stopGraceSeconds returns the docker stop timeout for a service, defaulting
@@ -547,17 +556,21 @@ func getCloudInitConfig(
 		"systemctl restart docker",
 	)
 
-	var extraUnits strings.Builder
+	var extraUnitsFmt strings.Builder
+	var extraUnitsArgs []any
 	if addHealthCheckSidecar {
 		var hcUnits string
 		hcUnits, runcmds = buildHealthCheckUnits(serviceName, containerName, runcmds)
-		extraUnits.WriteString(hcUnits)
+		extraUnitsFmt.WriteString("%s")
+		extraUnitsArgs = append(extraUnitsArgs, hcUnits)
 	}
 	for name, sc := range common.Sorted(sidecars) {
-		var unitText string
+		var unitText pulumi.StringInput
 		unitText, runcmds = buildSidecarUnit(serviceName, name, region, sc, sidecars, runcmds)
-		extraUnits.WriteString(unitText)
+		extraUnitsFmt.WriteString("%s")
+		extraUnitsArgs = append(extraUnitsArgs, unitText)
 	}
+	extraUnits := pulumi.Sprintf(extraUnitsFmt.String(), extraUnitsArgs...)
 
 	runcmds = append(runcmds,
 		fmt.Sprintf("systemctl enable %s.service", serviceName),
@@ -578,35 +591,34 @@ func getCloudInitConfig(
       RestartSec=30
       Environment="HOME=/home/container-user"
       ExecStartPre=/usr/bin/docker-credential-gcr configure-docker --registries %[5]s-docker.pkg.dev
-      ExecStart=/usr/bin/docker run --pull=always --rm --name=%[9]s %[3]s %[6]s%%s %[4]s
-      ExecStop=/usr/bin/docker stop -t %[8]d %[9]s
+      ExecStart=/usr/bin/docker run --pull=always --rm --name=%[7]s %[3]s %%s%%s %[4]s
+      ExecStop=/usr/bin/docker stop -t %[6]d %[7]s
       StandardOutput=journal+console
       StandardError=journal+console
 
       [Install]
       WantedBy=multi-user.target
-%[7]s
+%%s
 runcmd:
-  - %[10]s
+  - %[8]s
 `,
 		serviceName,
 		escapePercent(dependencies.String()),
 		escapePercent(strings.Join(params, " ")),
 		escapePercent(strings.Join(command, " ")),
 		region,
-		escapePercent(envFlags),
-		escapePercent(extraUnits.String()),
 		stopGraceSeconds(svc),
 		containerName,
 		escapePercent(strings.Join(runcmds, "\n  - ")))
 
-	// buf now contains exactly one %s (the escaped image placeholder from the
-	// format string above); all other dynamic text had its '%' doubled.
-	return pulumi.Sprintf(buf.String(), image)
+	// buf now contains exactly three %s placeholders (env flags, image, and
+	// extra units — the Inputs that may resolve at apply time); all other
+	// dynamic text had its '%' doubled.
+	return pulumi.Sprintf(buf.String(), envFlags, image, extraUnits)
 }
 
 // escapePercent doubles '%' so text survives the final pulumi.Sprintf pass
-// (which only substitutes the main image via %s).
+// (which only substitutes the env flags, main image, and extra units via %s).
 func escapePercent(s string) string {
 	return strings.ReplaceAll(s, "%", "%%")
 }
@@ -624,7 +636,7 @@ func buildSidecarUnit(
 	sc compose.ServiceConfig,
 	sidecars map[string]compose.ServiceConfig,
 	runcmds []string,
-) (string, []string) {
+) (pulumi.StringInput, []string) {
 	unit := sidecarUnitName(serviceName, sidecarName)
 	containerName := sc.GetContainerName(sidecarName)
 	params, command := dockerRunFlags(sc, sidecars)
@@ -642,7 +654,7 @@ func buildSidecarUnit(
 			stopGraceSeconds(sc), containerName)
 	}
 
-	units := fmt.Sprintf(`
+	units := pulumi.Sprintf(`
   - path: /etc/systemd/system/%[1]s.service
     permissions: "0644"
     owner: root

--- a/provider/defanggcp/gcp/compute.go
+++ b/provider/defanggcp/gcp/compute.go
@@ -629,6 +629,10 @@ func buildSidecarUnit(
 	containerName := sc.GetContainerName(sidecarName)
 	params, command := dockerRunFlags(sc, sidecars)
 	envFlags := flattenEnvFlags(nil, sc.Environment)
+	sidecarImage := "" // validated static & non-empty in createService
+	if img := sc.StaticImage(); img != nil {
+		sidecarImage = *img
+	}
 
 	var serviceSection string
 	if sc.Restart == "no" {
@@ -669,7 +673,7 @@ func buildSidecarUnit(
 		containerName,
 		strings.Join(params, " "),
 		envFlags,
-		*sc.Image,
+		sidecarImage,
 		strings.Join(command, " "))
 
 	runcmds = append(runcmds,

--- a/provider/defanggcp/gcp/compute.go
+++ b/provider/defanggcp/gcp/compute.go
@@ -9,13 +9,25 @@ import (
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/compute"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/projects"
-	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/serviceaccount"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 // ComputeEngineResult holds the output of CreateComputeEngine.
 type ComputeEngineResult struct {
 	InstanceGroup *compute.RegionInstanceGroupManager
+}
+
+// ComputeEngineArgs carries per-service extras beyond the compose config.
+type ComputeEngineArgs struct {
+	// SA is the identity the instances run as.
+	SA *ServiceIdentity
+	// Sidecars are additional containers run on the same instance, as extra
+	// systemd units. The main container's volumesFrom/dependsOn may reference
+	// sidecar names.
+	Sidecars map[string]compose.ServiceConfig
+	// Triggers force an instance template replacement (and thus a rolling
+	// update) when any value changes.
+	Triggers pulumi.StringMapInput
 }
 
 // CreateComputeEngine deploys a container service as a Compute Engine Managed Instance Group
@@ -26,18 +38,21 @@ func CreateComputeEngine(
 	serviceName string,
 	image pulumi.StringInput,
 	svc compose.ServiceConfig,
-	sa *serviceaccount.Account,
+	args *ComputeEngineArgs,
 	gcpConfig *SharedInfra,
 	parentOpt pulumi.ResourceOrInvokeOption,
 ) (*ComputeEngineResult, error) {
 	machineType := getComputeMachineType(svc)
 
-	iamDeps := addRolesToServiceAccount(ctx, sa, []string{
-		"roles/artifactregistry.reader",
-		"roles/logging.logWriter",
-		"roles/monitoring.metricWriter",
-		"roles/cloudtrace.agent",
-	}, gcpConfig, parentOpt)
+	var iamDeps pulumi.ResourceArrayOutput
+	if args.SA.Account != nil {
+		iamDeps = addRolesToServiceAccount(ctx, args.SA, []string{
+			"roles/artifactregistry.reader",
+			"roles/logging.logWriter",
+			"roles/monitoring.metricWriter",
+			"roles/cloudtrace.agent",
+		}, gcpConfig, parentOpt)
+	}
 
 	namedPorts := make(compute.RegionInstanceGroupManagerNamedPortArray, len(svc.Ports))
 	var healthCheckPort *int
@@ -62,16 +77,17 @@ func CreateComputeEngine(
 	// FQDN (<label>.google.internal) for internal services — the private zone is
 	// provisioned in alb.go and resolves within the VPC. See common.ServiceFQDN.
 	fqdn := common.ServiceFQDN(serviceName, svc, gcpConfig.Domain, "google.internal")
-	cloudInit := getCloudInitConfig(serviceName, image, svc, gcpConfig.Region, gcpConfig.Etag, fqdn, addHealthCheckSidecar)
+	cloudInit := getCloudInitConfig(
+		serviceName, image, svc, gcpConfig.Region, gcpConfig.Etag, fqdn, addHealthCheckSidecar, args.Sidecars)
 
 	instanceTemplate, err := createInstanceTemplate(
-		ctx, serviceName, serviceName, machineType, cloudInit, sa, gcpConfig, iamDeps, parentOpt)
+		ctx, serviceName, serviceName, machineType, cloudInit, args.SA, args.Triggers, gcpConfig, iamDeps, parentOpt)
 	if err != nil {
 		return nil, err
 	}
 
 	autoHealing, err := createMIGAutoHealing(
-		ctx, serviceName, serviceName, healthCheckPort, addHealthCheckSidecar, gcpConfig.VpcId, parentOpt)
+		ctx, serviceName, serviceName, healthCheckPort, addHealthCheckSidecar, networkID(gcpConfig), parentOpt)
 	if err != nil {
 		return nil, err
 	}
@@ -83,24 +99,34 @@ func CreateComputeEngine(
 	if err != nil {
 		return nil, fmt.Errorf("getting zones in region %s: %w", gcpConfig.Region, err)
 	}
-	updatePolicy := buildMIGUpdatePolicy(len(zones.Names), int(svc.GetReplicas()))
+	// Not every machine type is offered in every zone (notably ARM t2a); pin the
+	// MIG's distribution policy to the zones that actually have it.
+	zoneNames, err := zonesWithMachineType(ctx, zones.Names, machineType, parentOpt)
+	if err != nil {
+		return nil, err
+	}
+	updatePolicy := buildMIGUpdatePolicy(len(zoneNames), int(svc.GetReplicas()))
 
-	instanceGroup, err := compute.NewRegionInstanceGroupManager(ctx, serviceName+"-instance-group",
-		&compute.RegionInstanceGroupManagerArgs{
-			BaseInstanceName:    pulumi.String(serviceName), // FIXME: this resource does not support autonaming
-			AutoHealingPolicies: autoHealing,
-			Versions: compute.RegionInstanceGroupManagerVersionArray{
-				&compute.RegionInstanceGroupManagerVersionArgs{
-					InstanceTemplate: instanceTemplate.SelfLink,
-				},
+	migArgs := &compute.RegionInstanceGroupManagerArgs{
+		BaseInstanceName:    pulumi.String(serviceName), // FIXME: this resource does not support autonaming
+		AutoHealingPolicies: autoHealing,
+		Versions: compute.RegionInstanceGroupManagerVersionArray{
+			&compute.RegionInstanceGroupManagerVersionArgs{
+				InstanceTemplate: instanceTemplate.SelfLink,
 			},
-			UpdatePolicy:           updatePolicy,
-			Region:                 pulumi.String(gcpConfig.Region),
-			TargetSize:             pulumi.Int(svc.GetReplicas()),
-			NamedPorts:             namedPorts,
-			WaitForInstances:       pulumi.Bool(true),
-			WaitForInstancesStatus: pulumi.String("STABLE"),
-		}, parentOpt, pulumi.DependsOn([]pulumi.Resource{instanceTemplate}))
+		},
+		UpdatePolicy:           updatePolicy,
+		Region:                 pulumi.String(gcpConfig.Region),
+		TargetSize:             pulumi.Int(svc.GetReplicas()),
+		NamedPorts:             namedPorts,
+		WaitForInstances:       pulumi.Bool(true),
+		WaitForInstancesStatus: pulumi.String("STABLE"),
+	}
+	if len(zoneNames) < len(zones.Names) {
+		migArgs.DistributionPolicyZones = pulumi.ToStringArray(zoneNames)
+	}
+	instanceGroup, err := compute.NewRegionInstanceGroupManager(ctx, serviceName+"-instance-group",
+		migArgs, parentOpt, pulumi.DependsOn([]pulumi.Resource{instanceTemplate}))
 	if err != nil {
 		return nil, fmt.Errorf("creating instance group for %s: %w", serviceName, err)
 	}
@@ -108,15 +134,88 @@ func CreateComputeEngine(
 	return &ComputeEngineResult{InstanceGroup: instanceGroup}, nil
 }
 
+// networkID returns the network to attach instances and firewalls to: the
+// project VPC when one was provisioned, else the GCP default network so
+// standalone services (no shared infra) can still run on Compute Engine.
+func networkID(gcpConfig *SharedInfra) pulumi.StringInput {
+	if gcpConfig.PublicIP == nil {
+		return pulumi.String("default")
+	}
+	return gcpConfig.VpcId
+}
+
+// zonesWithMachineType filters zones to those offering the given machine type.
+// Falls back to all zones when the availability lookup finds none (e.g. mock
+// backends in tests).
+func zonesWithMachineType(
+	ctx *pulumi.Context, zones []string, machineType string, opt pulumi.InvokeOption,
+) ([]string, error) {
+	var available []string
+	for _, zone := range zones {
+		mts, err := compute.GetMachineTypes(ctx, &compute.GetMachineTypesArgs{
+			Filter: pulumi.StringRef(fmt.Sprintf("name = %q", machineType)),
+			Zone:   pulumi.StringRef(zone),
+		}, opt)
+		if err != nil {
+			return nil, fmt.Errorf("listing machine types in zone %s: %w", zone, err)
+		}
+		if len(mts.MachineTypes) > 0 {
+			available = append(available, zone)
+		}
+	}
+	if len(available) == 0 {
+		return zones, nil
+	}
+	return available, nil
+}
+
 func createInstanceTemplate(
 	ctx *pulumi.Context,
 	serviceName, instanceTag, machineType string,
 	cloudInit pulumi.StringInput,
-	sa *serviceaccount.Account,
+	sa *ServiceIdentity,
+	triggers pulumi.StringMapInput,
 	gcpConfig *SharedInfra,
 	iamDeps pulumi.ResourceArrayOutput,
 	opts ...pulumi.ResourceOption,
 ) (*compute.InstanceTemplate, error) {
+	network := &compute.InstanceTemplateNetworkInterfaceArgs{
+		Subnetwork: gcpConfig.SubnetId,
+		AccessConfigs: compute.InstanceTemplateNetworkInterfaceAccessConfigArray{
+			&compute.InstanceTemplateNetworkInterfaceAccessConfigArgs{},
+		},
+	}
+	if gcpConfig.PublicIP == nil {
+		// standalone: no project VPC — run on the default network
+		network.Subnetwork = nil
+		network.Network = pulumi.String("default")
+	}
+
+	// Trigger values land in instance metadata: instance templates are immutable,
+	// so any change replaces the template and rolls the MIG.
+	var metadata pulumi.StringMapInput = pulumi.StringMap{
+		"user-data":              cloudInit,
+		"google-logging-enabled": pulumi.String("true"),
+	}
+	if triggers != nil {
+		metadata = pulumi.All(cloudInit, triggers).ApplyT(func(vs []any) map[string]string {
+			m := map[string]string{
+				"user-data":              vs[0].(string),
+				"google-logging-enabled": "true",
+			}
+			for k, v := range vs[1].(map[string]string) {
+				m["defang-trigger-"+k] = v
+			}
+			return m
+		}).(pulumi.StringMapOutput)
+	}
+
+	templateOpts := make([]pulumi.ResourceOption, 0, len(opts)+2)
+	templateOpts = append(templateOpts, opts...)
+	templateOpts = append(templateOpts, pulumi.RetainOnDelete(true))
+	if sa.Account != nil {
+		templateOpts = append(templateOpts, pulumi.DependsOnInputs(iamDeps))
+	}
 	tmpl, err := compute.NewInstanceTemplate(ctx, serviceName+"-instance-template",
 		&compute.InstanceTemplateArgs{
 			MachineType: pulumi.String(machineType),
@@ -130,27 +229,14 @@ func createInstanceTemplate(
 					DiskSizeGb:  pulumi.Int(21),
 				},
 			},
-			NetworkInterfaces: compute.InstanceTemplateNetworkInterfaceArray{
-				&compute.InstanceTemplateNetworkInterfaceArgs{
-					Subnetwork: gcpConfig.SubnetId,
-					AccessConfigs: compute.InstanceTemplateNetworkInterfaceAccessConfigArray{
-						&compute.InstanceTemplateNetworkInterfaceAccessConfigArgs{},
-					},
-				},
-			},
-			Metadata: pulumi.StringMap{
-				"user-data":              cloudInit,
-				"google-logging-enabled": pulumi.String("true"),
-			},
+			NetworkInterfaces: compute.InstanceTemplateNetworkInterfaceArray{network},
+			Metadata:          metadata,
 			ServiceAccount: &compute.InstanceTemplateServiceAccountArgs{
 				Email:  sa.Email,
 				Scopes: pulumi.ToStringArray([]string{"cloud-platform"}),
 			},
 			Tags: pulumi.StringArray{pulumi.String(instanceTag)},
-		}, append(opts,
-			pulumi.DependsOnInputs(iamDeps),
-			pulumi.RetainOnDelete(true),
-		)...)
+		}, templateOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("creating instance template for %s: %w", serviceName, err)
 	}
@@ -162,7 +248,7 @@ func createMIGAutoHealing(
 	serviceName, instanceTag string,
 	healthCheckPort *int,
 	addSidecar bool,
-	vpcId pulumi.StringOutput,
+	network pulumi.StringInput,
 	opts ...pulumi.ResourceOption,
 ) (compute.RegionInstanceGroupManagerAutoHealingPoliciesPtrInput, error) {
 	if healthCheckPort == nil {
@@ -193,7 +279,7 @@ func createMIGAutoHealing(
 
 	portStr := strconv.Itoa(*healthCheckPort)
 	if _, err := compute.NewFirewall(ctx, serviceName+"-mig-hc-fw", &compute.FirewallArgs{
-		Network: vpcId,
+		Network: network,
 		// https://cloud.google.com/load-balancing/docs/health-checks#firewall_rules
 		SourceRanges: pulumi.StringArray{
 			pulumi.String("130.211.0.0/22"),
@@ -225,8 +311,10 @@ func createMIGAutoHealing(
 // the deployment region (from compute.GetZones); pass 1 if unknown.
 func buildMIGUpdatePolicy(numZones, targetSize int) *compute.RegionInstanceGroupManagerUpdatePolicyArgs {
 	policy := &compute.RegionInstanceGroupManagerUpdatePolicyArgs{
-		Type:          pulumi.String("PROACTIVE"),
-		MinimalAction: pulumi.String("RESTART"),
+		Type: pulumi.String("PROACTIVE"),
+		// REPLACE, not RESTART: user-data metadata changes applied via RESTART
+		// don't re-run cloud-init, leaving stale systemd units on the instance.
+		MinimalAction: pulumi.String("REPLACE"),
 	}
 	if targetSize > 10 {
 		policy.MaxSurgePercent = pulumi.Int(25)
@@ -246,7 +334,7 @@ func buildMIGUpdatePolicy(numZones, targetSize int) *compute.RegionInstanceGroup
 // Returns a resource array output that can be used as a dependency.
 func addRolesToServiceAccount(
 	ctx *pulumi.Context,
-	sa *serviceaccount.Account,
+	sa *ServiceIdentity,
 	roles []string,
 	gcpConfig *SharedInfra,
 	opts ...pulumi.ResourceOption,
@@ -260,10 +348,7 @@ func addRolesToServiceAccount(
 					Role:    pulumi.String(role),
 					Member:  pulumi.Sprintf("serviceAccount:%v", email),
 				},
-				append(opts,
-					pulumi.DeletedWith(sa),
-					pulumi.DeleteBeforeReplace(true),
-				)...,
+				append(opts, sa.deleteOpts()...)...,
 			)
 			if err != nil {
 				return nil, err
@@ -303,38 +388,47 @@ var e2MachineTypes = []machineTypeEntry{
 	{"e2-highcpu-32", 32, 32 * 1024},
 }
 
-// getComputeMachineType selects the smallest E2 machine type that satisfies the
-// service's CPU and memory reservations.
+// t2aMachineTypes lists T2A (Ampere ARM) machine types in ascending order.
+// Source: https://cloud.google.com/compute/docs/general-purpose-machines#t2a_machines
+var t2aMachineTypes = []machineTypeEntry{
+	{"t2a-standard-1", 1, 4 * 1024},
+	{"t2a-standard-2", 2, 8 * 1024},
+	{"t2a-standard-4", 4, 16 * 1024},
+	{"t2a-standard-8", 8, 32 * 1024},
+	{"t2a-standard-16", 16, 64 * 1024},
+	{"t2a-standard-32", 32, 128 * 1024},
+	{"t2a-standard-48", 48, 192 * 1024},
+}
+
+// getComputeMachineType selects the smallest machine type that satisfies the
+// service's CPU and memory reservations. ARM platforms get T2A (Ampere),
+// everything else E2.
 func getComputeMachineType(svc compose.ServiceConfig) string {
 	cpus := float32(svc.GetCPUs())
 	memMiB := uint64(svc.GetMemoryMiB()) //nolint:gosec // GetMemoryMiB() always returns >= 512
 
-	for _, mt := range e2MachineTypes {
+	table := e2MachineTypes
+	fallback := "e2-standard-2"
+	if strings.Contains(svc.GetPlatform(), "arm64") {
+		table = t2aMachineTypes
+		fallback = "t2a-standard-2"
+	}
+	for _, mt := range table {
 		if mt.cpu >= cpus && mt.mem >= memMiB {
 			return mt.name
 		}
 	}
-	return "e2-standard-2" // fallback
+	return fallback
 }
 
-// getCloudInitConfig generates a cloud-init YAML string for running a container on
-// Container-Optimized OS using systemd. For portless services it adds an HTTP health
-// check sidecar so the MIG auto-healer can probe container liveness.
-//
-//nolint:funlen
-func getCloudInitConfig(
-	serviceName string,
-	image pulumi.StringInput,
-	svc compose.ServiceConfig,
-	region, etag, fqdn string,
-	addHealthCheckSidecar bool,
-) pulumi.StringOutput {
-	var buf strings.Builder
-	buf.WriteString("#cloud-config\n\nwrite_files:")
-
-	params := make([]string, 0, len(svc.Entrypoint)+len(svc.Ports)*2)
-	var command []string
-
+// dockerRunFlags builds `docker run` flags shared by main and sidecar
+// containers: entrypoint, ports, mounts (-v), volumes-from, working dir.
+// The returned command is the argv appended after the image. sidecars is
+// used to resolve volumesFrom service names to container names.
+func dockerRunFlags(
+	svc compose.ServiceConfig, sidecars map[string]compose.ServiceConfig,
+) ([]string, []string) {
+	var params, command []string
 	if len(svc.Entrypoint) > 0 {
 		params = append(params, "--entrypoint", svc.Entrypoint[0])
 		if len(svc.Entrypoint) > 1 {
@@ -351,19 +445,40 @@ func getCloudInitConfig(
 		params = append(params, "-p", portMapping)
 	}
 
+	for _, vol := range svc.Volumes {
+		mount := vol.Source + ":" + vol.Target
+		if vol.ReadOnly {
+			mount += ":ro"
+		}
+		params = append(params, "-v", mount)
+	}
+
+	for _, ref := range svc.VolumesFrom {
+		name, suffix, _ := strings.Cut(ref, ":")
+		if sc, ok := sidecars[name]; ok {
+			name = sc.GetContainerName(name)
+		}
+		if suffix != "" {
+			name += ":" + suffix
+		}
+		params = append(params, "--volumes-from", name)
+	}
+
+	if svc.WorkingDir != nil && *svc.WorkingDir != "" {
+		params = append(params, "-w", *svc.WorkingDir)
+	}
+
+	return params, command
+}
+
+// flattenEnvFlags renders `-e "K=V"` docker flags for the given static env
+// pairs followed by the service's compose environment.
+func flattenEnvFlags(staticEnv [][2]string, env map[string]*string) string {
 	var envFlags strings.Builder
-	// Defang-injected runtime vars, mirroring the Cloud Run path (buildEnvVars).
-	staticEnv := [][2]string{{"DEFANG_SERVICE", serviceName}}
-	if etag != "" {
-		staticEnv = append(staticEnv, [2]string{"DEFANG_ETAG", etag})
-	}
-	if fqdn != "" {
-		staticEnv = append(staticEnv, [2]string{"DEFANG_FQDN", fqdn})
-	}
 	for _, kv := range staticEnv {
 		fmt.Fprintf(&envFlags, "-e %q ", fmt.Sprintf("%s=%s", kv[0], kv[1]))
 	}
-	for k, v := range common.Sorted(svc.Environment) {
+	for k, v := range common.Sorted(env) {
 		// Compute/VM deploys embed concrete values into the `docker run -e` cmd
 		// string — no runtime config-provider resolution is available here, so
 		// a nil *string (YAML "KEY:" with no value) flattens to an empty value.
@@ -374,19 +489,74 @@ func getCloudInitConfig(
 		// FIXME: provide all environment (and secrets) as env instead of flattening into the command line.
 		fmt.Fprintf(&envFlags, "-e %q ", fmt.Sprintf("%s=%s", k, val))
 	}
+	return envFlags.String()
+}
 
-	dependencies := "Wants=gcr-online.target docker.socket\n      After=gcr-online.target docker.socket"
+// stopGraceSeconds returns the docker stop timeout for a service, defaulting
+// to 30s (matches `docker stop`'s conservative default used previously).
+func stopGraceSeconds(svc compose.ServiceConfig) int {
+	if s := svc.GetStopGracePeriodSeconds(); s > 0 {
+		return s
+	}
+	return 30
+}
 
-	runcmds := make([]string, 0, 3+4+2)
+// getCloudInitConfig generates a cloud-init YAML string for running a container on
+// Container-Optimized OS using systemd. For portless services it adds an HTTP health
+// check sidecar so the MIG auto-healer can probe container liveness. User-defined
+// sidecars each get their own systemd unit, started before the main service so
+// `volumes_from` references resolve.
+func getCloudInitConfig(
+	serviceName string,
+	image pulumi.StringInput,
+	svc compose.ServiceConfig,
+	region, etag, fqdn string,
+	addHealthCheckSidecar bool,
+	sidecars map[string]compose.ServiceConfig,
+) pulumi.StringOutput {
+	var buf strings.Builder
+	buf.WriteString("#cloud-config\n\nwrite_files:")
+
+	containerName := svc.GetContainerName(serviceName)
+	params, command := dockerRunFlags(svc, sidecars)
+
+	// Defang-injected runtime vars, mirroring the Cloud Run path (buildEnvVars).
+	staticEnv := [][2]string{{"DEFANG_SERVICE", serviceName}}
+	if etag != "" {
+		staticEnv = append(staticEnv, [2]string{"DEFANG_ETAG", etag})
+	}
+	if fqdn != "" {
+		staticEnv = append(staticEnv, [2]string{"DEFANG_FQDN", fqdn})
+	}
+	envFlags := flattenEnvFlags(staticEnv, svc.Environment)
+
+	var dependencies strings.Builder
+	dependencies.WriteString("Wants=gcr-online.target docker.socket\n      After=gcr-online.target docker.socket")
+	for name := range common.Sorted(svc.DependsOn) {
+		if _, ok := sidecars[name]; !ok {
+			continue // only same-instance sidecar dependencies are enforceable here
+		}
+		unit := sidecarUnitName(serviceName, name)
+		fmt.Fprintf(&dependencies, "\n      Requires=%s.service\n      After=%s.service", unit, unit)
+	}
+
+	runcmds := make([]string, 0, 3+4+2*len(sidecars)+2)
 	runcmds = append(runcmds,
 		`echo 'DOCKER_OPTS="--registry-mirror=https://mirror.gcr.io"' | tee /etc/default/docker`,
 		"systemctl daemon-reload",
 		"systemctl restart docker",
 	)
 
-	sidecars := ""
+	var extraUnits strings.Builder
 	if addHealthCheckSidecar {
-		sidecars, runcmds = buildSidecarUnits(serviceName, runcmds)
+		var hcUnits string
+		hcUnits, runcmds = buildHealthCheckUnits(serviceName, containerName, runcmds)
+		extraUnits.WriteString(hcUnits)
+	}
+	for name, sc := range common.Sorted(sidecars) {
+		var unitText string
+		unitText, runcmds = buildSidecarUnit(serviceName, name, region, sc, sidecars, runcmds)
+		extraUnits.WriteString(unitText)
 	}
 
 	runcmds = append(runcmds,
@@ -408,8 +578,8 @@ func getCloudInitConfig(
       RestartSec=30
       Environment="HOME=/home/container-user"
       ExecStartPre=/usr/bin/docker-credential-gcr configure-docker --registries %[5]s-docker.pkg.dev
-      ExecStart=/usr/bin/docker run --pull=always --rm --name=%[1]s %[3]s %[6]s%%s %[4]s
-      ExecStop=/usr/bin/docker stop -t 30 %[1]s
+      ExecStart=/usr/bin/docker run --pull=always --rm --name=%[9]s %[3]s %[6]s%%s %[4]s
+      ExecStop=/usr/bin/docker stop -t %[8]d %[9]s
       StandardOutput=journal+console
       StandardError=journal+console
 
@@ -417,24 +587,102 @@ func getCloudInitConfig(
       WantedBy=multi-user.target
 %[7]s
 runcmd:
-  - %[8]s
+  - %[10]s
 `,
 		serviceName,
-		dependencies,
-		strings.Join(params, " "),
-		strings.Join(command, " "),
+		escapePercent(dependencies.String()),
+		escapePercent(strings.Join(params, " ")),
+		escapePercent(strings.Join(command, " ")),
 		region,
-		envFlags.String(),
-		sidecars,
-		strings.Join(runcmds, "\n  - "))
+		escapePercent(envFlags),
+		escapePercent(extraUnits.String()),
+		stopGraceSeconds(svc),
+		containerName,
+		escapePercent(strings.Join(runcmds, "\n  - ")))
 
+	// buf now contains exactly one %s (the escaped image placeholder from the
+	// format string above); all other dynamic text had its '%' doubled.
 	return pulumi.Sprintf(buf.String(), image)
 }
 
-// buildSidecarUnits returns the cloud-init write_files entries and runcmd lines for the
-// HTTP health check sidecar: a systemd socket that returns 200 when the container is
+// escapePercent doubles '%' so text survives the final pulumi.Sprintf pass
+// (which only substitutes the main image via %s).
+func escapePercent(s string) string {
+	return strings.ReplaceAll(s, "%", "%%")
+}
+
+func sidecarUnitName(serviceName, sidecarName string) string {
+	return serviceName + "-" + sidecarName
+}
+
+// buildSidecarUnit returns the cloud-init write_files entry and runcmd lines for a
+// user-defined sidecar container. Sidecars run without --rm so the main container's
+// --volumes-from keeps working across restarts; a run-once sidecar (restart: "no")
+// becomes a oneshot unit the main service can order After=.
+func buildSidecarUnit(
+	serviceName, sidecarName, region string,
+	sc compose.ServiceConfig,
+	sidecars map[string]compose.ServiceConfig,
+	runcmds []string,
+) (string, []string) {
+	unit := sidecarUnitName(serviceName, sidecarName)
+	containerName := sc.GetContainerName(sidecarName)
+	params, command := dockerRunFlags(sc, sidecars)
+	envFlags := flattenEnvFlags(nil, sc.Environment)
+
+	var serviceSection string
+	if sc.Restart == "no" {
+		serviceSection = "Type=oneshot\n      RemainAfterExit=yes"
+	} else {
+		serviceSection = fmt.Sprintf("Restart=always\n      RestartSec=30\n      ExecStop=/usr/bin/docker stop -t %d %s",
+			stopGraceSeconds(sc), containerName)
+	}
+
+	units := fmt.Sprintf(`
+  - path: /etc/systemd/system/%[1]s.service
+    permissions: "0644"
+    owner: root
+    content: |
+      [Unit]
+      Description=%[2]s sidecar for %[3]s
+      Wants=gcr-online.target docker.socket
+      After=gcr-online.target docker.socket
+      Before=%[3]s.service
+
+      [Service]
+      %[4]s
+      Environment="HOME=/home/container-user"
+      ExecStartPre=/usr/bin/docker-credential-gcr configure-docker --registries %[5]s-docker.pkg.dev
+      ExecStartPre=-/usr/bin/docker rm -f %[6]s
+      ExecStart=/usr/bin/docker run --pull=always --name=%[6]s %[7]s %[8]s%[9]s %[10]s
+      StandardOutput=journal+console
+      StandardError=journal+console
+
+      [Install]
+      WantedBy=multi-user.target
+`,
+		unit,
+		sidecarName,
+		serviceName,
+		serviceSection,
+		region,
+		containerName,
+		strings.Join(params, " "),
+		envFlags,
+		*sc.Image,
+		strings.Join(command, " "))
+
+	runcmds = append(runcmds,
+		fmt.Sprintf("systemctl enable %s.service", unit),
+		fmt.Sprintf("systemctl start %s.service", unit),
+	)
+	return units, runcmds
+}
+
+// buildHealthCheckUnits returns the cloud-init write_files entries and runcmd lines for
+// the HTTP health check sidecar: a systemd socket that returns 200 when the container is
 // running and 500 otherwise, allowing the MIG auto-healer to probe portless services.
-func buildSidecarUnits(serviceName string, runcmds []string) (string, []string) {
+func buildHealthCheckUnits(serviceName, containerName string, runcmds []string) (string, []string) {
 	units := fmt.Sprintf(`
   - path: /etc/systemd/system/%[1]s-health-firewall.service
     permissions: "0644"
@@ -477,14 +725,14 @@ func buildSidecarUnits(serviceName string, runcmds []string) (string, []string) 
 
       [Service]
       ExecStart=/bin/bash -c '\
-        if docker inspect --format "{{.State.Status}}" %[1]s 2>/dev/null | grep -q running; then \
+        if docker inspect --format "{{.State.Status}}" %[2]s 2>/dev/null | grep -q running; then \
           echo -e "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK"; \
         else \
           echo -e "HTTP/1.1 500 FAIL\r\nContent-Length: 4\r\n\r\nFAIL"; \
         fi;'
       StandardInput=socket
       StandardOutput=socket
-`, serviceName)
+`, serviceName, containerName)
 
 	runcmds = append(runcmds,
 		fmt.Sprintf("systemctl enable %s-health-firewall.service", serviceName),

--- a/provider/defanggcp/gcp/compute.go
+++ b/provider/defanggcp/gcp/compute.go
@@ -428,7 +428,8 @@ func getComputeMachineType(svc compose.ServiceConfig) string {
 func dockerRunFlags(
 	svc compose.ServiceConfig, sidecars map[string]compose.ServiceConfig,
 ) ([]string, []string) {
-	var params, command []string
+	params := make([]string, 0, 2+2*len(svc.Ports)+2*len(svc.Volumes)+len(svc.VolumesFrom)+2)
+	var command []string
 	if len(svc.Entrypoint) > 0 {
 		params = append(params, "--entrypoint", svc.Entrypoint[0])
 		if len(svc.Entrypoint) > 1 {
@@ -557,7 +558,7 @@ func getCloudInitConfig(
 	)
 
 	var extraUnitsFmt strings.Builder
-	var extraUnitsArgs []any
+	extraUnitsArgs := make([]any, 0, len(sidecars)+1)
 	if addHealthCheckSidecar {
 		var hcUnits string
 		hcUnits, runcmds = buildHealthCheckUnits(serviceName, containerName, runcmds)

--- a/provider/defanggcp/gcp/compute_test.go
+++ b/provider/defanggcp/gcp/compute_test.go
@@ -1,6 +1,7 @@
 package gcp
 
 import (
+	"strings"
 	"sync"
 	"testing"
 
@@ -43,7 +44,7 @@ func TestGetCloudInitConfigDefangEnv(t *testing.T) {
 			var wg sync.WaitGroup
 			wg.Add(1)
 			err := pulumi.RunErr(func(ctx *pulumi.Context) error {
-				out := getCloudInitConfig("api", pulumi.String("img:latest"), svc, "us-central1", tt.etag, tt.fqdn, false)
+				out := getCloudInitConfig("api", pulumi.String("img:latest"), svc, "us-central1", tt.etag, tt.fqdn, false, nil)
 				out.ApplyT(func(s string) string {
 					defer wg.Done()
 					cloudInit = s
@@ -62,4 +63,66 @@ func TestGetCloudInitConfigDefangEnv(t *testing.T) {
 			}
 		})
 	}
+}
+
+// A run-once sidecar (restart: "no") must become a oneshot unit started before
+// the main service, with the main container mounting its volumes via
+// --volumes-from; '%' in env values must survive the pulumi.Sprintf pass.
+func TestGetCloudInitConfigSidecars(t *testing.T) {
+	handlerImage := "region-docker.pkg.dev/proj/repo/handler:1"
+	percentVal := "100%"
+	svc := compose.ServiceConfig{
+		Entrypoint:  []string{"/handler/handler"},
+		VolumesFrom: []string{"handler"},
+		DependsOn:   compose.DependsOnConfig{"handler": {}},
+		Environment: map[string]*string{"RATIO": &percentVal},
+	}
+	sidecars := map[string]compose.ServiceConfig{
+		"handler": {
+			Image:      &handlerImage,
+			Entrypoint: []string{"true"},
+			Restart:    "no",
+			Volumes: []compose.ServiceVolumeConfig{
+				{Source: "handler", Target: "/handler", ReadOnly: true},
+				{Source: "pulumi-plugins", Target: "/root/.pulumi/plugins"},
+			},
+		},
+	}
+
+	var cloudInit string
+	var wg sync.WaitGroup
+	wg.Add(1)
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		out := getCloudInitConfig("cd", pulumi.String("img:latest"), svc, "us-central1", "", "", true, sidecars)
+		out.ApplyT(func(s string) string {
+			defer wg.Done()
+			cloudInit = s
+			return s
+		})
+		return nil
+	}, pulumi.WithMocks("proj", "stack", testMocks{}))
+	require.NoError(t, err)
+	wg.Wait()
+
+	// sidecar unit: oneshot, no --rm, named container, volume mounts
+	assert.Contains(t, cloudInit, "/etc/systemd/system/cd-handler.service")
+	assert.Contains(t, cloudInit, "Type=oneshot")
+	assert.Contains(t, cloudInit, "RemainAfterExit=yes")
+	assert.Contains(t, cloudInit,
+		"--name=handler --entrypoint true -v handler:/handler:ro -v pulumi-plugins:/root/.pulumi/plugins")
+	assert.Contains(t, cloudInit, handlerImage)
+	// main unit: ordered after the sidecar, volumes-from it
+	assert.Contains(t, cloudInit, "Requires=cd-handler.service")
+	assert.Contains(t, cloudInit, "After=cd-handler.service")
+	assert.Contains(t, cloudInit, "--volumes-from handler")
+	// sidecar started before the main service
+	handlerStart := strings.Index(cloudInit, "systemctl start cd-handler.service")
+	mainStart := strings.Index(cloudInit, "systemctl start cd.service")
+	require.Positive(t, handlerStart)
+	require.Positive(t, mainStart)
+	assert.Less(t, handlerStart, mainStart)
+	// '%' escaping: env value intact, image substituted
+	assert.Contains(t, cloudInit, `-e "RATIO=100%"`)
+	assert.Contains(t, cloudInit, "img:latest")
+	assert.NotContains(t, cloudInit, "%!")
 }

--- a/provider/defanggcp/gcp/compute_test.go
+++ b/provider/defanggcp/gcp/compute_test.go
@@ -69,7 +69,7 @@ func TestGetCloudInitConfigDefangEnv(t *testing.T) {
 // the main service, with the main container mounting its volumes via
 // --volumes-from; '%' in env values must survive the pulumi.Sprintf pass.
 func TestGetCloudInitConfigSidecars(t *testing.T) {
-	handlerImage := "region-docker.pkg.dev/proj/repo/handler:1"
+	handlerImage := pulumi.String("region-docker.pkg.dev/proj/repo/handler:1")
 	percentVal := "100%"
 	svc := compose.ServiceConfig{
 		Entrypoint:  []string{"/handler/handler"},
@@ -79,7 +79,7 @@ func TestGetCloudInitConfigSidecars(t *testing.T) {
 	}
 	sidecars := map[string]compose.ServiceConfig{
 		"handler": {
-			Image:      &handlerImage,
+			Image:      handlerImage,
 			Entrypoint: []string{"true"},
 			Restart:    "no",
 			Volumes: []compose.ServiceVolumeConfig{

--- a/provider/defanggcp/gcp/compute_test.go
+++ b/provider/defanggcp/gcp/compute_test.go
@@ -75,7 +75,7 @@ func TestGetCloudInitConfigSidecars(t *testing.T) {
 		Entrypoint:  []string{"/handler/handler"},
 		VolumesFrom: []string{"handler"},
 		DependsOn:   compose.DependsOnConfig{"handler": {}},
-		Environment: map[string]*string{"RATIO": &percentVal},
+		Environment: compose.Environment{"RATIO": pulumi.String(percentVal)},
 	}
 	sidecars := map[string]compose.ServiceConfig{
 		"handler": {

--- a/provider/defanggcp/gcp/identity.go
+++ b/provider/defanggcp/gcp/identity.go
@@ -1,0 +1,31 @@
+package gcp
+
+import (
+	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/serviceaccount"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// ServiceIdentity is the service account a service runs as. Account is non-nil
+// only when the provider created the account itself; when the caller supplies
+// an existing service account (by email), Account is nil and the caller owns
+// all IAM role grants for it.
+type ServiceIdentity struct {
+	Account *serviceaccount.Account
+	Email   pulumi.StringInput
+}
+
+// deleteOpts returns options for IAM bindings on this identity. Bindings on a
+// provider-created account are additionally tied to the account's lifetime.
+func (si *ServiceIdentity) deleteOpts() []pulumi.ResourceOption {
+	opts := []pulumi.ResourceOption{
+		// membership is not a distinct resource, so we risk deleting the
+		// membership we are trying to create
+		pulumi.DeleteBeforeReplace(true),
+	}
+	if si.Account != nil {
+		// prevent "service account does not exist" errors on down; the binding
+		// is removed automatically when the account is deleted
+		opts = append(opts, pulumi.DeletedWith(si.Account))
+	}
+	return opts
+}

--- a/provider/defanggcp/gcp/image.go
+++ b/provider/defanggcp/gcp/image.go
@@ -133,7 +133,14 @@ func GetServiceImage(
 		return pulumi.StringOutput{}, fmt.Errorf("service %s: %w", serviceName, common.ErrNoImageOrBuildConfig)
 	}
 
-	info := common.ParseImage(*svc.Image)
+	img := svc.StaticImage()
+	if img == nil {
+		// Dynamic (Output) image: registry can't be inspected synchronously, so
+		// skip the unsupported-registry rewrite and pass it through as-is.
+		return svc.Image.ToStringOutput(), nil
+	}
+
+	info := common.ParseImage(*img)
 	if !isCloudRunSupportedRegistry(info.Registry) {
 		gcpProject := config.GetProject(ctx)
 		region := GcpRegion(ctx)
@@ -156,7 +163,7 @@ func GetServiceImage(
 		image := repo.RepositoryId.ApplyT(func(repoId string) string {
 			info.Repo = fmt.Sprintf("%s/%s/%s", gcpProject, repoId, info.Repo)
 			msg := fmt.Sprintf("rewriting image for service %s: %s -> %s (registry not supported by Cloud Run)",
-				serviceName, *svc.Image, info.FullImage())
+				serviceName, *img, info.FullImage())
 			_ = ctx.Log.Info(msg, nil)
 			return info.FullImage()
 		}).(pulumi.StringOutput)

--- a/provider/defanggcp/gcp/image.go
+++ b/provider/defanggcp/gcp/image.go
@@ -19,6 +19,7 @@ import (
 )
 
 var errNoRemoteRepoConfigured = errors.New("no remote repository configured for registry")
+var errMultiPlatformUnsupported = errors.New("multi-platform builds are unsupported on GCP Cloud Build")
 
 // Based on Cloud Run error:
 // "Expected an image path like [host/]repo-path[:tag and/or @digest], where host is one of
@@ -65,8 +66,26 @@ type buildStep struct {
 // a Docker image and loads it into the local Docker daemon. Cloud Build then
 // pushes the image to the registry via the images: field so that build results
 // contain the image digest.
-func generateBuildSteps(dest pulumi.StringOutput) pulumi.StringOutput {
+//
+// Multi-platform builds are rejected: the --load step and the images: push
+// only handle a single-platform image (Cloud Build's daemon cannot load a
+// multi-arch manifest list).
+func generateBuildSteps(build *compose.BuildConfig, dest pulumi.StringOutput) pulumi.StringOutput {
+	platform := "linux/amd64"
+	if len(build.Platforms) == 1 {
+		platform = build.Platforms[0]
+	}
+	buildArgs := []string{"buildx", "build", "--platform", platform}
+	for _, c := range build.CacheFrom {
+		buildArgs = append(buildArgs, "--cache-from="+c)
+	}
+	for _, c := range build.CacheTo {
+		buildArgs = append(buildArgs, "--cache-to="+c)
+	}
 	return dest.ApplyT(func(d string) (string, error) {
+		if len(build.Platforms) > 1 {
+			return "", fmt.Errorf("%w (got %v)", errMultiPlatformUnsupported, build.Platforms)
+		}
 		steps := []buildStep{
 			{
 				Name: "gcr.io/cloud-builders/docker",
@@ -77,10 +96,7 @@ func generateBuildSteps(dest pulumi.StringOutput) pulumi.StringOutput {
 			},
 			{
 				Name: "gcr.io/cloud-builders/docker",
-				Args: []string{
-					"buildx", "build", "--platform", "linux/amd64",
-					"-t", d, "--load", ".",
-				},
+				Args: append(buildArgs, "-t", d, "--load", "."),
 			},
 		}
 		b, err := yaml.Marshal(steps)
@@ -190,6 +206,7 @@ func buildSourceDigest(build *compose.BuildConfig) pulumi.StringOutput {
 		h.Write([]byte(ctx))
 		h.Write([]byte(build.GetDockerfile()))
 		h.Write([]byte(build.GetTarget()))
+		h.Write([]byte(strings.Join(build.Platforms, ",")))
 		argBytes, err := json.Marshal(build.Args)
 		if err != nil {
 			return "", fmt.Errorf("marshaling build args: %w", err)
@@ -236,7 +253,7 @@ func buildServiceImage(
 	opts ...pulumi.ResourceOption,
 ) (pulumi.StringOutput, error) {
 	dest := pulumi.Sprintf("%s/%s:latest", infra.RepositoryURL, serviceName)
-	steps := generateBuildSteps(dest)
+	steps := generateBuildSteps(svc.Build, dest)
 	shmBytes := svc.Build.GetShmSizeBytes()
 
 	sourceURI, err := resolveSourceURI(ctx, serviceName, svc.Build, infra, opts...)

--- a/provider/defanggcp/gcp/image_test.go
+++ b/provider/defanggcp/gcp/image_test.go
@@ -159,31 +159,31 @@ func TestGetServiceImage(t *testing.T) {
 		},
 		{
 			name:      "docker.io image returned as-is",
-			svc:       compose.ServiceConfig{Image: strPtr("nginx:latest")},
+			svc:       compose.ServiceConfig{Image: pulumi.String("nginx:latest")},
 			infra:     fakeInfra,
 			wantImage: "nginx:latest",
 		},
 		{
 			name:      "explicit docker.io image returned as-is",
-			svc:       compose.ServiceConfig{Image: strPtr("docker.io/library/nginx:1.25")},
+			svc:       compose.ServiceConfig{Image: pulumi.String("docker.io/library/nginx:1.25")},
 			infra:     fakeInfra,
 			wantImage: "docker.io/library/nginx:1.25",
 		},
 		{
 			name:      "gcr.io image returned as-is",
-			svc:       compose.ServiceConfig{Image: strPtr("gcr.io/my-project/app:v1")},
+			svc:       compose.ServiceConfig{Image: pulumi.String("gcr.io/my-project/app:v1")},
 			infra:     fakeInfra,
 			wantImage: "gcr.io/my-project/app:v1",
 		},
 		{
 			name:      "artifact registry image returned as-is",
-			svc:       compose.ServiceConfig{Image: strPtr("us-central1-docker.pkg.dev/proj/repo/app:v1")},
+			svc:       compose.ServiceConfig{Image: pulumi.String("us-central1-docker.pkg.dev/proj/repo/app:v1")},
 			infra:     fakeInfra,
 			wantImage: "us-central1-docker.pkg.dev/proj/repo/app:v1",
 		},
 		{
 			name:  "quay.io image rewritten to artifact registry",
-			svc:   compose.ServiceConfig{Image: strPtr("quay.io/prometheus/node-exporter:v1.8.0")},
+			svc:   compose.ServiceConfig{Image: pulumi.String("quay.io/prometheus/node-exporter:v1.8.0")},
 			infra: fakeInfra,
 			repos: map[string]*artifactregistry.Repository{
 				"quay.io": {RepositoryId: pulumi.String("quay-io").ToStringOutput()},
@@ -192,7 +192,7 @@ func TestGetServiceImage(t *testing.T) {
 		},
 		{
 			name:  "ghcr.io image rewritten to artifact registry",
-			svc:   compose.ServiceConfig{Image: strPtr("ghcr.io/owner/image:sha-abc123")},
+			svc:   compose.ServiceConfig{Image: pulumi.String("ghcr.io/owner/image:sha-abc123")},
 			infra: fakeInfra,
 			repos: map[string]*artifactregistry.Repository{
 				"ghcr.io": {RepositoryId: pulumi.String("ghcr-io").ToStringOutput()},

--- a/provider/defanggcp/gcp/image_test.go
+++ b/provider/defanggcp/gcp/image_test.go
@@ -237,7 +237,7 @@ func TestGenerateBuildSteps(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
-		out := generateBuildSteps(pulumi.String(dest).ToStringOutput())
+		out := generateBuildSteps(&compose.BuildConfig{Context: pulumi.String("./app")}, pulumi.String(dest).ToStringOutput())
 		out.ApplyT(func(stepsYAML string) string {
 			defer wg.Done()
 			unmarshalErr = yaml.Unmarshal([]byte(stepsYAML), &steps)
@@ -261,6 +261,40 @@ func TestGenerateBuildSteps(t *testing.T) {
 	assert.Contains(t, steps[1].Args, "--load")
 	assert.NotContains(t, steps[1].Args, "--push")
 	assert.Contains(t, steps[1].Args, dest)
+	assert.Contains(t, steps[1].Args, "linux/amd64") // default platform
+}
+
+func TestGenerateBuildStepsPlatformAndCache(t *testing.T) {
+	const dest = "us-central1-docker.pkg.dev/my-project/my-repo/app:latest"
+	build := &compose.BuildConfig{
+		Context:   pulumi.String("./app"),
+		Platforms: []string{"linux/arm64"},
+		CacheFrom: []string{"type=registry,ref=my/app:cache"},
+		CacheTo:   []string{"type=registry,mode=max,ref=my/app:cache"},
+	}
+
+	var steps []buildStep
+	var unmarshalErr error
+	var wg sync.WaitGroup
+	wg.Add(1)
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		out := generateBuildSteps(build, pulumi.String(dest).ToStringOutput())
+		out.ApplyT(func(stepsYAML string) string {
+			defer wg.Done()
+			unmarshalErr = yaml.Unmarshal([]byte(stepsYAML), &steps)
+			return stepsYAML
+		})
+		return nil
+	}, pulumi.WithMocks("proj", "stack", testMocks{}))
+	require.NoError(t, err)
+	wg.Wait()
+	require.NoError(t, unmarshalErr)
+	require.Len(t, steps, 2)
+
+	assert.Contains(t, steps[1].Args, "linux/arm64")
+	assert.NotContains(t, steps[1].Args, "linux/amd64")
+	assert.Contains(t, steps[1].Args, "--cache-from=type=registry,ref=my/app:cache")
+	assert.Contains(t, steps[1].Args, "--cache-to=type=registry,mode=max,ref=my/app:cache")
 }
 
 func TestBuildSourceDigest(t *testing.T) {

--- a/provider/defanggcp/gcp/memorystore.go
+++ b/provider/defanggcp/gcp/memorystore.go
@@ -79,8 +79,8 @@ func CreateMemoryStore(
 	}
 
 	imageTag := ""
-	if svc.Image != nil {
-		imageTag = compose.ParseImageTag(*svc.Image)
+	if img := svc.StaticImage(); img != nil {
+		imageTag = compose.ParseImageTag(*img)
 	}
 
 	instance, err := redis.NewInstance(ctx, serviceName, &redis.InstanceArgs{

--- a/provider/defanggcp/postgres.go
+++ b/provider/defanggcp/postgres.go
@@ -18,7 +18,7 @@ type PostgresInputs struct {
 	Postgres    *compose.PostgresConfig     `pulumi:"postgres,optional"`
 	Image       *string                     `pulumi:"image,optional"`
 	Deploy      *compose.DeployConfig       `pulumi:"deploy,optional"`
-	Environment map[string]*string          `pulumi:"environment,optional"`
+	Environment compose.Environment             `pulumi:"environment,optional"`
 	Ports       []compose.ServicePortConfig `pulumi:"ports,optional"`
 }
 

--- a/provider/defanggcp/postgres.go
+++ b/provider/defanggcp/postgres.go
@@ -46,7 +46,7 @@ func (*Postgres) Construct(
 
 	svc := compose.ServiceConfig{
 		Postgres:    inputs.Postgres,
-		Image:       inputs.Image,
+		Image:       compose.ImageFromPtr(inputs.Image),
 		Deploy:      inputs.Deploy,
 		Environment: inputs.Environment,
 		Ports:       inputs.Ports,

--- a/provider/defanggcp/project.go
+++ b/provider/defanggcp/project.go
@@ -209,7 +209,7 @@ func buildService(
 		if err != nil {
 			return pulumi.StringOutput{}, nil, nil, fmt.Errorf("resolving image for %s: %w", svcName, err)
 		}
-		if err := createService(ctx, svcCompTyped, projectName, configProvider, svcName, image, svc, infra); err != nil {
+		if err := createService(ctx, svcCompTyped, projectName, configProvider, svcName, image, svc, infra, nil); err != nil {
 			return pulumi.StringOutput{}, nil, nil, err
 		}
 		endpoint = svcCompTyped.Endpoint
@@ -255,25 +255,29 @@ func enableLLM(
 	ctx *pulumi.Context,
 	svcName string,
 	svc *compose.ServiceConfig,
-	sa *serviceaccount.Account,
+	sa *providergcp.ServiceIdentity,
 	infra *providergcp.SharedInfra,
 	svcChildOpts []pulumi.ResourceOption,
 ) error {
-	// TODO: add dependency to the member resource
-	_, err := projects.NewIAMMember(ctx, svcName+"-defang-llm", &projects.IAMMemberArgs{
-		Project: pulumi.String(infra.GcpProject),
-		// for details see https://cloud.google.com/vertex-ai/docs/general/access-control
-		Role:   pulumi.String("roles/aiplatform.user"),
-		Member: pulumi.Sprintf("serviceAccount:%v", sa.Email),
-	}, append(svcChildOpts,
-		// prevent service account does not exist error when down, will be automatically removed when sa is removed
-		pulumi.DeletedWith(sa),
-		// membership is not a distinct resource, so we risk deleting the membership we are trying to create
-		pulumi.DeleteBeforeReplace(true),
-	)...,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to grant aiplatform access to service account %v: %w", sa.Email, err)
+	// Only grant the role on provider-created accounts; IAM on a
+	// caller-supplied service account is owned by the caller.
+	if sa.Account != nil {
+		// TODO: add dependency to the member resource
+		_, err := projects.NewIAMMember(ctx, svcName+"-defang-llm", &projects.IAMMemberArgs{
+			Project: pulumi.String(infra.GcpProject),
+			// for details see https://cloud.google.com/vertex-ai/docs/general/access-control
+			Role:   pulumi.String("roles/aiplatform.user"),
+			Member: pulumi.Sprintf("serviceAccount:%v", sa.Email),
+		}, append(svcChildOpts,
+			// prevent service account does not exist error when down, will be automatically removed when sa is removed
+			pulumi.DeletedWith(sa.Account),
+			// membership is not a distinct resource, so we risk deleting the membership we are trying to create
+			pulumi.DeleteBeforeReplace(true),
+		)...,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to grant aiplatform access to service account %v: %w", sa.Email, err)
+		}
 	}
 
 	if svc.Environment == nil {

--- a/provider/defanggcp/project.go
+++ b/provider/defanggcp/project.go
@@ -281,19 +281,19 @@ func enableLLM(
 	}
 
 	if svc.Environment == nil {
-		svc.Environment = make(map[string]*string)
+		svc.Environment = compose.Environment{}
 	}
 
 	// setDefault fills an env var with a default only when absent or empty-literal.
-	// A nil *string value (YAML "KEY:" with no value) means "resolve at runtime from
-	// config" — leave it alone.
+	// A nil value (YAML "KEY:" with no value) means "resolve at runtime from
+	// config" and a dynamic (Output) value is opaque — leave both alone.
 	setDefault := func(key, defaultVal string) {
-		val, ok := svc.Environment[key]
-		if ok && (val == nil || *val != "") {
-			return
+		if val, ok := svc.Environment[key]; ok {
+			if sv, static := compose.StaticEnvValue(val); !static || sv == nil || *sv != "" {
+				return
+			}
 		}
-		v := defaultVal
-		svc.Environment[key] = &v
+		svc.Environment[key] = pulumi.String(defaultVal)
 	}
 
 	// Inject environment variables for Vercel routing for GCP Vertex AI access

--- a/provider/defanggcp/redis.go
+++ b/provider/defanggcp/redis.go
@@ -44,7 +44,7 @@ func (*Redis) Construct(
 
 	svc := compose.ServiceConfig{
 		Redis:  inputs.Redis,
-		Image:  inputs.Image,
+		Image:  compose.ImageFromPtr(inputs.Image),
 		Deploy: inputs.Deploy,
 		Ports:  inputs.Ports,
 	}

--- a/provider/defanggcp/service.go
+++ b/provider/defanggcp/service.go
@@ -1,6 +1,7 @@
 package defanggcp
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/DefangLabs/pulumi-defang/provider/common"
@@ -8,6 +9,9 @@ import (
 	providergcp "github.com/DefangLabs/pulumi-defang/provider/defanggcp/gcp"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
+
+var errSidecarsRequireComputeEngine = errors.New(
+	"sidecars and volumes are only supported on Compute Engine services (no single ingress port)")
 
 // Service is the controller struct for the defang-gcp:index:Service component.
 type Service struct{}
@@ -28,10 +32,31 @@ type ServiceInputs struct {
 	HealthCheck *compose.HealthCheckConfig  `pulumi:"healthCheck,optional"`
 	DomainName  string                      `pulumi:"domainName,optional"`
 	LLM         *compose.LlmConfig          `pulumi:"llm,optional"`
+
+	// Compose-shaped container settings (honored by the Compute Engine path)
+	ContainerName   *string                       `pulumi:"containerName,optional"`
+	WorkingDir      *string                       `pulumi:"workingDir,optional"`
+	StopGracePeriod *string                       `pulumi:"stopGracePeriod,optional"`
+	Volumes         []compose.ServiceVolumeConfig `pulumi:"volumes,optional"`
+	VolumesFrom     []string                      `pulumi:"volumesFrom,optional"`
+	DependsOn       compose.DependsOnConfig       `pulumi:"dependsOn,optional"`
+
+	// Sidecars are additional containers run on the same Compute Engine
+	// instance (as extra systemd units). volumesFrom / dependsOn may
+	// reference sidecar names. Not supported on Cloud Run-shaped services.
+	Sidecars map[string]compose.ServiceConfig `pulumi:"sidecars,optional"`
+	// ServiceAccountEmail reuses an existing service account instead of
+	// creating one per service; its IAM role grants are owned by the caller.
+	ServiceAccountEmail pulumi.StringInput `pulumi:"serviceAccountEmail,optional"`
+	// Triggers force a rolling replacement of Compute Engine instances when
+	// any value changes.
+	Triggers pulumi.StringMapInput `pulumi:"triggers,optional"`
+
 	// Infra is an optional shared GCP project infrastructure. When non-nil, the
 	// Service reuses it (region/VPC, build repos, LLM bindings). When nil, the
-	// Service runs standalone with minimal defaults (region + project only) and
-	// without VPC access, Compute Engine, or build-from-source support. Untagged
+	// Service runs standalone with minimal defaults (region + project only):
+	// Cloud Run without VPC access, or Compute Engine on the default network;
+	// build-from-source is unsupported. Untagged
 	// because SharedInfra contains Pulumi Output and resource-pointer fields
 	// that aren't schema-compatible; the project dispatcher passes it in Go.
 	Infra *providergcp.SharedInfra
@@ -41,6 +66,9 @@ type ServiceInputs struct {
 type ServiceOutputs struct {
 	pulumi.ResourceState
 	Endpoint pulumi.StringOutput `pulumi:"endpoint"`
+	// ServiceAccountEmail is the email of the service account the service runs
+	// as (created or caller-supplied) — e.g. for granting extra IAM roles.
+	ServiceAccountEmail pulumi.StringOutput `pulumi:"serviceAccountEmail"`
 	// LBEntry is an internal-only handle used by the project dispatcher to wire
 	// services into the external load balancer. Untagged — not part of the SDK schema.
 	LBEntry *providergcp.LBServiceEntry
@@ -62,16 +90,22 @@ func (*Service) Construct(
 		return nil, fmt.Errorf("service %s: %w", name, common.ErrStandaloneServiceRequiresImage)
 	}
 	svc := compose.ServiceConfig{
-		Image:       &inputs.Image,
-		Platform:    inputs.Platform,
-		Ports:       inputs.Ports,
-		Deploy:      inputs.Deploy,
-		Environment: inputs.Environment,
-		Command:     inputs.Command,
-		Entrypoint:  inputs.Entrypoint,
-		HealthCheck: inputs.HealthCheck,
-		DomainName:  inputs.DomainName,
-		LLM:         inputs.LLM,
+		Image:           &inputs.Image,
+		Platform:        inputs.Platform,
+		Ports:           inputs.Ports,
+		Deploy:          inputs.Deploy,
+		Environment:     inputs.Environment,
+		Command:         inputs.Command,
+		Entrypoint:      inputs.Entrypoint,
+		HealthCheck:     inputs.HealthCheck,
+		DomainName:      inputs.DomainName,
+		LLM:             inputs.LLM,
+		ContainerName:   inputs.ContainerName,
+		WorkingDir:      inputs.WorkingDir,
+		StopGracePeriod: inputs.StopGracePeriod,
+		Volumes:         inputs.Volumes,
+		VolumesFrom:     inputs.VolumesFrom,
+		DependsOn:       inputs.DependsOn,
 	}
 
 	projectName := inputs.ProjectName
@@ -92,10 +126,23 @@ func (*Service) Construct(
 
 	image := pulumi.String(inputs.Image)
 
-	if err := createService(ctx, comp, projectName, configProvider, name, image, svc, infra); err != nil {
+	extras := &serviceExtras{
+		ServiceAccountEmail: inputs.ServiceAccountEmail,
+		Sidecars:            inputs.Sidecars,
+		Triggers:            inputs.Triggers,
+	}
+	if err := createService(ctx, comp, projectName, configProvider, name, image, svc, infra, extras); err != nil {
 		return nil, err
 	}
 	return comp, nil
+}
+
+// serviceExtras carries standalone-only Service inputs into the shared worker.
+// The project dispatcher passes nil (compose files cannot express these).
+type serviceExtras struct {
+	ServiceAccountEmail pulumi.StringInput
+	Sidecars            map[string]compose.ServiceConfig
+	Triggers            pulumi.StringMapInput
 }
 
 // createService creates the service account, optional LLM IAM bindings, and either
@@ -111,17 +158,32 @@ func createService(
 	image pulumi.StringInput,
 	svc compose.ServiceConfig,
 	infra *providergcp.SharedInfra,
+	extras *serviceExtras,
 ) error {
 	parentOpt := pulumi.Parent(comp)
 	childOpts := []pulumi.ResourceOption{parentOpt}
+	if extras == nil {
+		extras = &serviceExtras{}
+	}
+	for name, sc := range extras.Sidecars {
+		if sc.Image == nil || *sc.Image == "" {
+			return fmt.Errorf("service %s sidecar %s: %w", serviceName, name, common.ErrStandaloneServiceRequiresImage)
+		}
+	}
 
-	sa, err := createServiceAccount(ctx, projectName, serviceName, infra, childOpts)
-	if err != nil {
-		return err
+	var identity *providergcp.ServiceIdentity
+	if extras.ServiceAccountEmail != nil {
+		identity = &providergcp.ServiceIdentity{Email: extras.ServiceAccountEmail}
+	} else {
+		sa, err := createServiceAccount(ctx, projectName, serviceName, infra, childOpts)
+		if err != nil {
+			return err
+		}
+		identity = &providergcp.ServiceIdentity{Account: sa, Email: sa.Email}
 	}
 
 	if svc.LLM != nil {
-		if err := enableLLM(ctx, serviceName, &svc, sa, infra, childOpts); err != nil {
+		if err := enableLLM(ctx, serviceName, &svc, identity, infra, childOpts); err != nil {
 			return err
 		}
 	}
@@ -129,13 +191,23 @@ func createService(
 	var endpoint pulumi.StringOutput
 	var lbEntry *providergcp.LBServiceEntry
 
-	// Compute Engine requires a project VPC/subnet/public IP; standalone (no
-	// shared infra) can only deploy via Cloud Run. Force Cloud Run when no VPC
-	// is available, regardless of port configuration.
-	useCloudRun := providergcp.IsCloudRunService(&svc) || infra.PublicIP == nil
+	// Cloud Run for single-ingress-port services; everything else (portless
+	// workers, host ports, multiple ports) runs on Compute Engine — unless
+	// there's no shared project infra, where the legacy standalone behavior of
+	// forcing Cloud Run is preserved. Sidecars/volumes are CE-only, so they
+	// override the standalone forcing (CE then attaches to the default network)
+	// but are an error on services whose port shape demands Cloud Run.
+	needsCE := len(extras.Sidecars) > 0 || len(svc.Volumes) > 0 || len(svc.VolumesFrom) > 0
+	useCloudRun := providergcp.IsCloudRunService(&svc)
+	if !useCloudRun && infra.PublicIP == nil && !needsCE {
+		useCloudRun = true // legacy: standalone CE was unsupported (no shared VPC)
+	}
 	if useCloudRun {
+		if needsCE {
+			return fmt.Errorf("service %s: %w", serviceName, errSidecarsRequireComputeEngine)
+		}
 		crResult, crErr := providergcp.CreateCloudRunService(
-			ctx, configProvider, serviceName, image, svc, sa, infra, parentOpt,
+			ctx, configProvider, serviceName, image, svc, identity, infra, parentOpt,
 		)
 		if crErr != nil {
 			return fmt.Errorf("creating Cloud Run service %s: %w", serviceName, crErr)
@@ -143,13 +215,23 @@ func createService(
 		endpoint = crResult.Service.Uri
 		lbEntry = &providergcp.LBServiceEntry{Name: serviceName, CloudRunService: crResult.Service, Config: svc}
 	} else {
+		ceArgs := &providergcp.ComputeEngineArgs{
+			SA:       identity,
+			Sidecars: extras.Sidecars,
+			Triggers: extras.Triggers,
+		}
 		ceResult, ceErr := providergcp.CreateComputeEngine(
-			ctx, serviceName, image, svc, sa, infra, parentOpt,
+			ctx, serviceName, image, svc, ceArgs, infra, parentOpt,
 		)
 		if ceErr != nil {
 			return fmt.Errorf("creating Compute Engine service %s: %w", serviceName, ceErr)
 		}
-		endpoint = infra.PublicIP.Address.ToStringOutput()
+		if infra.PublicIP != nil {
+			endpoint = infra.PublicIP.Address.ToStringOutput()
+		} else {
+			// standalone CE has no load balancer; portless workers have no endpoint
+			endpoint = pulumi.String("").ToStringOutput()
+		}
 		if svc.HasIngressPorts() || svc.HasHostPorts() {
 			lbEntry = &providergcp.LBServiceEntry{Name: serviceName, InstanceGroup: ceResult.InstanceGroup, Config: svc}
 		}
@@ -159,11 +241,14 @@ func createService(
 		lbEntry.PrivateFqdn = fmt.Sprintf("%s.%s", common.ServiceLabel(serviceName), "google.internal")
 	}
 
+	saEmail := identity.Email.ToStringOutput()
 	comp.Endpoint = endpoint
+	comp.ServiceAccountEmail = saEmail
 	comp.LBEntry = lbEntry
 
 	if err := ctx.RegisterResourceOutputs(comp, pulumi.Map{
-		"endpoint": endpoint,
+		"endpoint":            endpoint,
+		"serviceAccountEmail": saEmail,
 	}); err != nil {
 		return fmt.Errorf("registering outputs for %s: %w", serviceName, err)
 	}

--- a/provider/defanggcp/service.go
+++ b/provider/defanggcp/service.go
@@ -14,6 +14,8 @@ var (
 	errSidecarsRequireComputeEngine = errors.New(
 		"sidecars and volumes are only supported on Compute Engine services (no single ingress port)")
 	errPoliciesUnsupported = errors.New("x-defang-policies is not supported on GCP")
+	errSidecarImageNotStatic = errors.New(
+		"sidecar image must be a static string on GCP (it is baked into a cloud-init systemd unit)")
 )
 
 // Service is the controller struct for the defang-gcp:index:Service component.
@@ -149,6 +151,21 @@ type serviceExtras struct {
 	Triggers            pulumi.StringMapInput
 }
 
+// validateSidecarImages requires every sidecar to have a non-empty, static
+// image: it gets baked into a cloud-init systemd unit, so Outputs won't do.
+func validateSidecarImages(serviceName string, sidecars map[string]compose.ServiceConfig) error {
+	for name, sc := range sidecars {
+		img := sc.StaticImage()
+		if sc.Image != nil && img == nil {
+			return fmt.Errorf("service %s sidecar %s: %w", serviceName, name, errSidecarImageNotStatic)
+		}
+		if img == nil || *img == "" {
+			return fmt.Errorf("service %s sidecar %s: %w", serviceName, name, common.ErrStandaloneServiceRequiresImage)
+		}
+	}
+	return nil
+}
+
 // createService creates the service account, optional LLM IAM bindings, and either
 // the Cloud Run service or Compute Engine MIG under an already-registered Service
 // component, populates its Endpoint/LBEntry, and registers its outputs. Shared
@@ -172,10 +189,8 @@ func createService(
 	if len(svc.Policies) > 0 {
 		return fmt.Errorf("service %s: %w", serviceName, errPoliciesUnsupported)
 	}
-	for name, sc := range extras.Sidecars {
-		if sc.Image == nil || *sc.Image == "" {
-			return fmt.Errorf("service %s sidecar %s: %w", serviceName, name, common.ErrStandaloneServiceRequiresImage)
-		}
+	if err := validateSidecarImages(serviceName, extras.Sidecars); err != nil {
+		return err
 	}
 
 	var identity *providergcp.ServiceIdentity

--- a/provider/defanggcp/service.go
+++ b/provider/defanggcp/service.go
@@ -33,7 +33,7 @@ type ServiceInputs struct {
 	ProjectName string                      `pulumi:"projectName"`
 	Ports       []compose.ServicePortConfig `pulumi:"ports,optional"`
 	Deploy      *compose.DeployConfig       `pulumi:"deploy,optional"`
-	Environment map[string]*string          `pulumi:"environment,optional"`
+	Environment compose.Environment             `pulumi:"environment,optional"`
 	Command     []string                    `pulumi:"command,optional"`
 	Entrypoint  []string                    `pulumi:"entrypoint,optional"`
 	HealthCheck *compose.HealthCheckConfig  `pulumi:"healthCheck,optional"`

--- a/provider/defanggcp/service.go
+++ b/provider/defanggcp/service.go
@@ -10,8 +10,11 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-var errSidecarsRequireComputeEngine = errors.New(
-	"sidecars and volumes are only supported on Compute Engine services (no single ingress port)")
+var (
+	errSidecarsRequireComputeEngine = errors.New(
+		"sidecars and volumes are only supported on Compute Engine services (no single ingress port)")
+	errPoliciesUnsupported = errors.New("x-defang-policies is not supported on GCP")
+)
 
 // Service is the controller struct for the defang-gcp:index:Service component.
 type Service struct{}
@@ -21,7 +24,9 @@ type Service struct{}
 // via Image. Build orchestration belongs to the Project component, which provisions the
 // shared BuildInfra (Artifact Registry + Cloud Build) needed to produce the image.
 type ServiceInputs struct {
-	Image       string                      `pulumi:"image"`
+	// Image is the pre-built container image URI; it may be an Output of an
+	// image build (e.g. a Build resource or a caller-side pipeline).
+	Image       pulumi.StringInput          `pulumi:"image"`
 	Platform    *string                     `pulumi:"platform,optional"`
 	ProjectName string                      `pulumi:"projectName"`
 	Ports       []compose.ServicePortConfig `pulumi:"ports,optional"`
@@ -86,11 +91,10 @@ func (*Service) Construct(
 		return nil, err
 	}
 
-	if inputs.Image == "" {
+	if inputs.Image == nil {
 		return nil, fmt.Errorf("service %s: %w", name, common.ErrStandaloneServiceRequiresImage)
 	}
 	svc := compose.ServiceConfig{
-		Image:           &inputs.Image,
 		Platform:        inputs.Platform,
 		Ports:           inputs.Ports,
 		Deploy:          inputs.Deploy,
@@ -124,7 +128,7 @@ func (*Service) Construct(
 		infra = providergcp.NewStandaloneGlobalConfig(ctx)
 	}
 
-	image := pulumi.String(inputs.Image)
+	image := inputs.Image
 
 	extras := &serviceExtras{
 		ServiceAccountEmail: inputs.ServiceAccountEmail,
@@ -164,6 +168,9 @@ func createService(
 	childOpts := []pulumi.ResourceOption{parentOpt}
 	if extras == nil {
 		extras = &serviceExtras{}
+	}
+	if len(svc.Policies) > 0 {
+		return fmt.Errorf("service %s: %w", serviceName, errPoliciesUnsupported)
 	}
 	for name, sc := range extras.Sidecars {
 		if sc.Image == nil || *sc.Image == "" {

--- a/sdk/v2/go/defang-aws/aws/pulumiTypes.go
+++ b/sdk/v2/go/defang-aws/aws/pulumiTypes.go
@@ -14,11 +14,18 @@ import (
 var _ = internal.GetEnvOrDefault
 
 type SharedInfra struct {
-	PrivateSgID      *string  `pulumi:"privateSgID"`
-	PrivateSubnetIDs []string `pulumi:"privateSubnetIDs"`
-	PrivateZoneID    *string  `pulumi:"privateZoneID"`
-	PublicSubnetIDs  []string `pulumi:"publicSubnetIDs"`
-	VpcID            string   `pulumi:"vpcID"`
+	AlbDnsName         *string  `pulumi:"albDnsName"`
+	AlbSecurityGroupId *string  `pulumi:"albSecurityGroupId"`
+	ClusterArn         *string  `pulumi:"clusterArn"`
+	ExecutionRoleArn   *string  `pulumi:"executionRoleArn"`
+	HttpListenerArn    *string  `pulumi:"httpListenerArn"`
+	HttpsListenerArn   *string  `pulumi:"httpsListenerArn"`
+	LogGroupName       *string  `pulumi:"logGroupName"`
+	PrivateSgID        *string  `pulumi:"privateSgID"`
+	PrivateSubnetIDs   []string `pulumi:"privateSubnetIDs"`
+	PrivateZoneID      *string  `pulumi:"privateZoneID"`
+	PublicSubnetIDs    []string `pulumi:"publicSubnetIDs"`
+	VpcID              string   `pulumi:"vpcID"`
 }
 
 // SharedInfraInput is an input type that accepts SharedInfraArgs and SharedInfraOutput values.
@@ -33,11 +40,18 @@ type SharedInfraInput interface {
 }
 
 type SharedInfraArgs struct {
-	PrivateSgID      pulumi.StringPtrInput   `pulumi:"privateSgID"`
-	PrivateSubnetIDs pulumi.StringArrayInput `pulumi:"privateSubnetIDs"`
-	PrivateZoneID    pulumi.StringPtrInput   `pulumi:"privateZoneID"`
-	PublicSubnetIDs  pulumi.StringArrayInput `pulumi:"publicSubnetIDs"`
-	VpcID            pulumi.StringInput      `pulumi:"vpcID"`
+	AlbDnsName         pulumi.StringPtrInput   `pulumi:"albDnsName"`
+	AlbSecurityGroupId pulumi.StringPtrInput   `pulumi:"albSecurityGroupId"`
+	ClusterArn         pulumi.StringPtrInput   `pulumi:"clusterArn"`
+	ExecutionRoleArn   pulumi.StringPtrInput   `pulumi:"executionRoleArn"`
+	HttpListenerArn    pulumi.StringPtrInput   `pulumi:"httpListenerArn"`
+	HttpsListenerArn   pulumi.StringPtrInput   `pulumi:"httpsListenerArn"`
+	LogGroupName       pulumi.StringPtrInput   `pulumi:"logGroupName"`
+	PrivateSgID        pulumi.StringPtrInput   `pulumi:"privateSgID"`
+	PrivateSubnetIDs   pulumi.StringArrayInput `pulumi:"privateSubnetIDs"`
+	PrivateZoneID      pulumi.StringPtrInput   `pulumi:"privateZoneID"`
+	PublicSubnetIDs    pulumi.StringArrayInput `pulumi:"publicSubnetIDs"`
+	VpcID              pulumi.StringInput      `pulumi:"vpcID"`
 }
 
 func (SharedInfraArgs) ElementType() reflect.Type {
@@ -117,6 +131,34 @@ func (o SharedInfraOutput) ToSharedInfraPtrOutputWithContext(ctx context.Context
 	}).(SharedInfraPtrOutput)
 }
 
+func (o SharedInfraOutput) AlbDnsName() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v SharedInfra) *string { return v.AlbDnsName }).(pulumi.StringPtrOutput)
+}
+
+func (o SharedInfraOutput) AlbSecurityGroupId() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v SharedInfra) *string { return v.AlbSecurityGroupId }).(pulumi.StringPtrOutput)
+}
+
+func (o SharedInfraOutput) ClusterArn() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v SharedInfra) *string { return v.ClusterArn }).(pulumi.StringPtrOutput)
+}
+
+func (o SharedInfraOutput) ExecutionRoleArn() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v SharedInfra) *string { return v.ExecutionRoleArn }).(pulumi.StringPtrOutput)
+}
+
+func (o SharedInfraOutput) HttpListenerArn() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v SharedInfra) *string { return v.HttpListenerArn }).(pulumi.StringPtrOutput)
+}
+
+func (o SharedInfraOutput) HttpsListenerArn() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v SharedInfra) *string { return v.HttpsListenerArn }).(pulumi.StringPtrOutput)
+}
+
+func (o SharedInfraOutput) LogGroupName() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v SharedInfra) *string { return v.LogGroupName }).(pulumi.StringPtrOutput)
+}
+
 func (o SharedInfraOutput) PrivateSgID() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v SharedInfra) *string { return v.PrivateSgID }).(pulumi.StringPtrOutput)
 }
@@ -159,6 +201,69 @@ func (o SharedInfraPtrOutput) Elem() SharedInfraOutput {
 		var ret SharedInfra
 		return ret
 	}).(SharedInfraOutput)
+}
+
+func (o SharedInfraPtrOutput) AlbDnsName() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *SharedInfra) *string {
+		if v == nil {
+			return nil
+		}
+		return v.AlbDnsName
+	}).(pulumi.StringPtrOutput)
+}
+
+func (o SharedInfraPtrOutput) AlbSecurityGroupId() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *SharedInfra) *string {
+		if v == nil {
+			return nil
+		}
+		return v.AlbSecurityGroupId
+	}).(pulumi.StringPtrOutput)
+}
+
+func (o SharedInfraPtrOutput) ClusterArn() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *SharedInfra) *string {
+		if v == nil {
+			return nil
+		}
+		return v.ClusterArn
+	}).(pulumi.StringPtrOutput)
+}
+
+func (o SharedInfraPtrOutput) ExecutionRoleArn() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *SharedInfra) *string {
+		if v == nil {
+			return nil
+		}
+		return v.ExecutionRoleArn
+	}).(pulumi.StringPtrOutput)
+}
+
+func (o SharedInfraPtrOutput) HttpListenerArn() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *SharedInfra) *string {
+		if v == nil {
+			return nil
+		}
+		return v.HttpListenerArn
+	}).(pulumi.StringPtrOutput)
+}
+
+func (o SharedInfraPtrOutput) HttpsListenerArn() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *SharedInfra) *string {
+		if v == nil {
+			return nil
+		}
+		return v.HttpsListenerArn
+	}).(pulumi.StringPtrOutput)
+}
+
+func (o SharedInfraPtrOutput) LogGroupName() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *SharedInfra) *string {
+		if v == nil {
+			return nil
+		}
+		return v.LogGroupName
+	}).(pulumi.StringPtrOutput)
 }
 
 func (o SharedInfraPtrOutput) PrivateSgID() pulumi.StringPtrOutput {

--- a/sdk/v2/go/defang-aws/aws/pulumiTypes.go
+++ b/sdk/v2/go/defang-aws/aws/pulumiTypes.go
@@ -14,18 +14,14 @@ import (
 var _ = internal.GetEnvOrDefault
 
 type SharedInfra struct {
-	AlbDnsName         *string  `pulumi:"albDnsName"`
-	AlbSecurityGroupId *string  `pulumi:"albSecurityGroupId"`
-	ClusterArn         *string  `pulumi:"clusterArn"`
-	ExecutionRoleArn   *string  `pulumi:"executionRoleArn"`
-	HttpListenerArn    *string  `pulumi:"httpListenerArn"`
-	HttpsListenerArn   *string  `pulumi:"httpsListenerArn"`
-	LogGroupName       *string  `pulumi:"logGroupName"`
-	PrivateSgID        *string  `pulumi:"privateSgID"`
-	PrivateSubnetIDs   []string `pulumi:"privateSubnetIDs"`
-	PrivateZoneID      *string  `pulumi:"privateZoneID"`
-	PublicSubnetIDs    []string `pulumi:"publicSubnetIDs"`
-	VpcID              string   `pulumi:"vpcID"`
+	ClusterArn       *string  `pulumi:"clusterArn"`
+	ExecutionRoleArn *string  `pulumi:"executionRoleArn"`
+	LogGroupName     *string  `pulumi:"logGroupName"`
+	PrivateSgID      *string  `pulumi:"privateSgID"`
+	PrivateSubnetIDs []string `pulumi:"privateSubnetIDs"`
+	PrivateZoneID    *string  `pulumi:"privateZoneID"`
+	PublicSubnetIDs  []string `pulumi:"publicSubnetIDs"`
+	VpcID            string   `pulumi:"vpcID"`
 }
 
 // SharedInfraInput is an input type that accepts SharedInfraArgs and SharedInfraOutput values.
@@ -40,18 +36,14 @@ type SharedInfraInput interface {
 }
 
 type SharedInfraArgs struct {
-	AlbDnsName         pulumi.StringPtrInput   `pulumi:"albDnsName"`
-	AlbSecurityGroupId pulumi.StringPtrInput   `pulumi:"albSecurityGroupId"`
-	ClusterArn         pulumi.StringPtrInput   `pulumi:"clusterArn"`
-	ExecutionRoleArn   pulumi.StringPtrInput   `pulumi:"executionRoleArn"`
-	HttpListenerArn    pulumi.StringPtrInput   `pulumi:"httpListenerArn"`
-	HttpsListenerArn   pulumi.StringPtrInput   `pulumi:"httpsListenerArn"`
-	LogGroupName       pulumi.StringPtrInput   `pulumi:"logGroupName"`
-	PrivateSgID        pulumi.StringPtrInput   `pulumi:"privateSgID"`
-	PrivateSubnetIDs   pulumi.StringArrayInput `pulumi:"privateSubnetIDs"`
-	PrivateZoneID      pulumi.StringPtrInput   `pulumi:"privateZoneID"`
-	PublicSubnetIDs    pulumi.StringArrayInput `pulumi:"publicSubnetIDs"`
-	VpcID              pulumi.StringInput      `pulumi:"vpcID"`
+	ClusterArn       pulumi.StringPtrInput   `pulumi:"clusterArn"`
+	ExecutionRoleArn pulumi.StringPtrInput   `pulumi:"executionRoleArn"`
+	LogGroupName     pulumi.StringPtrInput   `pulumi:"logGroupName"`
+	PrivateSgID      pulumi.StringPtrInput   `pulumi:"privateSgID"`
+	PrivateSubnetIDs pulumi.StringArrayInput `pulumi:"privateSubnetIDs"`
+	PrivateZoneID    pulumi.StringPtrInput   `pulumi:"privateZoneID"`
+	PublicSubnetIDs  pulumi.StringArrayInput `pulumi:"publicSubnetIDs"`
+	VpcID            pulumi.StringInput      `pulumi:"vpcID"`
 }
 
 func (SharedInfraArgs) ElementType() reflect.Type {
@@ -131,28 +123,12 @@ func (o SharedInfraOutput) ToSharedInfraPtrOutputWithContext(ctx context.Context
 	}).(SharedInfraPtrOutput)
 }
 
-func (o SharedInfraOutput) AlbDnsName() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v SharedInfra) *string { return v.AlbDnsName }).(pulumi.StringPtrOutput)
-}
-
-func (o SharedInfraOutput) AlbSecurityGroupId() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v SharedInfra) *string { return v.AlbSecurityGroupId }).(pulumi.StringPtrOutput)
-}
-
 func (o SharedInfraOutput) ClusterArn() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v SharedInfra) *string { return v.ClusterArn }).(pulumi.StringPtrOutput)
 }
 
 func (o SharedInfraOutput) ExecutionRoleArn() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v SharedInfra) *string { return v.ExecutionRoleArn }).(pulumi.StringPtrOutput)
-}
-
-func (o SharedInfraOutput) HttpListenerArn() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v SharedInfra) *string { return v.HttpListenerArn }).(pulumi.StringPtrOutput)
-}
-
-func (o SharedInfraOutput) HttpsListenerArn() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v SharedInfra) *string { return v.HttpsListenerArn }).(pulumi.StringPtrOutput)
 }
 
 func (o SharedInfraOutput) LogGroupName() pulumi.StringPtrOutput {
@@ -203,24 +179,6 @@ func (o SharedInfraPtrOutput) Elem() SharedInfraOutput {
 	}).(SharedInfraOutput)
 }
 
-func (o SharedInfraPtrOutput) AlbDnsName() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *SharedInfra) *string {
-		if v == nil {
-			return nil
-		}
-		return v.AlbDnsName
-	}).(pulumi.StringPtrOutput)
-}
-
-func (o SharedInfraPtrOutput) AlbSecurityGroupId() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *SharedInfra) *string {
-		if v == nil {
-			return nil
-		}
-		return v.AlbSecurityGroupId
-	}).(pulumi.StringPtrOutput)
-}
-
 func (o SharedInfraPtrOutput) ClusterArn() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *SharedInfra) *string {
 		if v == nil {
@@ -236,24 +194,6 @@ func (o SharedInfraPtrOutput) ExecutionRoleArn() pulumi.StringPtrOutput {
 			return nil
 		}
 		return v.ExecutionRoleArn
-	}).(pulumi.StringPtrOutput)
-}
-
-func (o SharedInfraPtrOutput) HttpListenerArn() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *SharedInfra) *string {
-		if v == nil {
-			return nil
-		}
-		return v.HttpListenerArn
-	}).(pulumi.StringPtrOutput)
-}
-
-func (o SharedInfraPtrOutput) HttpsListenerArn() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *SharedInfra) *string {
-		if v == nil {
-			return nil
-		}
-		return v.HttpsListenerArn
 	}).(pulumi.StringPtrOutput)
 }
 

--- a/sdk/v2/go/defang-aws/compose/pulumiTypes.go
+++ b/sdk/v2/go/defang-aws/compose/pulumiTypes.go
@@ -15,8 +15,11 @@ var _ = internal.GetEnvOrDefault
 
 type BuildConfig struct {
 	Args       map[string]string `pulumi:"args"`
+	CacheFrom  []string          `pulumi:"cacheFrom"`
+	CacheTo    []string          `pulumi:"cacheTo"`
 	Context    string            `pulumi:"context"`
 	Dockerfile *string           `pulumi:"dockerfile"`
+	Platforms  []string          `pulumi:"platforms"`
 	ShmSize    *string           `pulumi:"shmSize"`
 	Target     *string           `pulumi:"target"`
 }
@@ -33,11 +36,14 @@ type BuildConfigInput interface {
 }
 
 type BuildConfigArgs struct {
-	Args       pulumi.StringMapInput `pulumi:"args"`
-	Context    pulumi.StringInput    `pulumi:"context"`
-	Dockerfile pulumi.StringPtrInput `pulumi:"dockerfile"`
-	ShmSize    pulumi.StringPtrInput `pulumi:"shmSize"`
-	Target     pulumi.StringPtrInput `pulumi:"target"`
+	Args       pulumi.StringMapInput   `pulumi:"args"`
+	CacheFrom  pulumi.StringArrayInput `pulumi:"cacheFrom"`
+	CacheTo    pulumi.StringArrayInput `pulumi:"cacheTo"`
+	Context    pulumi.StringInput      `pulumi:"context"`
+	Dockerfile pulumi.StringPtrInput   `pulumi:"dockerfile"`
+	Platforms  pulumi.StringArrayInput `pulumi:"platforms"`
+	ShmSize    pulumi.StringPtrInput   `pulumi:"shmSize"`
+	Target     pulumi.StringPtrInput   `pulumi:"target"`
 }
 
 func (BuildConfigArgs) ElementType() reflect.Type {
@@ -121,12 +127,24 @@ func (o BuildConfigOutput) Args() pulumi.StringMapOutput {
 	return o.ApplyT(func(v BuildConfig) map[string]string { return v.Args }).(pulumi.StringMapOutput)
 }
 
+func (o BuildConfigOutput) CacheFrom() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v BuildConfig) []string { return v.CacheFrom }).(pulumi.StringArrayOutput)
+}
+
+func (o BuildConfigOutput) CacheTo() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v BuildConfig) []string { return v.CacheTo }).(pulumi.StringArrayOutput)
+}
+
 func (o BuildConfigOutput) Context() pulumi.StringOutput {
 	return o.ApplyT(func(v BuildConfig) string { return v.Context }).(pulumi.StringOutput)
 }
 
 func (o BuildConfigOutput) Dockerfile() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v BuildConfig) *string { return v.Dockerfile }).(pulumi.StringPtrOutput)
+}
+
+func (o BuildConfigOutput) Platforms() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v BuildConfig) []string { return v.Platforms }).(pulumi.StringArrayOutput)
 }
 
 func (o BuildConfigOutput) ShmSize() pulumi.StringPtrOutput {
@@ -170,6 +188,24 @@ func (o BuildConfigPtrOutput) Args() pulumi.StringMapOutput {
 	}).(pulumi.StringMapOutput)
 }
 
+func (o BuildConfigPtrOutput) CacheFrom() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *BuildConfig) []string {
+		if v == nil {
+			return nil
+		}
+		return v.CacheFrom
+	}).(pulumi.StringArrayOutput)
+}
+
+func (o BuildConfigPtrOutput) CacheTo() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *BuildConfig) []string {
+		if v == nil {
+			return nil
+		}
+		return v.CacheTo
+	}).(pulumi.StringArrayOutput)
+}
+
 func (o BuildConfigPtrOutput) Context() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *BuildConfig) *string {
 		if v == nil {
@@ -186,6 +222,15 @@ func (o BuildConfigPtrOutput) Dockerfile() pulumi.StringPtrOutput {
 		}
 		return v.Dockerfile
 	}).(pulumi.StringPtrOutput)
+}
+
+func (o BuildConfigPtrOutput) Platforms() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *BuildConfig) []string {
+		if v == nil {
+			return nil
+		}
+		return v.Platforms
+	}).(pulumi.StringArrayOutput)
 }
 
 func (o BuildConfigPtrOutput) ShmSize() pulumi.StringPtrOutput {
@@ -1337,22 +1382,28 @@ func (o ResourcesPtrOutput) Reservations() ResourceConfigPtrOutput {
 }
 
 type ServiceConfig struct {
-	Build       *BuildConfig                    `pulumi:"build"`
-	Command     []string                        `pulumi:"command"`
-	DependsOn   map[string]ServiceDependency    `pulumi:"dependsOn"`
-	Deploy      *DeployConfig                   `pulumi:"deploy"`
-	DomainName  *string                         `pulumi:"domainName"`
-	Entrypoint  []string                        `pulumi:"entrypoint"`
-	Environment map[string]string               `pulumi:"environment"`
-	HealthCheck *HealthCheckConfig              `pulumi:"healthCheck"`
-	Image       *string                         `pulumi:"image"`
-	Llm         *LlmConfig                      `pulumi:"llm"`
-	Networks    map[string]ServiceNetworkConfig `pulumi:"networks"`
-	Platform    *string                         `pulumi:"platform"`
-	Ports       []ServicePortConfig             `pulumi:"ports"`
-	Postgres    *PostgresConfig                 `pulumi:"postgres"`
-	Redis       *RedisConfig                    `pulumi:"redis"`
-	Restart     *string                         `pulumi:"restart"`
+	Autoscaling     *bool                           `pulumi:"autoscaling"`
+	Build           *BuildConfig                    `pulumi:"build"`
+	Command         []string                        `pulumi:"command"`
+	ContainerName   *string                         `pulumi:"containerName"`
+	DependsOn       map[string]ServiceDependency    `pulumi:"dependsOn"`
+	Deploy          *DeployConfig                   `pulumi:"deploy"`
+	DomainName      *string                         `pulumi:"domainName"`
+	Entrypoint      []string                        `pulumi:"entrypoint"`
+	Environment     map[string]string               `pulumi:"environment"`
+	HealthCheck     *HealthCheckConfig              `pulumi:"healthCheck"`
+	Image           *string                         `pulumi:"image"`
+	Llm             *LlmConfig                      `pulumi:"llm"`
+	Networks        map[string]ServiceNetworkConfig `pulumi:"networks"`
+	Platform        *string                         `pulumi:"platform"`
+	Ports           []ServicePortConfig             `pulumi:"ports"`
+	Postgres        *PostgresConfig                 `pulumi:"postgres"`
+	Redis           *RedisConfig                    `pulumi:"redis"`
+	Restart         *string                         `pulumi:"restart"`
+	StopGracePeriod *string                         `pulumi:"stopGracePeriod"`
+	Volumes         []ServiceVolumeConfig           `pulumi:"volumes"`
+	VolumesFrom     []string                        `pulumi:"volumesFrom"`
+	WorkingDir      *string                         `pulumi:"workingDir"`
 }
 
 // ServiceConfigInput is an input type that accepts ServiceConfigArgs and ServiceConfigOutput values.
@@ -1367,22 +1418,28 @@ type ServiceConfigInput interface {
 }
 
 type ServiceConfigArgs struct {
-	Build       BuildConfigPtrInput          `pulumi:"build"`
-	Command     pulumi.StringArrayInput      `pulumi:"command"`
-	DependsOn   ServiceDependencyMapInput    `pulumi:"dependsOn"`
-	Deploy      DeployConfigPtrInput         `pulumi:"deploy"`
-	DomainName  pulumi.StringPtrInput        `pulumi:"domainName"`
-	Entrypoint  pulumi.StringArrayInput      `pulumi:"entrypoint"`
-	Environment pulumi.StringMapInput        `pulumi:"environment"`
-	HealthCheck HealthCheckConfigPtrInput    `pulumi:"healthCheck"`
-	Image       pulumi.StringPtrInput        `pulumi:"image"`
-	Llm         LlmConfigPtrInput            `pulumi:"llm"`
-	Networks    ServiceNetworkConfigMapInput `pulumi:"networks"`
-	Platform    pulumi.StringPtrInput        `pulumi:"platform"`
-	Ports       ServicePortConfigArrayInput  `pulumi:"ports"`
-	Postgres    PostgresConfigPtrInput       `pulumi:"postgres"`
-	Redis       RedisConfigPtrInput          `pulumi:"redis"`
-	Restart     pulumi.StringPtrInput        `pulumi:"restart"`
+	Autoscaling     pulumi.BoolPtrInput           `pulumi:"autoscaling"`
+	Build           BuildConfigPtrInput           `pulumi:"build"`
+	Command         pulumi.StringArrayInput       `pulumi:"command"`
+	ContainerName   pulumi.StringPtrInput         `pulumi:"containerName"`
+	DependsOn       ServiceDependencyMapInput     `pulumi:"dependsOn"`
+	Deploy          DeployConfigPtrInput          `pulumi:"deploy"`
+	DomainName      pulumi.StringPtrInput         `pulumi:"domainName"`
+	Entrypoint      pulumi.StringArrayInput       `pulumi:"entrypoint"`
+	Environment     pulumi.StringMapInput         `pulumi:"environment"`
+	HealthCheck     HealthCheckConfigPtrInput     `pulumi:"healthCheck"`
+	Image           pulumi.StringPtrInput         `pulumi:"image"`
+	Llm             LlmConfigPtrInput             `pulumi:"llm"`
+	Networks        ServiceNetworkConfigMapInput  `pulumi:"networks"`
+	Platform        pulumi.StringPtrInput         `pulumi:"platform"`
+	Ports           ServicePortConfigArrayInput   `pulumi:"ports"`
+	Postgres        PostgresConfigPtrInput        `pulumi:"postgres"`
+	Redis           RedisConfigPtrInput           `pulumi:"redis"`
+	Restart         pulumi.StringPtrInput         `pulumi:"restart"`
+	StopGracePeriod pulumi.StringPtrInput         `pulumi:"stopGracePeriod"`
+	Volumes         ServiceVolumeConfigArrayInput `pulumi:"volumes"`
+	VolumesFrom     pulumi.StringArrayInput       `pulumi:"volumesFrom"`
+	WorkingDir      pulumi.StringPtrInput         `pulumi:"workingDir"`
 }
 
 func (ServiceConfigArgs) ElementType() reflect.Type {
@@ -1436,12 +1493,20 @@ func (o ServiceConfigOutput) ToServiceConfigOutputWithContext(ctx context.Contex
 	return o
 }
 
+func (o ServiceConfigOutput) Autoscaling() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v ServiceConfig) *bool { return v.Autoscaling }).(pulumi.BoolPtrOutput)
+}
+
 func (o ServiceConfigOutput) Build() BuildConfigPtrOutput {
 	return o.ApplyT(func(v ServiceConfig) *BuildConfig { return v.Build }).(BuildConfigPtrOutput)
 }
 
 func (o ServiceConfigOutput) Command() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v ServiceConfig) []string { return v.Command }).(pulumi.StringArrayOutput)
+}
+
+func (o ServiceConfigOutput) ContainerName() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v ServiceConfig) *string { return v.ContainerName }).(pulumi.StringPtrOutput)
 }
 
 func (o ServiceConfigOutput) DependsOn() ServiceDependencyMapOutput {
@@ -1498,6 +1563,22 @@ func (o ServiceConfigOutput) Redis() RedisConfigPtrOutput {
 
 func (o ServiceConfigOutput) Restart() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ServiceConfig) *string { return v.Restart }).(pulumi.StringPtrOutput)
+}
+
+func (o ServiceConfigOutput) StopGracePeriod() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v ServiceConfig) *string { return v.StopGracePeriod }).(pulumi.StringPtrOutput)
+}
+
+func (o ServiceConfigOutput) Volumes() ServiceVolumeConfigArrayOutput {
+	return o.ApplyT(func(v ServiceConfig) []ServiceVolumeConfig { return v.Volumes }).(ServiceVolumeConfigArrayOutput)
+}
+
+func (o ServiceConfigOutput) VolumesFrom() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v ServiceConfig) []string { return v.VolumesFrom }).(pulumi.StringArrayOutput)
+}
+
+func (o ServiceConfigOutput) WorkingDir() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v ServiceConfig) *string { return v.WorkingDir }).(pulumi.StringPtrOutput)
 }
 
 type ServiceConfigMapOutput struct{ *pulumi.OutputState }
@@ -1716,6 +1797,7 @@ func (o ServiceNetworkConfigMapOutput) MapIndex(k pulumi.StringInput) ServiceNet
 
 type ServicePortConfig struct {
 	AppProtocol *string `pulumi:"appProtocol"`
+	Listener    *string `pulumi:"listener"`
 	Mode        *string `pulumi:"mode"`
 	Protocol    *string `pulumi:"protocol"`
 	Target      int     `pulumi:"target"`
@@ -1734,6 +1816,7 @@ type ServicePortConfigInput interface {
 
 type ServicePortConfigArgs struct {
 	AppProtocol pulumi.StringPtrInput `pulumi:"appProtocol"`
+	Listener    pulumi.StringPtrInput `pulumi:"listener"`
 	Mode        pulumi.StringPtrInput `pulumi:"mode"`
 	Protocol    pulumi.StringPtrInput `pulumi:"protocol"`
 	Target      pulumi.IntInput       `pulumi:"target"`
@@ -1794,6 +1877,10 @@ func (o ServicePortConfigOutput) AppProtocol() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ServicePortConfig) *string { return v.AppProtocol }).(pulumi.StringPtrOutput)
 }
 
+func (o ServicePortConfigOutput) Listener() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v ServicePortConfig) *string { return v.Listener }).(pulumi.StringPtrOutput)
+}
+
 func (o ServicePortConfigOutput) Mode() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ServicePortConfig) *string { return v.Mode }).(pulumi.StringPtrOutput)
 }
@@ -1826,6 +1913,112 @@ func (o ServicePortConfigArrayOutput) Index(i pulumi.IntInput) ServicePortConfig
 	}).(ServicePortConfigOutput)
 }
 
+type ServiceVolumeConfig struct {
+	ReadOnly *bool  `pulumi:"readOnly"`
+	Source   string `pulumi:"source"`
+	Target   string `pulumi:"target"`
+}
+
+// ServiceVolumeConfigInput is an input type that accepts ServiceVolumeConfigArgs and ServiceVolumeConfigOutput values.
+// You can construct a concrete instance of `ServiceVolumeConfigInput` via:
+//
+//	ServiceVolumeConfigArgs{...}
+type ServiceVolumeConfigInput interface {
+	pulumi.Input
+
+	ToServiceVolumeConfigOutput() ServiceVolumeConfigOutput
+	ToServiceVolumeConfigOutputWithContext(context.Context) ServiceVolumeConfigOutput
+}
+
+type ServiceVolumeConfigArgs struct {
+	ReadOnly pulumi.BoolPtrInput `pulumi:"readOnly"`
+	Source   pulumi.StringInput  `pulumi:"source"`
+	Target   pulumi.StringInput  `pulumi:"target"`
+}
+
+func (ServiceVolumeConfigArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*ServiceVolumeConfig)(nil)).Elem()
+}
+
+func (i ServiceVolumeConfigArgs) ToServiceVolumeConfigOutput() ServiceVolumeConfigOutput {
+	return i.ToServiceVolumeConfigOutputWithContext(context.Background())
+}
+
+func (i ServiceVolumeConfigArgs) ToServiceVolumeConfigOutputWithContext(ctx context.Context) ServiceVolumeConfigOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(ServiceVolumeConfigOutput)
+}
+
+// ServiceVolumeConfigArrayInput is an input type that accepts ServiceVolumeConfigArray and ServiceVolumeConfigArrayOutput values.
+// You can construct a concrete instance of `ServiceVolumeConfigArrayInput` via:
+//
+//	ServiceVolumeConfigArray{ ServiceVolumeConfigArgs{...} }
+type ServiceVolumeConfigArrayInput interface {
+	pulumi.Input
+
+	ToServiceVolumeConfigArrayOutput() ServiceVolumeConfigArrayOutput
+	ToServiceVolumeConfigArrayOutputWithContext(context.Context) ServiceVolumeConfigArrayOutput
+}
+
+type ServiceVolumeConfigArray []ServiceVolumeConfigInput
+
+func (ServiceVolumeConfigArray) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]ServiceVolumeConfig)(nil)).Elem()
+}
+
+func (i ServiceVolumeConfigArray) ToServiceVolumeConfigArrayOutput() ServiceVolumeConfigArrayOutput {
+	return i.ToServiceVolumeConfigArrayOutputWithContext(context.Background())
+}
+
+func (i ServiceVolumeConfigArray) ToServiceVolumeConfigArrayOutputWithContext(ctx context.Context) ServiceVolumeConfigArrayOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(ServiceVolumeConfigArrayOutput)
+}
+
+type ServiceVolumeConfigOutput struct{ *pulumi.OutputState }
+
+func (ServiceVolumeConfigOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*ServiceVolumeConfig)(nil)).Elem()
+}
+
+func (o ServiceVolumeConfigOutput) ToServiceVolumeConfigOutput() ServiceVolumeConfigOutput {
+	return o
+}
+
+func (o ServiceVolumeConfigOutput) ToServiceVolumeConfigOutputWithContext(ctx context.Context) ServiceVolumeConfigOutput {
+	return o
+}
+
+func (o ServiceVolumeConfigOutput) ReadOnly() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v ServiceVolumeConfig) *bool { return v.ReadOnly }).(pulumi.BoolPtrOutput)
+}
+
+func (o ServiceVolumeConfigOutput) Source() pulumi.StringOutput {
+	return o.ApplyT(func(v ServiceVolumeConfig) string { return v.Source }).(pulumi.StringOutput)
+}
+
+func (o ServiceVolumeConfigOutput) Target() pulumi.StringOutput {
+	return o.ApplyT(func(v ServiceVolumeConfig) string { return v.Target }).(pulumi.StringOutput)
+}
+
+type ServiceVolumeConfigArrayOutput struct{ *pulumi.OutputState }
+
+func (ServiceVolumeConfigArrayOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]ServiceVolumeConfig)(nil)).Elem()
+}
+
+func (o ServiceVolumeConfigArrayOutput) ToServiceVolumeConfigArrayOutput() ServiceVolumeConfigArrayOutput {
+	return o
+}
+
+func (o ServiceVolumeConfigArrayOutput) ToServiceVolumeConfigArrayOutputWithContext(ctx context.Context) ServiceVolumeConfigArrayOutput {
+	return o
+}
+
+func (o ServiceVolumeConfigArrayOutput) Index(i pulumi.IntInput) ServiceVolumeConfigOutput {
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) ServiceVolumeConfig {
+		return vs[0].([]ServiceVolumeConfig)[vs[1].(int)]
+	}).(ServiceVolumeConfigOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*BuildConfigInput)(nil)).Elem(), BuildConfigArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*BuildConfigPtrInput)(nil)).Elem(), BuildConfigArgs{})
@@ -1853,6 +2046,8 @@ func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*ServiceNetworkConfigMapInput)(nil)).Elem(), ServiceNetworkConfigMap{})
 	pulumi.RegisterInputType(reflect.TypeOf((*ServicePortConfigInput)(nil)).Elem(), ServicePortConfigArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*ServicePortConfigArrayInput)(nil)).Elem(), ServicePortConfigArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ServiceVolumeConfigInput)(nil)).Elem(), ServiceVolumeConfigArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ServiceVolumeConfigArrayInput)(nil)).Elem(), ServiceVolumeConfigArray{})
 	pulumi.RegisterOutputType(BuildConfigOutput{})
 	pulumi.RegisterOutputType(BuildConfigPtrOutput{})
 	pulumi.RegisterOutputType(DeployConfigOutput{})
@@ -1879,4 +2074,6 @@ func init() {
 	pulumi.RegisterOutputType(ServiceNetworkConfigMapOutput{})
 	pulumi.RegisterOutputType(ServicePortConfigOutput{})
 	pulumi.RegisterOutputType(ServicePortConfigArrayOutput{})
+	pulumi.RegisterOutputType(ServiceVolumeConfigOutput{})
+	pulumi.RegisterOutputType(ServiceVolumeConfigArrayOutput{})
 }

--- a/sdk/v2/go/defang-aws/compose/pulumiTypes.go
+++ b/sdk/v2/go/defang-aws/compose/pulumiTypes.go
@@ -1396,6 +1396,7 @@ type ServiceConfig struct {
 	Llm             *LlmConfig                      `pulumi:"llm"`
 	Networks        map[string]ServiceNetworkConfig `pulumi:"networks"`
 	Platform        *string                         `pulumi:"platform"`
+	Policies        []string                        `pulumi:"policies"`
 	Ports           []ServicePortConfig             `pulumi:"ports"`
 	Postgres        *PostgresConfig                 `pulumi:"postgres"`
 	Redis           *RedisConfig                    `pulumi:"redis"`
@@ -1432,6 +1433,7 @@ type ServiceConfigArgs struct {
 	Llm             LlmConfigPtrInput             `pulumi:"llm"`
 	Networks        ServiceNetworkConfigMapInput  `pulumi:"networks"`
 	Platform        pulumi.StringPtrInput         `pulumi:"platform"`
+	Policies        pulumi.StringArrayInput       `pulumi:"policies"`
 	Ports           ServicePortConfigArrayInput   `pulumi:"ports"`
 	Postgres        PostgresConfigPtrInput        `pulumi:"postgres"`
 	Redis           RedisConfigPtrInput           `pulumi:"redis"`
@@ -1547,6 +1549,10 @@ func (o ServiceConfigOutput) Networks() ServiceNetworkConfigMapOutput {
 
 func (o ServiceConfigOutput) Platform() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ServiceConfig) *string { return v.Platform }).(pulumi.StringPtrOutput)
+}
+
+func (o ServiceConfigOutput) Policies() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v ServiceConfig) []string { return v.Policies }).(pulumi.StringArrayOutput)
 }
 
 func (o ServiceConfigOutput) Ports() ServicePortConfigArrayOutput {

--- a/sdk/v2/go/defang-aws/compose/pulumiTypes.go
+++ b/sdk/v2/go/defang-aws/compose/pulumiTypes.go
@@ -1394,6 +1394,7 @@ type ServiceConfig struct {
 	HealthCheck     *HealthCheckConfig              `pulumi:"healthCheck"`
 	Image           *string                         `pulumi:"image"`
 	Llm             *LlmConfig                      `pulumi:"llm"`
+	NetworkMode     *string                         `pulumi:"networkMode"`
 	Networks        map[string]ServiceNetworkConfig `pulumi:"networks"`
 	Platform        *string                         `pulumi:"platform"`
 	Policies        []string                        `pulumi:"policies"`
@@ -1431,6 +1432,7 @@ type ServiceConfigArgs struct {
 	HealthCheck     HealthCheckConfigPtrInput     `pulumi:"healthCheck"`
 	Image           pulumi.StringPtrInput         `pulumi:"image"`
 	Llm             LlmConfigPtrInput             `pulumi:"llm"`
+	NetworkMode     pulumi.StringPtrInput         `pulumi:"networkMode"`
 	Networks        ServiceNetworkConfigMapInput  `pulumi:"networks"`
 	Platform        pulumi.StringPtrInput         `pulumi:"platform"`
 	Policies        pulumi.StringArrayInput       `pulumi:"policies"`
@@ -1541,6 +1543,10 @@ func (o ServiceConfigOutput) Image() pulumi.StringPtrOutput {
 
 func (o ServiceConfigOutput) Llm() LlmConfigPtrOutput {
 	return o.ApplyT(func(v ServiceConfig) *LlmConfig { return v.Llm }).(LlmConfigPtrOutput)
+}
+
+func (o ServiceConfigOutput) NetworkMode() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v ServiceConfig) *string { return v.NetworkMode }).(pulumi.StringPtrOutput)
 }
 
 func (o ServiceConfigOutput) Networks() ServiceNetworkConfigMapOutput {

--- a/sdk/v2/go/defang-aws/project.go
+++ b/sdk/v2/go/defang-aws/project.go
@@ -45,18 +45,20 @@ func NewProject(ctx *pulumi.Context,
 }
 
 type projectArgs struct {
-	Aws      *AWSConfig                       `pulumi:"aws"`
-	Etag     *string                          `pulumi:"etag"`
-	Networks map[string]compose.NetworkConfig `pulumi:"networks"`
-	Services map[string]compose.ServiceConfig `pulumi:"services"`
+	Aws                *AWSConfig                       `pulumi:"aws"`
+	Etag               *string                          `pulumi:"etag"`
+	Networks           map[string]compose.NetworkConfig `pulumi:"networks"`
+	Services           map[string]compose.ServiceConfig `pulumi:"services"`
+	WaitForSteadyState *bool                            `pulumi:"waitForSteadyState"`
 }
 
 // The set of arguments for constructing a Project resource.
 type ProjectArgs struct {
-	Aws      AWSConfigPtrInput
-	Etag     *string
-	Networks compose.NetworkConfigMapInput
-	Services compose.ServiceConfigMapInput
+	Aws                AWSConfigPtrInput
+	Etag               *string
+	Networks           compose.NetworkConfigMapInput
+	Services           compose.ServiceConfigMapInput
+	WaitForSteadyState *bool
 }
 
 func (ProjectArgs) ElementType() reflect.Type {

--- a/sdk/v2/go/defang-aws/project.go
+++ b/sdk/v2/go/defang-aws/project.go
@@ -16,8 +16,13 @@ import (
 type Project struct {
 	pulumi.ResourceState
 
+	ClusterName     pulumi.StringOutput    `pulumi:"clusterName"`
 	Endpoints       pulumi.StringMapOutput `pulumi:"endpoints"`
+	LoadBalancerArn pulumi.StringPtrOutput `pulumi:"loadBalancerArn"`
 	LoadBalancerDns pulumi.StringPtrOutput `pulumi:"loadBalancerDns"`
+	LogGroupName    pulumi.StringOutput    `pulumi:"logGroupName"`
+	ServiceNames    pulumi.StringMapOutput `pulumi:"serviceNames"`
+	TaskRoleArns    pulumi.StringMapOutput `pulumi:"taskRoleArns"`
 }
 
 // NewProject registers a new resource with the given unique name, arguments, and options.
@@ -91,12 +96,32 @@ func (o ProjectOutput) ToProjectOutputWithContext(ctx context.Context) ProjectOu
 	return o
 }
 
+func (o ProjectOutput) ClusterName() pulumi.StringOutput {
+	return o.ApplyT(func(v *Project) pulumi.StringOutput { return v.ClusterName }).(pulumi.StringOutput)
+}
+
 func (o ProjectOutput) Endpoints() pulumi.StringMapOutput {
 	return o.ApplyT(func(v *Project) pulumi.StringMapOutput { return v.Endpoints }).(pulumi.StringMapOutput)
 }
 
+func (o ProjectOutput) LoadBalancerArn() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Project) pulumi.StringPtrOutput { return v.LoadBalancerArn }).(pulumi.StringPtrOutput)
+}
+
 func (o ProjectOutput) LoadBalancerDns() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Project) pulumi.StringPtrOutput { return v.LoadBalancerDns }).(pulumi.StringPtrOutput)
+}
+
+func (o ProjectOutput) LogGroupName() pulumi.StringOutput {
+	return o.ApplyT(func(v *Project) pulumi.StringOutput { return v.LogGroupName }).(pulumi.StringOutput)
+}
+
+func (o ProjectOutput) ServiceNames() pulumi.StringMapOutput {
+	return o.ApplyT(func(v *Project) pulumi.StringMapOutput { return v.ServiceNames }).(pulumi.StringMapOutput)
+}
+
+func (o ProjectOutput) TaskRoleArns() pulumi.StringMapOutput {
+	return o.ApplyT(func(v *Project) pulumi.StringMapOutput { return v.TaskRoleArns }).(pulumi.StringMapOutput)
 }
 
 func init() {

--- a/sdk/v2/go/defang-aws/pulumiTypes.go
+++ b/sdk/v2/go/defang-aws/pulumiTypes.go
@@ -14,8 +14,13 @@ import (
 var _ = internal.GetEnvOrDefault
 
 type AWSConfig struct {
-	ProjectDomain *string `pulumi:"projectDomain"`
-	PublicZoneId  *string `pulumi:"publicZoneId"`
+	AlbCertificateArn *string  `pulumi:"albCertificateArn"`
+	DnsRoleArn        *string  `pulumi:"dnsRoleArn"`
+	PrivateSubnetIDs  []string `pulumi:"privateSubnetIDs"`
+	ProjectDomain     *string  `pulumi:"projectDomain"`
+	PublicSubnetIDs   []string `pulumi:"publicSubnetIDs"`
+	PublicZoneId      *string  `pulumi:"publicZoneId"`
+	VpcID             *string  `pulumi:"vpcID"`
 }
 
 // AWSConfigInput is an input type that accepts AWSConfigArgs and AWSConfigOutput values.
@@ -30,8 +35,13 @@ type AWSConfigInput interface {
 }
 
 type AWSConfigArgs struct {
-	ProjectDomain pulumi.StringPtrInput `pulumi:"projectDomain"`
-	PublicZoneId  pulumi.StringPtrInput `pulumi:"publicZoneId"`
+	AlbCertificateArn pulumi.StringPtrInput   `pulumi:"albCertificateArn"`
+	DnsRoleArn        pulumi.StringPtrInput   `pulumi:"dnsRoleArn"`
+	PrivateSubnetIDs  pulumi.StringArrayInput `pulumi:"privateSubnetIDs"`
+	ProjectDomain     pulumi.StringPtrInput   `pulumi:"projectDomain"`
+	PublicSubnetIDs   pulumi.StringArrayInput `pulumi:"publicSubnetIDs"`
+	PublicZoneId      pulumi.StringPtrInput   `pulumi:"publicZoneId"`
+	VpcID             pulumi.StringPtrInput   `pulumi:"vpcID"`
 }
 
 func (AWSConfigArgs) ElementType() reflect.Type {
@@ -111,12 +121,32 @@ func (o AWSConfigOutput) ToAWSConfigPtrOutputWithContext(ctx context.Context) AW
 	}).(AWSConfigPtrOutput)
 }
 
+func (o AWSConfigOutput) AlbCertificateArn() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v AWSConfig) *string { return v.AlbCertificateArn }).(pulumi.StringPtrOutput)
+}
+
+func (o AWSConfigOutput) DnsRoleArn() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v AWSConfig) *string { return v.DnsRoleArn }).(pulumi.StringPtrOutput)
+}
+
+func (o AWSConfigOutput) PrivateSubnetIDs() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v AWSConfig) []string { return v.PrivateSubnetIDs }).(pulumi.StringArrayOutput)
+}
+
 func (o AWSConfigOutput) ProjectDomain() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v AWSConfig) *string { return v.ProjectDomain }).(pulumi.StringPtrOutput)
 }
 
+func (o AWSConfigOutput) PublicSubnetIDs() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v AWSConfig) []string { return v.PublicSubnetIDs }).(pulumi.StringArrayOutput)
+}
+
 func (o AWSConfigOutput) PublicZoneId() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v AWSConfig) *string { return v.PublicZoneId }).(pulumi.StringPtrOutput)
+}
+
+func (o AWSConfigOutput) VpcID() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v AWSConfig) *string { return v.VpcID }).(pulumi.StringPtrOutput)
 }
 
 type AWSConfigPtrOutput struct{ *pulumi.OutputState }
@@ -143,6 +173,33 @@ func (o AWSConfigPtrOutput) Elem() AWSConfigOutput {
 	}).(AWSConfigOutput)
 }
 
+func (o AWSConfigPtrOutput) AlbCertificateArn() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *AWSConfig) *string {
+		if v == nil {
+			return nil
+		}
+		return v.AlbCertificateArn
+	}).(pulumi.StringPtrOutput)
+}
+
+func (o AWSConfigPtrOutput) DnsRoleArn() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *AWSConfig) *string {
+		if v == nil {
+			return nil
+		}
+		return v.DnsRoleArn
+	}).(pulumi.StringPtrOutput)
+}
+
+func (o AWSConfigPtrOutput) PrivateSubnetIDs() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *AWSConfig) []string {
+		if v == nil {
+			return nil
+		}
+		return v.PrivateSubnetIDs
+	}).(pulumi.StringArrayOutput)
+}
+
 func (o AWSConfigPtrOutput) ProjectDomain() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *AWSConfig) *string {
 		if v == nil {
@@ -152,12 +209,30 @@ func (o AWSConfigPtrOutput) ProjectDomain() pulumi.StringPtrOutput {
 	}).(pulumi.StringPtrOutput)
 }
 
+func (o AWSConfigPtrOutput) PublicSubnetIDs() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *AWSConfig) []string {
+		if v == nil {
+			return nil
+		}
+		return v.PublicSubnetIDs
+	}).(pulumi.StringArrayOutput)
+}
+
 func (o AWSConfigPtrOutput) PublicZoneId() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *AWSConfig) *string {
 		if v == nil {
 			return nil
 		}
 		return v.PublicZoneId
+	}).(pulumi.StringPtrOutput)
+}
+
+func (o AWSConfigPtrOutput) VpcID() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *AWSConfig) *string {
+		if v == nil {
+			return nil
+		}
+		return v.VpcID
 	}).(pulumi.StringPtrOutput)
 }
 

--- a/sdk/v2/go/defang-aws/service.go
+++ b/sdk/v2/go/defang-aws/service.go
@@ -30,6 +30,9 @@ func NewService(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
+	if args.Image == nil {
+		return nil, errors.New("invalid value for required argument 'Image'")
+	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource Service
 	err := ctx.RegisterRemoteComponentResource("defang-aws:index:Service", name, args, &resource, opts...)
@@ -52,6 +55,7 @@ type serviceArgs struct {
 	HealthCheck        *compose.HealthCheckConfig           `pulumi:"healthCheck"`
 	Image              string                               `pulumi:"image"`
 	Platform           *string                              `pulumi:"platform"`
+	Policies           []string                             `pulumi:"policies"`
 	Ports              []compose.ServicePortConfig          `pulumi:"ports"`
 	ProjectName        string                               `pulumi:"projectName"`
 	Secrets            map[string]string                    `pulumi:"secrets"`
@@ -78,8 +82,9 @@ type ServiceArgs struct {
 	Entrypoint         pulumi.StringArrayInput
 	Environment        pulumi.StringMapInput
 	HealthCheck        compose.HealthCheckConfigPtrInput
-	Image              string
+	Image              pulumi.StringInput
 	Platform           *string
+	Policies           pulumi.StringArrayInput
 	Ports              compose.ServicePortConfigArrayInput
 	ProjectName        string
 	Secrets            pulumi.StringMapInput

--- a/sdk/v2/go/defang-aws/service.go
+++ b/sdk/v2/go/defang-aws/service.go
@@ -17,7 +17,10 @@ import (
 type Service struct {
 	pulumi.ResourceState
 
-	Endpoint pulumi.StringOutput `pulumi:"endpoint"`
+	ClusterName pulumi.StringOutput `pulumi:"clusterName"`
+	Endpoint    pulumi.StringOutput `pulumi:"endpoint"`
+	ServiceName pulumi.StringOutput `pulumi:"serviceName"`
+	TaskRoleArn pulumi.StringOutput `pulumi:"taskRoleArn"`
 }
 
 // NewService registers a new resource with the given unique name, arguments, and options.
@@ -37,32 +40,58 @@ func NewService(ctx *pulumi.Context,
 }
 
 type serviceArgs struct {
-	Aws         *aws.SharedInfra            `pulumi:"aws"`
-	Command     []string                    `pulumi:"command"`
-	Deploy      *compose.DeployConfig       `pulumi:"deploy"`
-	DomainName  *string                     `pulumi:"domainName"`
-	Entrypoint  []string                    `pulumi:"entrypoint"`
-	Environment map[string]string           `pulumi:"environment"`
-	HealthCheck *compose.HealthCheckConfig  `pulumi:"healthCheck"`
-	Image       string                      `pulumi:"image"`
-	Platform    *string                     `pulumi:"platform"`
-	Ports       []compose.ServicePortConfig `pulumi:"ports"`
-	ProjectName string                      `pulumi:"projectName"`
+	Autoscaling        *bool                                `pulumi:"autoscaling"`
+	Aws                *aws.SharedInfra                     `pulumi:"aws"`
+	Command            []string                             `pulumi:"command"`
+	ContainerName      *string                              `pulumi:"containerName"`
+	DependsOn          map[string]compose.ServiceDependency `pulumi:"dependsOn"`
+	Deploy             *compose.DeployConfig                `pulumi:"deploy"`
+	DomainName         *string                              `pulumi:"domainName"`
+	Entrypoint         []string                             `pulumi:"entrypoint"`
+	Environment        map[string]string                    `pulumi:"environment"`
+	HealthCheck        *compose.HealthCheckConfig           `pulumi:"healthCheck"`
+	Image              string                               `pulumi:"image"`
+	Platform           *string                              `pulumi:"platform"`
+	Ports              []compose.ServicePortConfig          `pulumi:"ports"`
+	ProjectName        string                               `pulumi:"projectName"`
+	Secrets            map[string]string                    `pulumi:"secrets"`
+	SecurityGroupIds   []string                             `pulumi:"securityGroupIds"`
+	Sidecars           map[string]compose.ServiceConfig     `pulumi:"sidecars"`
+	StopGracePeriod    *string                              `pulumi:"stopGracePeriod"`
+	TaskRoleArn        *string                              `pulumi:"taskRoleArn"`
+	Triggers           map[string]string                    `pulumi:"triggers"`
+	Volumes            []compose.ServiceVolumeConfig        `pulumi:"volumes"`
+	VolumesFrom        []string                             `pulumi:"volumesFrom"`
+	WaitForSteadyState *bool                                `pulumi:"waitForSteadyState"`
+	WorkingDir         *string                              `pulumi:"workingDir"`
 }
 
 // The set of arguments for constructing a Service resource.
 type ServiceArgs struct {
-	Aws         aws.SharedInfraPtrInput
-	Command     pulumi.StringArrayInput
-	Deploy      compose.DeployConfigPtrInput
-	DomainName  *string
-	Entrypoint  pulumi.StringArrayInput
-	Environment pulumi.StringMapInput
-	HealthCheck compose.HealthCheckConfigPtrInput
-	Image       string
-	Platform    *string
-	Ports       compose.ServicePortConfigArrayInput
-	ProjectName string
+	Autoscaling        *bool
+	Aws                aws.SharedInfraPtrInput
+	Command            pulumi.StringArrayInput
+	ContainerName      *string
+	DependsOn          compose.ServiceDependencyMapInput
+	Deploy             compose.DeployConfigPtrInput
+	DomainName         *string
+	Entrypoint         pulumi.StringArrayInput
+	Environment        pulumi.StringMapInput
+	HealthCheck        compose.HealthCheckConfigPtrInput
+	Image              string
+	Platform           *string
+	Ports              compose.ServicePortConfigArrayInput
+	ProjectName        string
+	Secrets            pulumi.StringMapInput
+	SecurityGroupIds   pulumi.StringArrayInput
+	Sidecars           compose.ServiceConfigMapInput
+	StopGracePeriod    *string
+	TaskRoleArn        pulumi.StringPtrInput
+	Triggers           pulumi.StringMapInput
+	Volumes            compose.ServiceVolumeConfigArrayInput
+	VolumesFrom        pulumi.StringArrayInput
+	WaitForSteadyState *bool
+	WorkingDir         *string
 }
 
 func (ServiceArgs) ElementType() reflect.Type {
@@ -102,8 +131,20 @@ func (o ServiceOutput) ToServiceOutputWithContext(ctx context.Context) ServiceOu
 	return o
 }
 
+func (o ServiceOutput) ClusterName() pulumi.StringOutput {
+	return o.ApplyT(func(v *Service) pulumi.StringOutput { return v.ClusterName }).(pulumi.StringOutput)
+}
+
 func (o ServiceOutput) Endpoint() pulumi.StringOutput {
 	return o.ApplyT(func(v *Service) pulumi.StringOutput { return v.Endpoint }).(pulumi.StringOutput)
+}
+
+func (o ServiceOutput) ServiceName() pulumi.StringOutput {
+	return o.ApplyT(func(v *Service) pulumi.StringOutput { return v.ServiceName }).(pulumi.StringOutput)
+}
+
+func (o ServiceOutput) TaskRoleArn() pulumi.StringOutput {
+	return o.ApplyT(func(v *Service) pulumi.StringOutput { return v.TaskRoleArn }).(pulumi.StringOutput)
 }
 
 func init() {

--- a/sdk/v2/go/defang-azure/compose/pulumiTypes.go
+++ b/sdk/v2/go/defang-azure/compose/pulumiTypes.go
@@ -15,8 +15,11 @@ var _ = internal.GetEnvOrDefault
 
 type BuildConfig struct {
 	Args       map[string]string `pulumi:"args"`
+	CacheFrom  []string          `pulumi:"cacheFrom"`
+	CacheTo    []string          `pulumi:"cacheTo"`
 	Context    string            `pulumi:"context"`
 	Dockerfile *string           `pulumi:"dockerfile"`
+	Platforms  []string          `pulumi:"platforms"`
 	ShmSize    *string           `pulumi:"shmSize"`
 	Target     *string           `pulumi:"target"`
 }
@@ -33,11 +36,14 @@ type BuildConfigInput interface {
 }
 
 type BuildConfigArgs struct {
-	Args       pulumi.StringMapInput `pulumi:"args"`
-	Context    pulumi.StringInput    `pulumi:"context"`
-	Dockerfile pulumi.StringPtrInput `pulumi:"dockerfile"`
-	ShmSize    pulumi.StringPtrInput `pulumi:"shmSize"`
-	Target     pulumi.StringPtrInput `pulumi:"target"`
+	Args       pulumi.StringMapInput   `pulumi:"args"`
+	CacheFrom  pulumi.StringArrayInput `pulumi:"cacheFrom"`
+	CacheTo    pulumi.StringArrayInput `pulumi:"cacheTo"`
+	Context    pulumi.StringInput      `pulumi:"context"`
+	Dockerfile pulumi.StringPtrInput   `pulumi:"dockerfile"`
+	Platforms  pulumi.StringArrayInput `pulumi:"platforms"`
+	ShmSize    pulumi.StringPtrInput   `pulumi:"shmSize"`
+	Target     pulumi.StringPtrInput   `pulumi:"target"`
 }
 
 func (BuildConfigArgs) ElementType() reflect.Type {
@@ -121,12 +127,24 @@ func (o BuildConfigOutput) Args() pulumi.StringMapOutput {
 	return o.ApplyT(func(v BuildConfig) map[string]string { return v.Args }).(pulumi.StringMapOutput)
 }
 
+func (o BuildConfigOutput) CacheFrom() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v BuildConfig) []string { return v.CacheFrom }).(pulumi.StringArrayOutput)
+}
+
+func (o BuildConfigOutput) CacheTo() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v BuildConfig) []string { return v.CacheTo }).(pulumi.StringArrayOutput)
+}
+
 func (o BuildConfigOutput) Context() pulumi.StringOutput {
 	return o.ApplyT(func(v BuildConfig) string { return v.Context }).(pulumi.StringOutput)
 }
 
 func (o BuildConfigOutput) Dockerfile() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v BuildConfig) *string { return v.Dockerfile }).(pulumi.StringPtrOutput)
+}
+
+func (o BuildConfigOutput) Platforms() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v BuildConfig) []string { return v.Platforms }).(pulumi.StringArrayOutput)
 }
 
 func (o BuildConfigOutput) ShmSize() pulumi.StringPtrOutput {
@@ -170,6 +188,24 @@ func (o BuildConfigPtrOutput) Args() pulumi.StringMapOutput {
 	}).(pulumi.StringMapOutput)
 }
 
+func (o BuildConfigPtrOutput) CacheFrom() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *BuildConfig) []string {
+		if v == nil {
+			return nil
+		}
+		return v.CacheFrom
+	}).(pulumi.StringArrayOutput)
+}
+
+func (o BuildConfigPtrOutput) CacheTo() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *BuildConfig) []string {
+		if v == nil {
+			return nil
+		}
+		return v.CacheTo
+	}).(pulumi.StringArrayOutput)
+}
+
 func (o BuildConfigPtrOutput) Context() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *BuildConfig) *string {
 		if v == nil {
@@ -186,6 +222,15 @@ func (o BuildConfigPtrOutput) Dockerfile() pulumi.StringPtrOutput {
 		}
 		return v.Dockerfile
 	}).(pulumi.StringPtrOutput)
+}
+
+func (o BuildConfigPtrOutput) Platforms() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *BuildConfig) []string {
+		if v == nil {
+			return nil
+		}
+		return v.Platforms
+	}).(pulumi.StringArrayOutput)
 }
 
 func (o BuildConfigPtrOutput) ShmSize() pulumi.StringPtrOutput {
@@ -1337,22 +1382,28 @@ func (o ResourcesPtrOutput) Reservations() ResourceConfigPtrOutput {
 }
 
 type ServiceConfig struct {
-	Build       *BuildConfig                    `pulumi:"build"`
-	Command     []string                        `pulumi:"command"`
-	DependsOn   map[string]ServiceDependency    `pulumi:"dependsOn"`
-	Deploy      *DeployConfig                   `pulumi:"deploy"`
-	DomainName  *string                         `pulumi:"domainName"`
-	Entrypoint  []string                        `pulumi:"entrypoint"`
-	Environment map[string]string               `pulumi:"environment"`
-	HealthCheck *HealthCheckConfig              `pulumi:"healthCheck"`
-	Image       *string                         `pulumi:"image"`
-	Llm         *LlmConfig                      `pulumi:"llm"`
-	Networks    map[string]ServiceNetworkConfig `pulumi:"networks"`
-	Platform    *string                         `pulumi:"platform"`
-	Ports       []ServicePortConfig             `pulumi:"ports"`
-	Postgres    *PostgresConfig                 `pulumi:"postgres"`
-	Redis       *RedisConfig                    `pulumi:"redis"`
-	Restart     *string                         `pulumi:"restart"`
+	Autoscaling     *bool                           `pulumi:"autoscaling"`
+	Build           *BuildConfig                    `pulumi:"build"`
+	Command         []string                        `pulumi:"command"`
+	ContainerName   *string                         `pulumi:"containerName"`
+	DependsOn       map[string]ServiceDependency    `pulumi:"dependsOn"`
+	Deploy          *DeployConfig                   `pulumi:"deploy"`
+	DomainName      *string                         `pulumi:"domainName"`
+	Entrypoint      []string                        `pulumi:"entrypoint"`
+	Environment     map[string]string               `pulumi:"environment"`
+	HealthCheck     *HealthCheckConfig              `pulumi:"healthCheck"`
+	Image           *string                         `pulumi:"image"`
+	Llm             *LlmConfig                      `pulumi:"llm"`
+	Networks        map[string]ServiceNetworkConfig `pulumi:"networks"`
+	Platform        *string                         `pulumi:"platform"`
+	Ports           []ServicePortConfig             `pulumi:"ports"`
+	Postgres        *PostgresConfig                 `pulumi:"postgres"`
+	Redis           *RedisConfig                    `pulumi:"redis"`
+	Restart         *string                         `pulumi:"restart"`
+	StopGracePeriod *string                         `pulumi:"stopGracePeriod"`
+	Volumes         []ServiceVolumeConfig           `pulumi:"volumes"`
+	VolumesFrom     []string                        `pulumi:"volumesFrom"`
+	WorkingDir      *string                         `pulumi:"workingDir"`
 }
 
 // ServiceConfigInput is an input type that accepts ServiceConfigArgs and ServiceConfigOutput values.
@@ -1367,22 +1418,28 @@ type ServiceConfigInput interface {
 }
 
 type ServiceConfigArgs struct {
-	Build       BuildConfigPtrInput          `pulumi:"build"`
-	Command     pulumi.StringArrayInput      `pulumi:"command"`
-	DependsOn   ServiceDependencyMapInput    `pulumi:"dependsOn"`
-	Deploy      DeployConfigPtrInput         `pulumi:"deploy"`
-	DomainName  pulumi.StringPtrInput        `pulumi:"domainName"`
-	Entrypoint  pulumi.StringArrayInput      `pulumi:"entrypoint"`
-	Environment pulumi.StringMapInput        `pulumi:"environment"`
-	HealthCheck HealthCheckConfigPtrInput    `pulumi:"healthCheck"`
-	Image       pulumi.StringPtrInput        `pulumi:"image"`
-	Llm         LlmConfigPtrInput            `pulumi:"llm"`
-	Networks    ServiceNetworkConfigMapInput `pulumi:"networks"`
-	Platform    pulumi.StringPtrInput        `pulumi:"platform"`
-	Ports       ServicePortConfigArrayInput  `pulumi:"ports"`
-	Postgres    PostgresConfigPtrInput       `pulumi:"postgres"`
-	Redis       RedisConfigPtrInput          `pulumi:"redis"`
-	Restart     pulumi.StringPtrInput        `pulumi:"restart"`
+	Autoscaling     pulumi.BoolPtrInput           `pulumi:"autoscaling"`
+	Build           BuildConfigPtrInput           `pulumi:"build"`
+	Command         pulumi.StringArrayInput       `pulumi:"command"`
+	ContainerName   pulumi.StringPtrInput         `pulumi:"containerName"`
+	DependsOn       ServiceDependencyMapInput     `pulumi:"dependsOn"`
+	Deploy          DeployConfigPtrInput          `pulumi:"deploy"`
+	DomainName      pulumi.StringPtrInput         `pulumi:"domainName"`
+	Entrypoint      pulumi.StringArrayInput       `pulumi:"entrypoint"`
+	Environment     pulumi.StringMapInput         `pulumi:"environment"`
+	HealthCheck     HealthCheckConfigPtrInput     `pulumi:"healthCheck"`
+	Image           pulumi.StringPtrInput         `pulumi:"image"`
+	Llm             LlmConfigPtrInput             `pulumi:"llm"`
+	Networks        ServiceNetworkConfigMapInput  `pulumi:"networks"`
+	Platform        pulumi.StringPtrInput         `pulumi:"platform"`
+	Ports           ServicePortConfigArrayInput   `pulumi:"ports"`
+	Postgres        PostgresConfigPtrInput        `pulumi:"postgres"`
+	Redis           RedisConfigPtrInput           `pulumi:"redis"`
+	Restart         pulumi.StringPtrInput         `pulumi:"restart"`
+	StopGracePeriod pulumi.StringPtrInput         `pulumi:"stopGracePeriod"`
+	Volumes         ServiceVolumeConfigArrayInput `pulumi:"volumes"`
+	VolumesFrom     pulumi.StringArrayInput       `pulumi:"volumesFrom"`
+	WorkingDir      pulumi.StringPtrInput         `pulumi:"workingDir"`
 }
 
 func (ServiceConfigArgs) ElementType() reflect.Type {
@@ -1436,12 +1493,20 @@ func (o ServiceConfigOutput) ToServiceConfigOutputWithContext(ctx context.Contex
 	return o
 }
 
+func (o ServiceConfigOutput) Autoscaling() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v ServiceConfig) *bool { return v.Autoscaling }).(pulumi.BoolPtrOutput)
+}
+
 func (o ServiceConfigOutput) Build() BuildConfigPtrOutput {
 	return o.ApplyT(func(v ServiceConfig) *BuildConfig { return v.Build }).(BuildConfigPtrOutput)
 }
 
 func (o ServiceConfigOutput) Command() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v ServiceConfig) []string { return v.Command }).(pulumi.StringArrayOutput)
+}
+
+func (o ServiceConfigOutput) ContainerName() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v ServiceConfig) *string { return v.ContainerName }).(pulumi.StringPtrOutput)
 }
 
 func (o ServiceConfigOutput) DependsOn() ServiceDependencyMapOutput {
@@ -1498,6 +1563,22 @@ func (o ServiceConfigOutput) Redis() RedisConfigPtrOutput {
 
 func (o ServiceConfigOutput) Restart() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ServiceConfig) *string { return v.Restart }).(pulumi.StringPtrOutput)
+}
+
+func (o ServiceConfigOutput) StopGracePeriod() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v ServiceConfig) *string { return v.StopGracePeriod }).(pulumi.StringPtrOutput)
+}
+
+func (o ServiceConfigOutput) Volumes() ServiceVolumeConfigArrayOutput {
+	return o.ApplyT(func(v ServiceConfig) []ServiceVolumeConfig { return v.Volumes }).(ServiceVolumeConfigArrayOutput)
+}
+
+func (o ServiceConfigOutput) VolumesFrom() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v ServiceConfig) []string { return v.VolumesFrom }).(pulumi.StringArrayOutput)
+}
+
+func (o ServiceConfigOutput) WorkingDir() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v ServiceConfig) *string { return v.WorkingDir }).(pulumi.StringPtrOutput)
 }
 
 type ServiceConfigMapOutput struct{ *pulumi.OutputState }
@@ -1716,6 +1797,7 @@ func (o ServiceNetworkConfigMapOutput) MapIndex(k pulumi.StringInput) ServiceNet
 
 type ServicePortConfig struct {
 	AppProtocol *string `pulumi:"appProtocol"`
+	Listener    *string `pulumi:"listener"`
 	Mode        *string `pulumi:"mode"`
 	Protocol    *string `pulumi:"protocol"`
 	Target      int     `pulumi:"target"`
@@ -1734,6 +1816,7 @@ type ServicePortConfigInput interface {
 
 type ServicePortConfigArgs struct {
 	AppProtocol pulumi.StringPtrInput `pulumi:"appProtocol"`
+	Listener    pulumi.StringPtrInput `pulumi:"listener"`
 	Mode        pulumi.StringPtrInput `pulumi:"mode"`
 	Protocol    pulumi.StringPtrInput `pulumi:"protocol"`
 	Target      pulumi.IntInput       `pulumi:"target"`
@@ -1794,6 +1877,10 @@ func (o ServicePortConfigOutput) AppProtocol() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ServicePortConfig) *string { return v.AppProtocol }).(pulumi.StringPtrOutput)
 }
 
+func (o ServicePortConfigOutput) Listener() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v ServicePortConfig) *string { return v.Listener }).(pulumi.StringPtrOutput)
+}
+
 func (o ServicePortConfigOutput) Mode() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ServicePortConfig) *string { return v.Mode }).(pulumi.StringPtrOutput)
 }
@@ -1826,6 +1913,112 @@ func (o ServicePortConfigArrayOutput) Index(i pulumi.IntInput) ServicePortConfig
 	}).(ServicePortConfigOutput)
 }
 
+type ServiceVolumeConfig struct {
+	ReadOnly *bool  `pulumi:"readOnly"`
+	Source   string `pulumi:"source"`
+	Target   string `pulumi:"target"`
+}
+
+// ServiceVolumeConfigInput is an input type that accepts ServiceVolumeConfigArgs and ServiceVolumeConfigOutput values.
+// You can construct a concrete instance of `ServiceVolumeConfigInput` via:
+//
+//	ServiceVolumeConfigArgs{...}
+type ServiceVolumeConfigInput interface {
+	pulumi.Input
+
+	ToServiceVolumeConfigOutput() ServiceVolumeConfigOutput
+	ToServiceVolumeConfigOutputWithContext(context.Context) ServiceVolumeConfigOutput
+}
+
+type ServiceVolumeConfigArgs struct {
+	ReadOnly pulumi.BoolPtrInput `pulumi:"readOnly"`
+	Source   pulumi.StringInput  `pulumi:"source"`
+	Target   pulumi.StringInput  `pulumi:"target"`
+}
+
+func (ServiceVolumeConfigArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*ServiceVolumeConfig)(nil)).Elem()
+}
+
+func (i ServiceVolumeConfigArgs) ToServiceVolumeConfigOutput() ServiceVolumeConfigOutput {
+	return i.ToServiceVolumeConfigOutputWithContext(context.Background())
+}
+
+func (i ServiceVolumeConfigArgs) ToServiceVolumeConfigOutputWithContext(ctx context.Context) ServiceVolumeConfigOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(ServiceVolumeConfigOutput)
+}
+
+// ServiceVolumeConfigArrayInput is an input type that accepts ServiceVolumeConfigArray and ServiceVolumeConfigArrayOutput values.
+// You can construct a concrete instance of `ServiceVolumeConfigArrayInput` via:
+//
+//	ServiceVolumeConfigArray{ ServiceVolumeConfigArgs{...} }
+type ServiceVolumeConfigArrayInput interface {
+	pulumi.Input
+
+	ToServiceVolumeConfigArrayOutput() ServiceVolumeConfigArrayOutput
+	ToServiceVolumeConfigArrayOutputWithContext(context.Context) ServiceVolumeConfigArrayOutput
+}
+
+type ServiceVolumeConfigArray []ServiceVolumeConfigInput
+
+func (ServiceVolumeConfigArray) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]ServiceVolumeConfig)(nil)).Elem()
+}
+
+func (i ServiceVolumeConfigArray) ToServiceVolumeConfigArrayOutput() ServiceVolumeConfigArrayOutput {
+	return i.ToServiceVolumeConfigArrayOutputWithContext(context.Background())
+}
+
+func (i ServiceVolumeConfigArray) ToServiceVolumeConfigArrayOutputWithContext(ctx context.Context) ServiceVolumeConfigArrayOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(ServiceVolumeConfigArrayOutput)
+}
+
+type ServiceVolumeConfigOutput struct{ *pulumi.OutputState }
+
+func (ServiceVolumeConfigOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*ServiceVolumeConfig)(nil)).Elem()
+}
+
+func (o ServiceVolumeConfigOutput) ToServiceVolumeConfigOutput() ServiceVolumeConfigOutput {
+	return o
+}
+
+func (o ServiceVolumeConfigOutput) ToServiceVolumeConfigOutputWithContext(ctx context.Context) ServiceVolumeConfigOutput {
+	return o
+}
+
+func (o ServiceVolumeConfigOutput) ReadOnly() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v ServiceVolumeConfig) *bool { return v.ReadOnly }).(pulumi.BoolPtrOutput)
+}
+
+func (o ServiceVolumeConfigOutput) Source() pulumi.StringOutput {
+	return o.ApplyT(func(v ServiceVolumeConfig) string { return v.Source }).(pulumi.StringOutput)
+}
+
+func (o ServiceVolumeConfigOutput) Target() pulumi.StringOutput {
+	return o.ApplyT(func(v ServiceVolumeConfig) string { return v.Target }).(pulumi.StringOutput)
+}
+
+type ServiceVolumeConfigArrayOutput struct{ *pulumi.OutputState }
+
+func (ServiceVolumeConfigArrayOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]ServiceVolumeConfig)(nil)).Elem()
+}
+
+func (o ServiceVolumeConfigArrayOutput) ToServiceVolumeConfigArrayOutput() ServiceVolumeConfigArrayOutput {
+	return o
+}
+
+func (o ServiceVolumeConfigArrayOutput) ToServiceVolumeConfigArrayOutputWithContext(ctx context.Context) ServiceVolumeConfigArrayOutput {
+	return o
+}
+
+func (o ServiceVolumeConfigArrayOutput) Index(i pulumi.IntInput) ServiceVolumeConfigOutput {
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) ServiceVolumeConfig {
+		return vs[0].([]ServiceVolumeConfig)[vs[1].(int)]
+	}).(ServiceVolumeConfigOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*BuildConfigInput)(nil)).Elem(), BuildConfigArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*BuildConfigPtrInput)(nil)).Elem(), BuildConfigArgs{})
@@ -1853,6 +2046,8 @@ func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*ServiceNetworkConfigMapInput)(nil)).Elem(), ServiceNetworkConfigMap{})
 	pulumi.RegisterInputType(reflect.TypeOf((*ServicePortConfigInput)(nil)).Elem(), ServicePortConfigArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*ServicePortConfigArrayInput)(nil)).Elem(), ServicePortConfigArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ServiceVolumeConfigInput)(nil)).Elem(), ServiceVolumeConfigArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ServiceVolumeConfigArrayInput)(nil)).Elem(), ServiceVolumeConfigArray{})
 	pulumi.RegisterOutputType(BuildConfigOutput{})
 	pulumi.RegisterOutputType(BuildConfigPtrOutput{})
 	pulumi.RegisterOutputType(DeployConfigOutput{})
@@ -1879,4 +2074,6 @@ func init() {
 	pulumi.RegisterOutputType(ServiceNetworkConfigMapOutput{})
 	pulumi.RegisterOutputType(ServicePortConfigOutput{})
 	pulumi.RegisterOutputType(ServicePortConfigArrayOutput{})
+	pulumi.RegisterOutputType(ServiceVolumeConfigOutput{})
+	pulumi.RegisterOutputType(ServiceVolumeConfigArrayOutput{})
 }

--- a/sdk/v2/go/defang-azure/compose/pulumiTypes.go
+++ b/sdk/v2/go/defang-azure/compose/pulumiTypes.go
@@ -1396,6 +1396,7 @@ type ServiceConfig struct {
 	Llm             *LlmConfig                      `pulumi:"llm"`
 	Networks        map[string]ServiceNetworkConfig `pulumi:"networks"`
 	Platform        *string                         `pulumi:"platform"`
+	Policies        []string                        `pulumi:"policies"`
 	Ports           []ServicePortConfig             `pulumi:"ports"`
 	Postgres        *PostgresConfig                 `pulumi:"postgres"`
 	Redis           *RedisConfig                    `pulumi:"redis"`
@@ -1432,6 +1433,7 @@ type ServiceConfigArgs struct {
 	Llm             LlmConfigPtrInput             `pulumi:"llm"`
 	Networks        ServiceNetworkConfigMapInput  `pulumi:"networks"`
 	Platform        pulumi.StringPtrInput         `pulumi:"platform"`
+	Policies        pulumi.StringArrayInput       `pulumi:"policies"`
 	Ports           ServicePortConfigArrayInput   `pulumi:"ports"`
 	Postgres        PostgresConfigPtrInput        `pulumi:"postgres"`
 	Redis           RedisConfigPtrInput           `pulumi:"redis"`
@@ -1547,6 +1549,10 @@ func (o ServiceConfigOutput) Networks() ServiceNetworkConfigMapOutput {
 
 func (o ServiceConfigOutput) Platform() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ServiceConfig) *string { return v.Platform }).(pulumi.StringPtrOutput)
+}
+
+func (o ServiceConfigOutput) Policies() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v ServiceConfig) []string { return v.Policies }).(pulumi.StringArrayOutput)
 }
 
 func (o ServiceConfigOutput) Ports() ServicePortConfigArrayOutput {

--- a/sdk/v2/go/defang-azure/compose/pulumiTypes.go
+++ b/sdk/v2/go/defang-azure/compose/pulumiTypes.go
@@ -1394,6 +1394,7 @@ type ServiceConfig struct {
 	HealthCheck     *HealthCheckConfig              `pulumi:"healthCheck"`
 	Image           *string                         `pulumi:"image"`
 	Llm             *LlmConfig                      `pulumi:"llm"`
+	NetworkMode     *string                         `pulumi:"networkMode"`
 	Networks        map[string]ServiceNetworkConfig `pulumi:"networks"`
 	Platform        *string                         `pulumi:"platform"`
 	Policies        []string                        `pulumi:"policies"`
@@ -1431,6 +1432,7 @@ type ServiceConfigArgs struct {
 	HealthCheck     HealthCheckConfigPtrInput     `pulumi:"healthCheck"`
 	Image           pulumi.StringPtrInput         `pulumi:"image"`
 	Llm             LlmConfigPtrInput             `pulumi:"llm"`
+	NetworkMode     pulumi.StringPtrInput         `pulumi:"networkMode"`
 	Networks        ServiceNetworkConfigMapInput  `pulumi:"networks"`
 	Platform        pulumi.StringPtrInput         `pulumi:"platform"`
 	Policies        pulumi.StringArrayInput       `pulumi:"policies"`
@@ -1541,6 +1543,10 @@ func (o ServiceConfigOutput) Image() pulumi.StringPtrOutput {
 
 func (o ServiceConfigOutput) Llm() LlmConfigPtrOutput {
 	return o.ApplyT(func(v ServiceConfig) *LlmConfig { return v.Llm }).(LlmConfigPtrOutput)
+}
+
+func (o ServiceConfigOutput) NetworkMode() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v ServiceConfig) *string { return v.NetworkMode }).(pulumi.StringPtrOutput)
 }
 
 func (o ServiceConfigOutput) Networks() ServiceNetworkConfigMapOutput {

--- a/sdk/v2/go/defang-azure/service.go
+++ b/sdk/v2/go/defang-azure/service.go
@@ -26,6 +26,9 @@ func NewService(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
+	if args.Image == nil {
+		return nil, errors.New("invalid value for required argument 'Image'")
+	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource Service
 	err := ctx.RegisterRemoteComponentResource("defang-azure:index:Service", name, args, &resource, opts...)
@@ -56,7 +59,7 @@ type ServiceArgs struct {
 	Entrypoint  pulumi.StringArrayInput
 	Environment pulumi.StringMapInput
 	HealthCheck compose.HealthCheckConfigPtrInput
-	Image       string
+	Image       pulumi.StringInput
 	Platform    *string
 	Ports       compose.ServicePortConfigArrayInput
 	ProjectName *string

--- a/sdk/v2/go/defang-gcp/compose/pulumiTypes.go
+++ b/sdk/v2/go/defang-gcp/compose/pulumiTypes.go
@@ -15,8 +15,11 @@ var _ = internal.GetEnvOrDefault
 
 type BuildConfig struct {
 	Args       map[string]string `pulumi:"args"`
+	CacheFrom  []string          `pulumi:"cacheFrom"`
+	CacheTo    []string          `pulumi:"cacheTo"`
 	Context    string            `pulumi:"context"`
 	Dockerfile *string           `pulumi:"dockerfile"`
+	Platforms  []string          `pulumi:"platforms"`
 	ShmSize    *string           `pulumi:"shmSize"`
 	Target     *string           `pulumi:"target"`
 }
@@ -33,11 +36,14 @@ type BuildConfigInput interface {
 }
 
 type BuildConfigArgs struct {
-	Args       pulumi.StringMapInput `pulumi:"args"`
-	Context    pulumi.StringInput    `pulumi:"context"`
-	Dockerfile pulumi.StringPtrInput `pulumi:"dockerfile"`
-	ShmSize    pulumi.StringPtrInput `pulumi:"shmSize"`
-	Target     pulumi.StringPtrInput `pulumi:"target"`
+	Args       pulumi.StringMapInput   `pulumi:"args"`
+	CacheFrom  pulumi.StringArrayInput `pulumi:"cacheFrom"`
+	CacheTo    pulumi.StringArrayInput `pulumi:"cacheTo"`
+	Context    pulumi.StringInput      `pulumi:"context"`
+	Dockerfile pulumi.StringPtrInput   `pulumi:"dockerfile"`
+	Platforms  pulumi.StringArrayInput `pulumi:"platforms"`
+	ShmSize    pulumi.StringPtrInput   `pulumi:"shmSize"`
+	Target     pulumi.StringPtrInput   `pulumi:"target"`
 }
 
 func (BuildConfigArgs) ElementType() reflect.Type {
@@ -121,12 +127,24 @@ func (o BuildConfigOutput) Args() pulumi.StringMapOutput {
 	return o.ApplyT(func(v BuildConfig) map[string]string { return v.Args }).(pulumi.StringMapOutput)
 }
 
+func (o BuildConfigOutput) CacheFrom() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v BuildConfig) []string { return v.CacheFrom }).(pulumi.StringArrayOutput)
+}
+
+func (o BuildConfigOutput) CacheTo() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v BuildConfig) []string { return v.CacheTo }).(pulumi.StringArrayOutput)
+}
+
 func (o BuildConfigOutput) Context() pulumi.StringOutput {
 	return o.ApplyT(func(v BuildConfig) string { return v.Context }).(pulumi.StringOutput)
 }
 
 func (o BuildConfigOutput) Dockerfile() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v BuildConfig) *string { return v.Dockerfile }).(pulumi.StringPtrOutput)
+}
+
+func (o BuildConfigOutput) Platforms() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v BuildConfig) []string { return v.Platforms }).(pulumi.StringArrayOutput)
 }
 
 func (o BuildConfigOutput) ShmSize() pulumi.StringPtrOutput {
@@ -170,6 +188,24 @@ func (o BuildConfigPtrOutput) Args() pulumi.StringMapOutput {
 	}).(pulumi.StringMapOutput)
 }
 
+func (o BuildConfigPtrOutput) CacheFrom() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *BuildConfig) []string {
+		if v == nil {
+			return nil
+		}
+		return v.CacheFrom
+	}).(pulumi.StringArrayOutput)
+}
+
+func (o BuildConfigPtrOutput) CacheTo() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *BuildConfig) []string {
+		if v == nil {
+			return nil
+		}
+		return v.CacheTo
+	}).(pulumi.StringArrayOutput)
+}
+
 func (o BuildConfigPtrOutput) Context() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *BuildConfig) *string {
 		if v == nil {
@@ -186,6 +222,15 @@ func (o BuildConfigPtrOutput) Dockerfile() pulumi.StringPtrOutput {
 		}
 		return v.Dockerfile
 	}).(pulumi.StringPtrOutput)
+}
+
+func (o BuildConfigPtrOutput) Platforms() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *BuildConfig) []string {
+		if v == nil {
+			return nil
+		}
+		return v.Platforms
+	}).(pulumi.StringArrayOutput)
 }
 
 func (o BuildConfigPtrOutput) ShmSize() pulumi.StringPtrOutput {
@@ -1337,22 +1382,28 @@ func (o ResourcesPtrOutput) Reservations() ResourceConfigPtrOutput {
 }
 
 type ServiceConfig struct {
-	Build       *BuildConfig                    `pulumi:"build"`
-	Command     []string                        `pulumi:"command"`
-	DependsOn   map[string]ServiceDependency    `pulumi:"dependsOn"`
-	Deploy      *DeployConfig                   `pulumi:"deploy"`
-	DomainName  *string                         `pulumi:"domainName"`
-	Entrypoint  []string                        `pulumi:"entrypoint"`
-	Environment map[string]string               `pulumi:"environment"`
-	HealthCheck *HealthCheckConfig              `pulumi:"healthCheck"`
-	Image       *string                         `pulumi:"image"`
-	Llm         *LlmConfig                      `pulumi:"llm"`
-	Networks    map[string]ServiceNetworkConfig `pulumi:"networks"`
-	Platform    *string                         `pulumi:"platform"`
-	Ports       []ServicePortConfig             `pulumi:"ports"`
-	Postgres    *PostgresConfig                 `pulumi:"postgres"`
-	Redis       *RedisConfig                    `pulumi:"redis"`
-	Restart     *string                         `pulumi:"restart"`
+	Autoscaling     *bool                           `pulumi:"autoscaling"`
+	Build           *BuildConfig                    `pulumi:"build"`
+	Command         []string                        `pulumi:"command"`
+	ContainerName   *string                         `pulumi:"containerName"`
+	DependsOn       map[string]ServiceDependency    `pulumi:"dependsOn"`
+	Deploy          *DeployConfig                   `pulumi:"deploy"`
+	DomainName      *string                         `pulumi:"domainName"`
+	Entrypoint      []string                        `pulumi:"entrypoint"`
+	Environment     map[string]string               `pulumi:"environment"`
+	HealthCheck     *HealthCheckConfig              `pulumi:"healthCheck"`
+	Image           *string                         `pulumi:"image"`
+	Llm             *LlmConfig                      `pulumi:"llm"`
+	Networks        map[string]ServiceNetworkConfig `pulumi:"networks"`
+	Platform        *string                         `pulumi:"platform"`
+	Ports           []ServicePortConfig             `pulumi:"ports"`
+	Postgres        *PostgresConfig                 `pulumi:"postgres"`
+	Redis           *RedisConfig                    `pulumi:"redis"`
+	Restart         *string                         `pulumi:"restart"`
+	StopGracePeriod *string                         `pulumi:"stopGracePeriod"`
+	Volumes         []ServiceVolumeConfig           `pulumi:"volumes"`
+	VolumesFrom     []string                        `pulumi:"volumesFrom"`
+	WorkingDir      *string                         `pulumi:"workingDir"`
 }
 
 // ServiceConfigInput is an input type that accepts ServiceConfigArgs and ServiceConfigOutput values.
@@ -1367,22 +1418,28 @@ type ServiceConfigInput interface {
 }
 
 type ServiceConfigArgs struct {
-	Build       BuildConfigPtrInput          `pulumi:"build"`
-	Command     pulumi.StringArrayInput      `pulumi:"command"`
-	DependsOn   ServiceDependencyMapInput    `pulumi:"dependsOn"`
-	Deploy      DeployConfigPtrInput         `pulumi:"deploy"`
-	DomainName  pulumi.StringPtrInput        `pulumi:"domainName"`
-	Entrypoint  pulumi.StringArrayInput      `pulumi:"entrypoint"`
-	Environment pulumi.StringMapInput        `pulumi:"environment"`
-	HealthCheck HealthCheckConfigPtrInput    `pulumi:"healthCheck"`
-	Image       pulumi.StringPtrInput        `pulumi:"image"`
-	Llm         LlmConfigPtrInput            `pulumi:"llm"`
-	Networks    ServiceNetworkConfigMapInput `pulumi:"networks"`
-	Platform    pulumi.StringPtrInput        `pulumi:"platform"`
-	Ports       ServicePortConfigArrayInput  `pulumi:"ports"`
-	Postgres    PostgresConfigPtrInput       `pulumi:"postgres"`
-	Redis       RedisConfigPtrInput          `pulumi:"redis"`
-	Restart     pulumi.StringPtrInput        `pulumi:"restart"`
+	Autoscaling     pulumi.BoolPtrInput           `pulumi:"autoscaling"`
+	Build           BuildConfigPtrInput           `pulumi:"build"`
+	Command         pulumi.StringArrayInput       `pulumi:"command"`
+	ContainerName   pulumi.StringPtrInput         `pulumi:"containerName"`
+	DependsOn       ServiceDependencyMapInput     `pulumi:"dependsOn"`
+	Deploy          DeployConfigPtrInput          `pulumi:"deploy"`
+	DomainName      pulumi.StringPtrInput         `pulumi:"domainName"`
+	Entrypoint      pulumi.StringArrayInput       `pulumi:"entrypoint"`
+	Environment     pulumi.StringMapInput         `pulumi:"environment"`
+	HealthCheck     HealthCheckConfigPtrInput     `pulumi:"healthCheck"`
+	Image           pulumi.StringPtrInput         `pulumi:"image"`
+	Llm             LlmConfigPtrInput             `pulumi:"llm"`
+	Networks        ServiceNetworkConfigMapInput  `pulumi:"networks"`
+	Platform        pulumi.StringPtrInput         `pulumi:"platform"`
+	Ports           ServicePortConfigArrayInput   `pulumi:"ports"`
+	Postgres        PostgresConfigPtrInput        `pulumi:"postgres"`
+	Redis           RedisConfigPtrInput           `pulumi:"redis"`
+	Restart         pulumi.StringPtrInput         `pulumi:"restart"`
+	StopGracePeriod pulumi.StringPtrInput         `pulumi:"stopGracePeriod"`
+	Volumes         ServiceVolumeConfigArrayInput `pulumi:"volumes"`
+	VolumesFrom     pulumi.StringArrayInput       `pulumi:"volumesFrom"`
+	WorkingDir      pulumi.StringPtrInput         `pulumi:"workingDir"`
 }
 
 func (ServiceConfigArgs) ElementType() reflect.Type {
@@ -1436,12 +1493,20 @@ func (o ServiceConfigOutput) ToServiceConfigOutputWithContext(ctx context.Contex
 	return o
 }
 
+func (o ServiceConfigOutput) Autoscaling() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v ServiceConfig) *bool { return v.Autoscaling }).(pulumi.BoolPtrOutput)
+}
+
 func (o ServiceConfigOutput) Build() BuildConfigPtrOutput {
 	return o.ApplyT(func(v ServiceConfig) *BuildConfig { return v.Build }).(BuildConfigPtrOutput)
 }
 
 func (o ServiceConfigOutput) Command() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v ServiceConfig) []string { return v.Command }).(pulumi.StringArrayOutput)
+}
+
+func (o ServiceConfigOutput) ContainerName() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v ServiceConfig) *string { return v.ContainerName }).(pulumi.StringPtrOutput)
 }
 
 func (o ServiceConfigOutput) DependsOn() ServiceDependencyMapOutput {
@@ -1498,6 +1563,22 @@ func (o ServiceConfigOutput) Redis() RedisConfigPtrOutput {
 
 func (o ServiceConfigOutput) Restart() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ServiceConfig) *string { return v.Restart }).(pulumi.StringPtrOutput)
+}
+
+func (o ServiceConfigOutput) StopGracePeriod() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v ServiceConfig) *string { return v.StopGracePeriod }).(pulumi.StringPtrOutput)
+}
+
+func (o ServiceConfigOutput) Volumes() ServiceVolumeConfigArrayOutput {
+	return o.ApplyT(func(v ServiceConfig) []ServiceVolumeConfig { return v.Volumes }).(ServiceVolumeConfigArrayOutput)
+}
+
+func (o ServiceConfigOutput) VolumesFrom() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v ServiceConfig) []string { return v.VolumesFrom }).(pulumi.StringArrayOutput)
+}
+
+func (o ServiceConfigOutput) WorkingDir() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v ServiceConfig) *string { return v.WorkingDir }).(pulumi.StringPtrOutput)
 }
 
 type ServiceConfigMapOutput struct{ *pulumi.OutputState }
@@ -1716,6 +1797,7 @@ func (o ServiceNetworkConfigMapOutput) MapIndex(k pulumi.StringInput) ServiceNet
 
 type ServicePortConfig struct {
 	AppProtocol *string `pulumi:"appProtocol"`
+	Listener    *string `pulumi:"listener"`
 	Mode        *string `pulumi:"mode"`
 	Protocol    *string `pulumi:"protocol"`
 	Target      int     `pulumi:"target"`
@@ -1734,6 +1816,7 @@ type ServicePortConfigInput interface {
 
 type ServicePortConfigArgs struct {
 	AppProtocol pulumi.StringPtrInput `pulumi:"appProtocol"`
+	Listener    pulumi.StringPtrInput `pulumi:"listener"`
 	Mode        pulumi.StringPtrInput `pulumi:"mode"`
 	Protocol    pulumi.StringPtrInput `pulumi:"protocol"`
 	Target      pulumi.IntInput       `pulumi:"target"`
@@ -1794,6 +1877,10 @@ func (o ServicePortConfigOutput) AppProtocol() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ServicePortConfig) *string { return v.AppProtocol }).(pulumi.StringPtrOutput)
 }
 
+func (o ServicePortConfigOutput) Listener() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v ServicePortConfig) *string { return v.Listener }).(pulumi.StringPtrOutput)
+}
+
 func (o ServicePortConfigOutput) Mode() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ServicePortConfig) *string { return v.Mode }).(pulumi.StringPtrOutput)
 }
@@ -1826,6 +1913,112 @@ func (o ServicePortConfigArrayOutput) Index(i pulumi.IntInput) ServicePortConfig
 	}).(ServicePortConfigOutput)
 }
 
+type ServiceVolumeConfig struct {
+	ReadOnly *bool  `pulumi:"readOnly"`
+	Source   string `pulumi:"source"`
+	Target   string `pulumi:"target"`
+}
+
+// ServiceVolumeConfigInput is an input type that accepts ServiceVolumeConfigArgs and ServiceVolumeConfigOutput values.
+// You can construct a concrete instance of `ServiceVolumeConfigInput` via:
+//
+//	ServiceVolumeConfigArgs{...}
+type ServiceVolumeConfigInput interface {
+	pulumi.Input
+
+	ToServiceVolumeConfigOutput() ServiceVolumeConfigOutput
+	ToServiceVolumeConfigOutputWithContext(context.Context) ServiceVolumeConfigOutput
+}
+
+type ServiceVolumeConfigArgs struct {
+	ReadOnly pulumi.BoolPtrInput `pulumi:"readOnly"`
+	Source   pulumi.StringInput  `pulumi:"source"`
+	Target   pulumi.StringInput  `pulumi:"target"`
+}
+
+func (ServiceVolumeConfigArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*ServiceVolumeConfig)(nil)).Elem()
+}
+
+func (i ServiceVolumeConfigArgs) ToServiceVolumeConfigOutput() ServiceVolumeConfigOutput {
+	return i.ToServiceVolumeConfigOutputWithContext(context.Background())
+}
+
+func (i ServiceVolumeConfigArgs) ToServiceVolumeConfigOutputWithContext(ctx context.Context) ServiceVolumeConfigOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(ServiceVolumeConfigOutput)
+}
+
+// ServiceVolumeConfigArrayInput is an input type that accepts ServiceVolumeConfigArray and ServiceVolumeConfigArrayOutput values.
+// You can construct a concrete instance of `ServiceVolumeConfigArrayInput` via:
+//
+//	ServiceVolumeConfigArray{ ServiceVolumeConfigArgs{...} }
+type ServiceVolumeConfigArrayInput interface {
+	pulumi.Input
+
+	ToServiceVolumeConfigArrayOutput() ServiceVolumeConfigArrayOutput
+	ToServiceVolumeConfigArrayOutputWithContext(context.Context) ServiceVolumeConfigArrayOutput
+}
+
+type ServiceVolumeConfigArray []ServiceVolumeConfigInput
+
+func (ServiceVolumeConfigArray) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]ServiceVolumeConfig)(nil)).Elem()
+}
+
+func (i ServiceVolumeConfigArray) ToServiceVolumeConfigArrayOutput() ServiceVolumeConfigArrayOutput {
+	return i.ToServiceVolumeConfigArrayOutputWithContext(context.Background())
+}
+
+func (i ServiceVolumeConfigArray) ToServiceVolumeConfigArrayOutputWithContext(ctx context.Context) ServiceVolumeConfigArrayOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(ServiceVolumeConfigArrayOutput)
+}
+
+type ServiceVolumeConfigOutput struct{ *pulumi.OutputState }
+
+func (ServiceVolumeConfigOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*ServiceVolumeConfig)(nil)).Elem()
+}
+
+func (o ServiceVolumeConfigOutput) ToServiceVolumeConfigOutput() ServiceVolumeConfigOutput {
+	return o
+}
+
+func (o ServiceVolumeConfigOutput) ToServiceVolumeConfigOutputWithContext(ctx context.Context) ServiceVolumeConfigOutput {
+	return o
+}
+
+func (o ServiceVolumeConfigOutput) ReadOnly() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v ServiceVolumeConfig) *bool { return v.ReadOnly }).(pulumi.BoolPtrOutput)
+}
+
+func (o ServiceVolumeConfigOutput) Source() pulumi.StringOutput {
+	return o.ApplyT(func(v ServiceVolumeConfig) string { return v.Source }).(pulumi.StringOutput)
+}
+
+func (o ServiceVolumeConfigOutput) Target() pulumi.StringOutput {
+	return o.ApplyT(func(v ServiceVolumeConfig) string { return v.Target }).(pulumi.StringOutput)
+}
+
+type ServiceVolumeConfigArrayOutput struct{ *pulumi.OutputState }
+
+func (ServiceVolumeConfigArrayOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]ServiceVolumeConfig)(nil)).Elem()
+}
+
+func (o ServiceVolumeConfigArrayOutput) ToServiceVolumeConfigArrayOutput() ServiceVolumeConfigArrayOutput {
+	return o
+}
+
+func (o ServiceVolumeConfigArrayOutput) ToServiceVolumeConfigArrayOutputWithContext(ctx context.Context) ServiceVolumeConfigArrayOutput {
+	return o
+}
+
+func (o ServiceVolumeConfigArrayOutput) Index(i pulumi.IntInput) ServiceVolumeConfigOutput {
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) ServiceVolumeConfig {
+		return vs[0].([]ServiceVolumeConfig)[vs[1].(int)]
+	}).(ServiceVolumeConfigOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*BuildConfigInput)(nil)).Elem(), BuildConfigArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*BuildConfigPtrInput)(nil)).Elem(), BuildConfigArgs{})
@@ -1853,6 +2046,8 @@ func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*ServiceNetworkConfigMapInput)(nil)).Elem(), ServiceNetworkConfigMap{})
 	pulumi.RegisterInputType(reflect.TypeOf((*ServicePortConfigInput)(nil)).Elem(), ServicePortConfigArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*ServicePortConfigArrayInput)(nil)).Elem(), ServicePortConfigArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ServiceVolumeConfigInput)(nil)).Elem(), ServiceVolumeConfigArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ServiceVolumeConfigArrayInput)(nil)).Elem(), ServiceVolumeConfigArray{})
 	pulumi.RegisterOutputType(BuildConfigOutput{})
 	pulumi.RegisterOutputType(BuildConfigPtrOutput{})
 	pulumi.RegisterOutputType(DeployConfigOutput{})
@@ -1879,4 +2074,6 @@ func init() {
 	pulumi.RegisterOutputType(ServiceNetworkConfigMapOutput{})
 	pulumi.RegisterOutputType(ServicePortConfigOutput{})
 	pulumi.RegisterOutputType(ServicePortConfigArrayOutput{})
+	pulumi.RegisterOutputType(ServiceVolumeConfigOutput{})
+	pulumi.RegisterOutputType(ServiceVolumeConfigArrayOutput{})
 }

--- a/sdk/v2/go/defang-gcp/compose/pulumiTypes.go
+++ b/sdk/v2/go/defang-gcp/compose/pulumiTypes.go
@@ -1396,6 +1396,7 @@ type ServiceConfig struct {
 	Llm             *LlmConfig                      `pulumi:"llm"`
 	Networks        map[string]ServiceNetworkConfig `pulumi:"networks"`
 	Platform        *string                         `pulumi:"platform"`
+	Policies        []string                        `pulumi:"policies"`
 	Ports           []ServicePortConfig             `pulumi:"ports"`
 	Postgres        *PostgresConfig                 `pulumi:"postgres"`
 	Redis           *RedisConfig                    `pulumi:"redis"`
@@ -1432,6 +1433,7 @@ type ServiceConfigArgs struct {
 	Llm             LlmConfigPtrInput             `pulumi:"llm"`
 	Networks        ServiceNetworkConfigMapInput  `pulumi:"networks"`
 	Platform        pulumi.StringPtrInput         `pulumi:"platform"`
+	Policies        pulumi.StringArrayInput       `pulumi:"policies"`
 	Ports           ServicePortConfigArrayInput   `pulumi:"ports"`
 	Postgres        PostgresConfigPtrInput        `pulumi:"postgres"`
 	Redis           RedisConfigPtrInput           `pulumi:"redis"`
@@ -1547,6 +1549,10 @@ func (o ServiceConfigOutput) Networks() ServiceNetworkConfigMapOutput {
 
 func (o ServiceConfigOutput) Platform() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ServiceConfig) *string { return v.Platform }).(pulumi.StringPtrOutput)
+}
+
+func (o ServiceConfigOutput) Policies() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v ServiceConfig) []string { return v.Policies }).(pulumi.StringArrayOutput)
 }
 
 func (o ServiceConfigOutput) Ports() ServicePortConfigArrayOutput {

--- a/sdk/v2/go/defang-gcp/compose/pulumiTypes.go
+++ b/sdk/v2/go/defang-gcp/compose/pulumiTypes.go
@@ -1394,6 +1394,7 @@ type ServiceConfig struct {
 	HealthCheck     *HealthCheckConfig              `pulumi:"healthCheck"`
 	Image           *string                         `pulumi:"image"`
 	Llm             *LlmConfig                      `pulumi:"llm"`
+	NetworkMode     *string                         `pulumi:"networkMode"`
 	Networks        map[string]ServiceNetworkConfig `pulumi:"networks"`
 	Platform        *string                         `pulumi:"platform"`
 	Policies        []string                        `pulumi:"policies"`
@@ -1431,6 +1432,7 @@ type ServiceConfigArgs struct {
 	HealthCheck     HealthCheckConfigPtrInput     `pulumi:"healthCheck"`
 	Image           pulumi.StringPtrInput         `pulumi:"image"`
 	Llm             LlmConfigPtrInput             `pulumi:"llm"`
+	NetworkMode     pulumi.StringPtrInput         `pulumi:"networkMode"`
 	Networks        ServiceNetworkConfigMapInput  `pulumi:"networks"`
 	Platform        pulumi.StringPtrInput         `pulumi:"platform"`
 	Policies        pulumi.StringArrayInput       `pulumi:"policies"`
@@ -1541,6 +1543,10 @@ func (o ServiceConfigOutput) Image() pulumi.StringPtrOutput {
 
 func (o ServiceConfigOutput) Llm() LlmConfigPtrOutput {
 	return o.ApplyT(func(v ServiceConfig) *LlmConfig { return v.Llm }).(LlmConfigPtrOutput)
+}
+
+func (o ServiceConfigOutput) NetworkMode() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v ServiceConfig) *string { return v.NetworkMode }).(pulumi.StringPtrOutput)
 }
 
 func (o ServiceConfigOutput) Networks() ServiceNetworkConfigMapOutput {

--- a/sdk/v2/go/defang-gcp/service.go
+++ b/sdk/v2/go/defang-gcp/service.go
@@ -16,7 +16,8 @@ import (
 type Service struct {
 	pulumi.ResourceState
 
-	Endpoint pulumi.StringOutput `pulumi:"endpoint"`
+	Endpoint            pulumi.StringOutput `pulumi:"endpoint"`
+	ServiceAccountEmail pulumi.StringOutput `pulumi:"serviceAccountEmail"`
 }
 
 // NewService registers a new resource with the given unique name, arguments, and options.
@@ -36,32 +37,50 @@ func NewService(ctx *pulumi.Context,
 }
 
 type serviceArgs struct {
-	Command     []string                    `pulumi:"command"`
-	Deploy      *compose.DeployConfig       `pulumi:"deploy"`
-	DomainName  *string                     `pulumi:"domainName"`
-	Entrypoint  []string                    `pulumi:"entrypoint"`
-	Environment map[string]string           `pulumi:"environment"`
-	HealthCheck *compose.HealthCheckConfig  `pulumi:"healthCheck"`
-	Image       string                      `pulumi:"image"`
-	Llm         *compose.LlmConfig          `pulumi:"llm"`
-	Platform    *string                     `pulumi:"platform"`
-	Ports       []compose.ServicePortConfig `pulumi:"ports"`
-	ProjectName string                      `pulumi:"projectName"`
+	Command             []string                             `pulumi:"command"`
+	ContainerName       *string                              `pulumi:"containerName"`
+	DependsOn           map[string]compose.ServiceDependency `pulumi:"dependsOn"`
+	Deploy              *compose.DeployConfig                `pulumi:"deploy"`
+	DomainName          *string                              `pulumi:"domainName"`
+	Entrypoint          []string                             `pulumi:"entrypoint"`
+	Environment         map[string]string                    `pulumi:"environment"`
+	HealthCheck         *compose.HealthCheckConfig           `pulumi:"healthCheck"`
+	Image               string                               `pulumi:"image"`
+	Llm                 *compose.LlmConfig                   `pulumi:"llm"`
+	Platform            *string                              `pulumi:"platform"`
+	Ports               []compose.ServicePortConfig          `pulumi:"ports"`
+	ProjectName         string                               `pulumi:"projectName"`
+	ServiceAccountEmail *string                              `pulumi:"serviceAccountEmail"`
+	Sidecars            map[string]compose.ServiceConfig     `pulumi:"sidecars"`
+	StopGracePeriod     *string                              `pulumi:"stopGracePeriod"`
+	Triggers            map[string]string                    `pulumi:"triggers"`
+	Volumes             []compose.ServiceVolumeConfig        `pulumi:"volumes"`
+	VolumesFrom         []string                             `pulumi:"volumesFrom"`
+	WorkingDir          *string                              `pulumi:"workingDir"`
 }
 
 // The set of arguments for constructing a Service resource.
 type ServiceArgs struct {
-	Command     pulumi.StringArrayInput
-	Deploy      compose.DeployConfigPtrInput
-	DomainName  *string
-	Entrypoint  pulumi.StringArrayInput
-	Environment pulumi.StringMapInput
-	HealthCheck compose.HealthCheckConfigPtrInput
-	Image       string
-	Llm         compose.LlmConfigPtrInput
-	Platform    *string
-	Ports       compose.ServicePortConfigArrayInput
-	ProjectName string
+	Command             pulumi.StringArrayInput
+	ContainerName       *string
+	DependsOn           compose.ServiceDependencyMapInput
+	Deploy              compose.DeployConfigPtrInput
+	DomainName          *string
+	Entrypoint          pulumi.StringArrayInput
+	Environment         pulumi.StringMapInput
+	HealthCheck         compose.HealthCheckConfigPtrInput
+	Image               string
+	Llm                 compose.LlmConfigPtrInput
+	Platform            *string
+	Ports               compose.ServicePortConfigArrayInput
+	ProjectName         string
+	ServiceAccountEmail pulumi.StringPtrInput
+	Sidecars            compose.ServiceConfigMapInput
+	StopGracePeriod     *string
+	Triggers            pulumi.StringMapInput
+	Volumes             compose.ServiceVolumeConfigArrayInput
+	VolumesFrom         pulumi.StringArrayInput
+	WorkingDir          *string
 }
 
 func (ServiceArgs) ElementType() reflect.Type {
@@ -103,6 +122,10 @@ func (o ServiceOutput) ToServiceOutputWithContext(ctx context.Context) ServiceOu
 
 func (o ServiceOutput) Endpoint() pulumi.StringOutput {
 	return o.ApplyT(func(v *Service) pulumi.StringOutput { return v.Endpoint }).(pulumi.StringOutput)
+}
+
+func (o ServiceOutput) ServiceAccountEmail() pulumi.StringOutput {
+	return o.ApplyT(func(v *Service) pulumi.StringOutput { return v.ServiceAccountEmail }).(pulumi.StringOutput)
 }
 
 func init() {

--- a/sdk/v2/go/defang-gcp/service.go
+++ b/sdk/v2/go/defang-gcp/service.go
@@ -27,6 +27,9 @@ func NewService(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
+	if args.Image == nil {
+		return nil, errors.New("invalid value for required argument 'Image'")
+	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource Service
 	err := ctx.RegisterRemoteComponentResource("defang-gcp:index:Service", name, args, &resource, opts...)
@@ -69,7 +72,7 @@ type ServiceArgs struct {
 	Entrypoint          pulumi.StringArrayInput
 	Environment         pulumi.StringMapInput
 	HealthCheck         compose.HealthCheckConfigPtrInput
-	Image               string
+	Image               pulumi.StringInput
 	Llm                 compose.LlmConfigPtrInput
 	Platform            *string
 	Ports               compose.ServicePortConfigArrayInput

--- a/tests/aws/project_test.go
+++ b/tests/aws/project_test.go
@@ -11,13 +11,16 @@ package aws
 // which can supply a richer mock.
 
 import (
+	"encoding/json"
 	"testing"
 
 	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	awsprov "github.com/DefangLabs/pulumi-defang/provider/defangaws/aws"
 	"github.com/DefangLabs/pulumi-defang/tests/testutil"
 )
 
@@ -33,6 +36,134 @@ func TestConstructAwsProject(t *testing.T) {
 	})
 
 	require.NoError(t, err)
+}
+
+// TestConstructAwsProjectFoldsSidecars verifies that a service with
+// network_mode: "service:<name>" is folded into the parent's task definition
+// as an additional container instead of being deployed as its own ECS service.
+func TestConstructAwsProjectFoldsSidecars(t *testing.T) {
+	var taskDefs []property.Map
+	ecsServices := 0
+	mock := &integration.MockResourceMonitor{
+		NewResourceF: func(args integration.MockResourceArgs) (string, property.Map, error) {
+			switch args.TypeToken {
+			case "aws:ecs/taskDefinition:TaskDefinition":
+				taskDefs = append(taskDefs, args.Inputs)
+			case "aws:ecs/service:Service":
+				ecsServices++
+			}
+			return args.Name, args.Inputs, nil
+		},
+	}
+	server := testutil.MakeAwsTestServer(integration.WithMocks(mock))
+
+	resp, err := server.Construct(p.ConstructRequest{
+		Urn: testutil.AwsURN("Project"),
+		Inputs: testutil.ServicesMap(map[string]property.Value{
+			"app": property.New(property.NewMap(map[string]property.Value{
+				"image":       property.New("myapp:latest"),
+				"volumesFrom": property.New(property.NewArray([]property.Value{property.New("helper")})),
+			})),
+			"helper": property.New(property.NewMap(map[string]property.Value{
+				"image":       property.New("helper:latest"),
+				"networkMode": property.New("service:app"),
+			})),
+		}),
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, ecsServices, "sidecar must not become its own ECS service")
+	require.Len(t, taskDefs, 1)
+	var defs []awsprov.ContainerDefinition
+	require.NoError(t, json.Unmarshal([]byte(taskDefs[0].Get("containerDefinitions").AsString()), &defs))
+	require.Len(t, defs, 2, "task definition should hold the main container plus the sidecar")
+	names := []string{defs[0].Name, defs[1].Name}
+	assert.Contains(t, names, "app")
+	assert.Contains(t, names, "helper")
+
+	// The sidecar must not surface in the endpoints output.
+	_, hasHelper := resp.State.Get("endpoints").AsMap().GetOk("helper")
+	assert.False(t, hasHelper, "sidecar should not have an endpoint")
+}
+
+// TestConstructAwsProjectSidecarErrors covers invalid sidecar wiring.
+func TestConstructAwsProjectSidecarErrors(t *testing.T) {
+	sidecar := func(parent string) property.Value {
+		return property.New(property.NewMap(map[string]property.Value{
+			"image":       property.New("helper:latest"),
+			"networkMode": property.New("service:" + parent),
+		}))
+	}
+
+	tests := map[string]struct {
+		services map[string]property.Value
+		wantErr  string
+	}{
+		"unknown parent": {
+			services: map[string]property.Value{"helper": sidecar("missing")},
+			wantErr:  "sidecar parent service not found",
+		},
+		"parent is itself a sidecar": {
+			services: map[string]property.Value{
+				"app":    testutil.ServiceWithImage("myapp:latest"),
+				"mid":    sidecar("app"),
+				"helper": sidecar("mid"),
+			},
+			wantErr: "sidecar parent is itself a sidecar",
+		},
+		"parent is managed": {
+			services: map[string]property.Value{
+				"cache": property.New(property.NewMap(map[string]property.Value{
+					"image": property.New("redis:7"),
+					"redis": property.New(property.NewMap(map[string]property.Value{})),
+				})),
+				"helper": sidecar("cache"),
+			},
+			wantErr: "must be a container service",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			server := testutil.MakeAwsTestServer()
+			_, err := server.Construct(p.ConstructRequest{
+				Urn:    testutil.AwsURN("Project"),
+				Inputs: testutil.ServicesMap(tc.services),
+			})
+			require.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}
+
+// TestConstructAwsProjectInfraOutputs verifies the Project surfaces handles to
+// its shared infrastructure so externally managed resources (WAF, alarms,
+// resource-based policies) can attach to it.
+func TestConstructAwsProjectInfraOutputs(t *testing.T) {
+	server := testutil.MakeAwsTestServer()
+
+	resp, err := server.Construct(p.ConstructRequest{
+		Urn: testutil.AwsURN("Project"),
+		Inputs: testutil.ServicesMap(map[string]property.Value{
+			"app":    testutil.ServiceWithPorts("nginx:latest", testutil.IngressPort(8080)),
+			"worker": testutil.ServiceWithImage("myapp:worker"),
+		}),
+	})
+	require.NoError(t, err)
+
+	// The mock state keeps the raw pulumi tag for optional fields, hence
+	// "loadBalancerArn,optional" (same quirk as the pre-existing
+	// "loadBalancerDns,optional").
+	for _, key := range []string{"clusterName", "logGroupName", "loadBalancerArn,optional"} {
+		_, ok := resp.State.GetOk(key)
+		assert.True(t, ok, "missing output %q", key)
+	}
+	serviceNames := resp.State.Get("serviceNames").AsMap()
+	taskRoleArns := resp.State.Get("taskRoleArns").AsMap()
+	for _, svc := range []string{"app", "worker"} {
+		_, ok := serviceNames.GetOk(svc)
+		assert.True(t, ok, "serviceNames missing %q", svc)
+		_, ok = taskRoleArns.GetOk(svc)
+		assert.True(t, ok, "taskRoleArns missing %q", svc)
+	}
 }
 
 // TestConstructAwsProjectAllResourcesAreChildren asserts that every resource

--- a/tests/aws/project_test.go
+++ b/tests/aws/project_test.go
@@ -51,6 +51,7 @@ func TestConstructAwsProjectFoldsSidecars(t *testing.T) {
 				taskDefs = append(taskDefs, args.Inputs)
 			case "aws:ecs/service:Service":
 				ecsServices++
+			default:
 			}
 			return args.Name, args.Inputs, nil
 		},

--- a/tests/aws/project_test.go
+++ b/tests/aws/project_test.go
@@ -46,7 +46,7 @@ func TestConstructAwsProjectFoldsSidecars(t *testing.T) {
 	ecsServices := 0
 	mock := &integration.MockResourceMonitor{
 		NewResourceF: func(args integration.MockResourceArgs) (string, property.Map, error) {
-			switch args.TypeToken {
+			switch string(args.TypeToken) {
 			case "aws:ecs/taskDefinition:TaskDefinition":
 				taskDefs = append(taskDefs, args.Inputs)
 			case "aws:ecs/service:Service":


### PR DESCRIPTION
## Summary

Extends the AWS/GCP providers so Defang's own fabric and CD stacks can be deployed with the public SDK ("defang-on-defang"), while keeping the schema Compose-shaped:

- **compose**: `container_name`, `working_dir`, `stop_grace_period`, `volumes`, `volumes_from`, `depends_on`, `x-defang-autoscaling`, per-port `x-defang-listener`; build spec gains `platforms`, `cache_from`, `cache_to`
- **AWS Service**: sidecar containers (same-task, enabling `volumes_from`), `secrets`, `taskRoleArn`, `securityGroupIds`, `triggers`, `waitForSteadyState`; CPU target-tracking autoscaling; `SharedInfra` gains schema-tagged reuse handles (`clusterArn`, `executionRoleArn`, `logGroupName`) for bring-your-own-plumbing standalone use — ALB attachment is deliberately not exposed (ingress-bearing services belong in a Project)
- **AWS Build**: `--platform` and `--cache-from/--cache-to` passthrough in the CodeBuild buildspec; `ARM_CONTAINER` only for single-arm64 platform lists
- **GCP Service**: sidecars as systemd units on COS (oneshot for `restart: "no"`), caller-supplied `serviceAccountEmail`, replacement `triggers` via instance metadata; standalone Compute Engine on the default network when sidecars/volumes demand it — portless standalone services keep the legacy Cloud Run routing
- **GCP Build**: platform + cache passthrough in Cloud Build steps (multi-platform rejected with an explicit error)
- **Azure**: parity intentionally deferred — documented as `TODO(azure-parity)` in CLAUDE.md and `defangazure/service.go`
- **x-defang-policies** (AWS-only): attach extra IAM policies (full ARN or customer-managed policy name) to the task role the provider creates; rejected when combined with a caller-supplied `taskRoleArn` and on GCP/Azure
- **AWS Project — sidecars and infra outputs**: compose services with `network_mode: "service:<name>"` fold into `<name>`'s task definition as sidecar containers instead of deploying standalone; Project now also outputs `loadBalancerArn`, `clusterName`, `logGroupName`, `serviceNames` and `taskRoleArns` so externally managed resources (WAF web ACLs, alarms, resource-based policies) can attach to its infrastructure
- **Output-friendly inputs**: `environment` (AWS Service) and `image` (compose `ServiceConfig`, so also sidecars) are now Input-typed, accepting Outputs of builds/parameters — required because the infer framework can't copy remote-component output-values into plain Go fields. Bare `${VAR}` environment values still become ECS secret refs; synchronous image-parsing paths (Postgres/Redis version detection, GCP registry rewrites) use a `StaticImage()` unwrap and GCP sidecar images must stay static (baked into cloud-init). No schema change.

Deliberately excluded as too Defang-internal for public API: nginx public-ECR proxy, registry auth injection, custom pre-build steps, custom local cache paths. Those remain in the consuming stack, which uses the `Build` resource only as the build trigger.

## Test plan

- [x] `make test` — unit + provider (mock server) + cd suites green
- [x] `golangci-lint run ./provider/... ./tests/...` — 0 issues
- [x] `make schema && make sdks` — regenerated, `sdk/v2` committed
- [x] New tests: AWS buildspec platform/cache flags, GCP Cloud Build steps platform/cache, GCP cloud-init sidecar units/ordering/%-escaping, Project sidecar folding + error cases + infra outputs
- [ ] Consumer validation: defang-mvp migration PR (follow-up) runs `pulumi preview` in CI against this SDK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

