### PR TITLE
feat: MemoryDB engine, config-path recipe, and x-defang-aliases adoption

### DIFF
--- a/provider/cmd/pulumi-resource-defang-aws/schema.json
+++ b/provider/cmd/pulumi-resource-defang-aws/schema.json
@@ -576,12 +576,16 @@
     },
     "defang-aws:index:Redis": {
       "properties": {
+        "clusterId": {
+          "type": "string"
+        },
         "endpoint": {
           "type": "string"
         }
       },
       "required": [
-        "endpoint"
+        "endpoint",
+        "clusterId"
       ],
       "inputProperties": {
         "aws": {

--- a/provider/cmd/pulumi-resource-defang-aws/schema.json
+++ b/provider/cmd/pulumi-resource-defang-aws/schema.json
@@ -202,6 +202,12 @@
     },
     "defang-aws:compose:ServiceConfig": {
       "properties": {
+        "aliases": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "autoscaling": {
           "type": "boolean"
         },
@@ -588,6 +594,13 @@
         "clusterId"
       ],
       "inputProperties": {
+        "aliases": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "plain": true
+          }
+        },
         "aws": {
           "$ref": "#/types/defang-aws:aws:SharedInfra"
         },

--- a/provider/cmd/pulumi-resource-defang-azure/schema.json
+++ b/provider/cmd/pulumi-resource-defang-azure/schema.json
@@ -163,6 +163,12 @@
     },
     "defang-azure:compose:ServiceConfig": {
       "properties": {
+        "aliases": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "autoscaling": {
           "type": "boolean"
         },

--- a/provider/cmd/pulumi-resource-defang-gcp/schema.json
+++ b/provider/cmd/pulumi-resource-defang-gcp/schema.json
@@ -163,6 +163,12 @@
     },
     "defang-gcp:compose:ServiceConfig": {
       "properties": {
+        "aliases": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "autoscaling": {
           "type": "boolean"
         },

--- a/provider/compose/aliases.go
+++ b/provider/compose/aliases.go
@@ -1,0 +1,26 @@
+package compose
+
+import "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+// Child resource kinds addressable via the x-defang-aliases extension. Each
+// provider applies the kinds relevant to the resources it creates for a
+// service.
+const (
+	AliasCluster        = "cluster"
+	AliasParameterGroup = "parameter-group"
+	AliasSecurityGroup  = "security-group"
+	AliasSubnetGroup    = "subnet-group"
+)
+
+// AliasOptions returns pulumi.Aliases resource options for the given child
+// resource kind when x-defang-aliases configures a pre-migration URN for it;
+// empty otherwise. Aliases must be applied where the child is registered
+// (inside the provider): resource options passed to a remote component do not
+// propagate to its children.
+func (s *ServiceConfig) AliasOptions(kind string) []pulumi.ResourceOption {
+	urn, ok := s.Aliases[kind]
+	if !ok || urn == "" {
+		return nil
+	}
+	return []pulumi.ResourceOption{pulumi.Aliases([]pulumi.Alias{{URN: pulumi.URN(urn)}})}
+}

--- a/provider/compose/types.go
+++ b/provider/compose/types.go
@@ -117,6 +117,13 @@ type ServiceConfig struct {
 	// reject it, and it cannot be combined with a caller-supplied task role.
 	Policies []string `pulumi:"policies,optional" yaml:"x-defang-policies,omitempty"`
 
+	// Aliases maps this service's child cloud resources — by provider-defined
+	// kind, e.g. "cluster", "subnet-group", "parameter-group",
+	// "security-group" — to pre-migration Pulumi URNs, applied as aliases so
+	// the engine adopts the existing resources instead of replacing them.
+	// Matches the x-defang-aliases extension.
+	Aliases map[string]string `pulumi:"aliases,optional" yaml:"x-defang-aliases,omitempty"`
+
 	// Models map[string]*ServiceModelConfig `pulumi:"models,optional" yaml:"models,omitempty"`
 }
 

--- a/provider/defangaws/aws/elasticache.go
+++ b/provider/defangaws/aws/elasticache.go
@@ -246,7 +246,7 @@ func CreateElasticache(
 			Description: pulumi.String(common.DefangComment),
 			SubnetIds:   privateSubnetIDs,
 			Tags:        tags,
-		}, opts...)
+		}, common.MergeOptions(opts, svc.AliasOptions(compose.AliasSubnetGroup)...)...)
 		if err != nil {
 			return nil, fmt.Errorf("creating ElastiCache subnet group: %w", err)
 		}
@@ -281,7 +281,7 @@ func CreateElasticache(
 			},
 		},
 		Tags: tags,
-	}, common.MergeOptions(opts,
+	}, common.MergeOptions(common.MergeOptions(opts, svc.AliasOptions(compose.AliasSecurityGroup)...),
 		pulumi.Timeouts(&pulumi.CustomTimeouts{Delete: "2m"}),
 	)...)
 	if err != nil {
@@ -334,7 +334,8 @@ func CreateElasticache(
 		rgArgs.SnapshotWindow = pulumi.String("09:30-10:30")
 	}
 
-	clusterOpts := append(append([]pulumi.ResourceOption{}, opts...), pulumi.IgnoreChanges([]string{
+	clusterOpts := common.MergeOptions(opts, svc.AliasOptions(compose.AliasCluster)...)
+	clusterOpts = append(clusterOpts, pulumi.IgnoreChanges([]string{
 		"atRestEncryptionEnabled",
 		"authToken", // TODO: allow user to set authToken via config
 		"authTokenUpdateStrategy",

--- a/provider/defangaws/aws/elasticache.go
+++ b/provider/defangaws/aws/elasticache.go
@@ -15,8 +15,33 @@ import (
 
 var ErrRedisConfigNil = errors.New("redis config is nil")
 
+const (
+	engineRedis  = "redis"
+	engineValkey = "valkey"
+)
+
+// detectRedisEngine returns the engine (redis vs valkey) and version derived
+// from the service's image name; defaults to "redis" with no version when the
+// image is unset or a dynamic Output.
+func detectRedisEngine(svc compose.ServiceConfig) (string, string) {
+	engine := engineRedis
+	var engineVersion string
+	if img := svc.StaticImage(); img != nil {
+		if strings.Contains(strings.ToLower(*img), engineValkey) {
+			engine = engineValkey
+		}
+		if parts := strings.Split(*img, ":"); len(parts) == 2 {
+			engineVersion = parts[1]
+		}
+	}
+	return engine, engineVersion
+}
+
 type ElasticacheResult struct {
 	Address pulumi.StringOutput // primary or configuration endpoint address
+	// ClusterID is the ElastiCache replication group ID or the MemoryDB
+	// cluster name, for downstream consumers such as CloudWatch alarms.
+	ClusterID pulumi.StringOutput
 }
 
 // ElastiCache node type catalogs.
@@ -164,7 +189,7 @@ func cacheNodeType(minCPUs float64, minMemoryMiB int, nodeType string) string {
 // "Transit encryption mode is not supported for engine version 6.2.6.
 // Please use engine version 7.0.5 or higher."
 func transitEncryptionSupported(engine, engineVersion string) bool {
-	if engine == "valkey" {
+	if engine == engineValkey {
 		return true
 	}
 	if engineVersion == "" {
@@ -195,18 +220,7 @@ func CreateElasticache(
 		return nil, ErrRedisConfigNil
 	}
 
-	// Detect engine (redis vs valkey) and version from the image name;
-	// default to "redis" when the image is unset or a dynamic Output.
-	engine := "redis"
-	var engineVersion string
-	if img := svc.StaticImage(); img != nil {
-		if strings.Contains(strings.ToLower(*img), "valkey") {
-			engine = "valkey"
-		}
-		if parts := strings.Split(*img, ":"); len(parts) == 2 {
-			engineVersion = parts[1]
-		}
-	}
+	engine, engineVersion := detectRedisEngine(svc)
 
 	allowDowntime := false
 	if svc.Redis.AllowDowntime != nil {
@@ -350,5 +364,5 @@ func CreateElasticache(
 				return primary
 			}).(pulumi.StringOutput)
 
-	return &ElasticacheResult{Address: address}, nil
+	return &ElasticacheResult{Address: address, ClusterID: rg.ReplicationGroupId}, nil
 }

--- a/provider/defangaws/aws/elasticache.go
+++ b/provider/defangaws/aws/elasticache.go
@@ -30,8 +30,8 @@ func detectRedisEngine(svc compose.ServiceConfig) (string, string) {
 		if strings.Contains(strings.ToLower(*img), engineValkey) {
 			engine = engineValkey
 		}
-		if parts := strings.Split(*img, ":"); len(parts) == 2 {
-			engineVersion = parts[1]
+		if tag := compose.ParseImageTag(*img); tag != "" {
+			engineVersion = tag
 		}
 	}
 	return engine, engineVersion

--- a/provider/defangaws/aws/memorydb.go
+++ b/provider/defangaws/aws/memorydb.go
@@ -1,0 +1,279 @@
+package aws
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/DefangLabs/pulumi-defang/provider/common"
+	"github.com/DefangLabs/pulumi-defang/provider/compose"
+	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/ec2"
+	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/memorydb"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// MemoryDB node type catalogs. Costs are approximate on-demand us-west-2
+// prices, used only for cheapest-match ordering within a catalog.
+// https://aws.amazon.com/memorydb/pricing/
+
+// Burstable MemoryDB instances (t4g Graviton). db.t4g.small is the smallest
+// available MemoryDB node type.
+var memoryDBBurstableNodeTypes = map[string]nodeInfo{
+	"db.t4g.small":  {vcpu: 2, gib: 1.37, cost: 0.048},
+	"db.t4g.medium": {vcpu: 2, gib: 3.09, cost: 0.096},
+}
+
+// Memory-optimized MemoryDB instances (r7g, r6g Graviton).
+var memoryDBMemoryOptimizedNodeTypes = map[string]nodeInfo{
+	"db.r7g.large":    {vcpu: 2, gib: 13.07, cost: 0.412},
+	"db.r7g.xlarge":   {vcpu: 4, gib: 26.32, cost: 0.824},
+	"db.r7g.2xlarge":  {vcpu: 8, gib: 52.82, cost: 1.648},
+	"db.r7g.4xlarge":  {vcpu: 16, gib: 105.81, cost: 3.297},
+	"db.r7g.8xlarge":  {vcpu: 32, gib: 209.55, cost: 6.594},
+	"db.r7g.12xlarge": {vcpu: 48, gib: 317.77, cost: 9.89},
+	"db.r7g.16xlarge": {vcpu: 64, gib: 419.09, cost: 13.188},
+
+	"db.r6g.large":    {vcpu: 2, gib: 13.07, cost: 0.395},
+	"db.r6g.xlarge":   {vcpu: 4, gib: 26.32, cost: 0.79},
+	"db.r6g.2xlarge":  {vcpu: 8, gib: 52.82, cost: 1.58},
+	"db.r6g.4xlarge":  {vcpu: 16, gib: 105.81, cost: 3.16},
+	"db.r6g.8xlarge":  {vcpu: 32, gib: 209.55, cost: 6.32},
+	"db.r6g.12xlarge": {vcpu: 48, gib: 317.77, cost: 9.48},
+	"db.r6g.16xlarge": {vcpu: 64, gib: 419.09, cost: 12.64},
+}
+
+// memoryDBNodeTypeCatalogs maps recipe node-type values to their catalog
+// search order. MemoryDB has no general-purpose (m-family) tier.
+var memoryDBNodeTypeCatalogs = map[string][]map[string]nodeInfo{
+	"burstable":        {memoryDBBurstableNodeTypes, memoryDBMemoryOptimizedNodeTypes},
+	"memory-optimized": {memoryDBMemoryOptimizedNodeTypes},
+}
+
+// memoryDBNodeType returns the cheapest MemoryDB node type meeting CPU/memory
+// requirements; see cacheNodeType.
+func memoryDBNodeType(minCPUs float64, minMemoryMiB int, nodeType string) string {
+	minGiB := float64(minMemoryMiB) / 1024
+
+	catalogs, ok := memoryDBNodeTypeCatalogs[nodeType]
+	if !ok {
+		catalogs = memoryDBNodeTypeCatalogs["burstable"]
+	}
+
+	for _, catalog := range catalogs {
+		if name := cheapestMatch(catalog, minCPUs, minGiB); name != "" {
+			return name
+		}
+	}
+
+	// Fallback: smallest burstable
+	return "db.t4g.small"
+}
+
+// redisAliasURNs returns the pre-migration URN aliases configured for one
+// child (kind) of the named Redis service via the redis-aliases recipe.
+func redisAliasURNs(ctx *pulumi.Context, serviceName, kind string) ([]pulumi.Alias, error) {
+	raw := RedisAliases.Get(ctx)
+	if raw == "" {
+		return nil, nil
+	}
+	var byService map[string]map[string]string
+	if err := json.Unmarshal([]byte(raw), &byService); err != nil {
+		return nil, fmt.Errorf("parsing defang-aws:redis-aliases: %w", err)
+	}
+	urn, ok := byService[serviceName][kind]
+	if !ok || urn == "" {
+		return nil, nil
+	}
+	return []pulumi.Alias{{URN: pulumi.URN(urn)}}, nil
+}
+
+// withRedisAliases appends any configured pre-migration aliases for the given
+// child kind to opts.
+func withRedisAliases(
+	ctx *pulumi.Context, serviceName, kind string, opts []pulumi.ResourceOption,
+) ([]pulumi.ResourceOption, error) {
+	aliases, err := redisAliasURNs(ctx, serviceName, kind)
+	if err != nil {
+		return nil, err
+	}
+	if len(aliases) == 0 {
+		return opts, nil
+	}
+	return common.MergeOptions(opts, pulumi.Aliases(aliases)), nil
+}
+
+// memoryDBParameterGroupFamily derives the parameter group family from the
+// engine and its major version, e.g. memorydb_redis7 or memorydb_valkey8.
+func memoryDBParameterGroupFamily(engine, engineVersion string) string {
+	major := "7"
+	if engineVersion != "" {
+		major = strings.SplitN(engineVersion, ".", 2)[0]
+	}
+	return fmt.Sprintf("memorydb_%s%s", engine, major)
+}
+
+// CreateMemoryDB creates a managed MemoryDB Redis/Valkey cluster for a
+// service. Selected over ElastiCache via the redis-engine recipe; the result
+// shape matches CreateElasticache so callers are engine-agnostic.
+//
+//nolint:funlen
+func CreateMemoryDB(
+	ctx *pulumi.Context,
+	serviceName string,
+	svc compose.ServiceConfig,
+	vpcID pulumi.StringInput,
+	privateSubnetIDs pulumi.StringArrayInput,
+	privateSgID pulumi.StringPtrInput,
+	deps []pulumi.Resource,
+	opts ...pulumi.ResourceOption,
+) (*ElasticacheResult, error) {
+	if svc.Redis == nil {
+		return nil, ErrRedisConfigNil
+	}
+
+	engine, engineVersion := detectRedisEngine(svc)
+
+	// Redis port: use first declared port or default 6379.
+	port := 6379
+	if len(svc.Ports) > 0 {
+		port = int(svc.Ports[0].Target)
+	}
+
+	tags := pulumi.StringMap{
+		"defang:service": pulumi.String(serviceName),
+	}
+
+	// MemoryDB subnet group (always private). Subnet IDs of an in-use subnet
+	// group can't be updated in place.
+	var subnetGroupName pulumi.StringPtrOutput
+	if privateSubnetIDs != nil {
+		sgOpts, err := withRedisAliases(ctx, serviceName, "subnetGroup", opts)
+		if err != nil {
+			return nil, err
+		}
+		subnetGroup, err := memorydb.NewSubnetGroup(ctx, serviceName, &memorydb.SubnetGroupArgs{
+			Description: pulumi.String(common.DefangComment),
+			SubnetIds:   privateSubnetIDs,
+			Tags:        tags,
+		}, common.MergeOptions(sgOpts, pulumi.ReplaceOnChanges([]string{"subnetIds"}))...)
+		if err != nil {
+			return nil, fmt.Errorf("creating MemoryDB subnet group: %w", err)
+		}
+		subnetGroupName = subnetGroup.Name.ToStringPtrOutput()
+	}
+
+	pgOpts, err := withRedisAliases(ctx, serviceName, "parameterGroup", opts)
+	if err != nil {
+		return nil, err
+	}
+	parameterGroup, err := memorydb.NewParameterGroup(ctx, serviceName, &memorydb.ParameterGroupArgs{
+		Description: pulumi.String(common.DefangComment),
+		Family:      pulumi.String(memoryDBParameterGroupFamily(engine, engineVersion)),
+		Parameters: memorydb.ParameterGroupParameterArray{
+			&memorydb.ParameterGroupParameterArgs{
+				Name:  pulumi.String("maxmemory-policy"),
+				Value: pulumi.String("allkeys-lru"),
+			},
+		},
+		Tags: tags,
+	}, pgOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("creating MemoryDB parameter group: %w", err)
+	}
+
+	// The service SG is only referenced when supplied; standalone Construct
+	// callers (e.g. unit tests) may omit it.
+	var ingressSGs pulumi.StringArray
+	if privateSgID != nil {
+		ingressSGs = pulumi.StringArray{privateSgID.ToStringPtrOutput().Elem()}
+	}
+	secOpts, err := withRedisAliases(ctx, serviceName, "securityGroup", opts)
+	if err != nil {
+		return nil, err
+	}
+	cacheSG, err := ec2.NewSecurityGroup(ctx, serviceName, &ec2.SecurityGroupArgs{
+		VpcId:       vpcID.ToStringOutput(),
+		Description: pulumi.String("MemoryDB security group for " + serviceName),
+		Ingress: ec2.SecurityGroupIngressArray{
+			&ec2.SecurityGroupIngressArgs{
+				Description:    pulumi.String("Allow incoming Redis traffic"),
+				Protocol:       pulumi.String("tcp"),
+				FromPort:       pulumi.Int(port),
+				ToPort:         pulumi.Int(port),
+				SecurityGroups: ingressSGs,
+			},
+		},
+		Egress: ec2.SecurityGroupEgressArray{
+			&ec2.SecurityGroupEgressArgs{
+				Description: pulumi.String("Allow all outbound traffic"),
+				Protocol:    pulumi.String("-1"),
+				FromPort:    pulumi.Int(0),
+				ToPort:      pulumi.Int(0),
+				CidrBlocks:  pulumi.StringArray{pulumi.String("0.0.0.0/0")},
+			},
+		},
+		Tags: tags,
+	}, common.MergeOptions(secOpts,
+		pulumi.Timeouts(&pulumi.CustomTimeouts{Delete: "2m"}),
+	)...)
+	if err != nil {
+		return nil, fmt.Errorf("creating MemoryDB security group: %w", err)
+	}
+
+	nodeType := memoryDBNodeType(svc.GetCPUs(), svc.GetMemoryMiB(), RDSNodeType.Get(ctx))
+	replicas := svc.GetReplicas()
+	deletionProtection := DeletionProtection.Get(ctx)
+
+	// Final snapshot: create one when deletion protection is on (production)
+	var finalSnapshotName pulumi.StringPtrInput
+	if deletionProtection {
+		finalSnapshotName = pulumi.String(fmt.Sprintf("%s-%s-%s-final", ctx.Project(), ctx.Stack(), serviceName))
+	}
+
+	clusterArgs := &memorydb.ClusterArgs{
+		AclName:                 pulumi.String("open-access"),
+		AutoMinorVersionUpgrade: pulumi.Bool(true),
+		Description:             pulumi.String(common.DefangComment),
+		Engine:                  pulumi.String(engine),
+		FinalSnapshotName:       finalSnapshotName,
+		NodeType:                pulumi.String(nodeType),
+		NumReplicasPerShard:     pulumi.Int(replicas - 1),
+		NumShards:               pulumi.Int(1),
+		ParameterGroupName:      parameterGroup.Name,
+		Port:                    pulumi.Int(port),
+		SecurityGroupIds:        pulumi.StringArray{cacheSG.ID()},
+		SubnetGroupName:         subnetGroupName,
+		Tags:                    tags,
+	}
+	if engineVersion != "" {
+		clusterArgs.EngineVersion = pulumi.String(engineVersion)
+	}
+	if svc.Redis.FromSnapshot != nil && *svc.Redis.FromSnapshot != "" {
+		clusterArgs.SnapshotName = pulumi.String(*svc.Redis.FromSnapshot)
+	}
+	if backupRetentionDays := BackupRetentionDays.Get(ctx); backupRetentionDays > 0 {
+		clusterArgs.SnapshotRetentionLimit = pulumi.Int(backupRetentionDays)
+		clusterArgs.SnapshotWindow = pulumi.String("09:30-10:30")
+	}
+
+	clusterOpts, err := withRedisAliases(ctx, serviceName, "cluster", opts)
+	if err != nil {
+		return nil, err
+	}
+	clusterOpts = common.MergeOptions(clusterOpts, pulumi.IgnoreChanges([]string{
+		"finalSnapshotName",
+		"maintenanceWindow",
+		"snapshotWindow",
+	}))
+	if len(deps) > 0 {
+		clusterOpts = append(clusterOpts, pulumi.DependsOn(deps))
+	}
+	cluster, err := memorydb.NewCluster(ctx, serviceName, clusterArgs, clusterOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("creating MemoryDB cluster: %w", err)
+	}
+
+	address := cluster.ClusterEndpoints.Index(pulumi.Int(0)).Address().Elem()
+
+	return &ElasticacheResult{Address: address, ClusterID: cluster.Name.ToStringOutput()}, nil
+}

--- a/provider/defangaws/aws/memorydb.go
+++ b/provider/defangaws/aws/memorydb.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -69,39 +68,6 @@ func memoryDBNodeType(minCPUs float64, minMemoryMiB int, nodeType string) string
 	return "db.t4g.small"
 }
 
-// redisAliasURNs returns the pre-migration URN aliases configured for one
-// child (kind) of the named Redis service via the redis-aliases recipe.
-func redisAliasURNs(ctx *pulumi.Context, serviceName, kind string) ([]pulumi.Alias, error) {
-	raw := RedisAliases.Get(ctx)
-	if raw == "" {
-		return nil, nil
-	}
-	var byService map[string]map[string]string
-	if err := json.Unmarshal([]byte(raw), &byService); err != nil {
-		return nil, fmt.Errorf("parsing defang-aws:redis-aliases: %w", err)
-	}
-	urn, ok := byService[serviceName][kind]
-	if !ok || urn == "" {
-		return nil, nil
-	}
-	return []pulumi.Alias{{URN: pulumi.URN(urn)}}, nil
-}
-
-// withRedisAliases appends any configured pre-migration aliases for the given
-// child kind to opts.
-func withRedisAliases(
-	ctx *pulumi.Context, serviceName, kind string, opts []pulumi.ResourceOption,
-) ([]pulumi.ResourceOption, error) {
-	aliases, err := redisAliasURNs(ctx, serviceName, kind)
-	if err != nil {
-		return nil, err
-	}
-	if len(aliases) == 0 {
-		return opts, nil
-	}
-	return common.MergeOptions(opts, pulumi.Aliases(aliases)), nil
-}
-
 // memoryDBParameterGroupFamily derives the parameter group family from the
 // engine and its major version, e.g. memorydb_redis7 or memorydb_valkey8.
 func memoryDBParameterGroupFamily(engine, engineVersion string) string {
@@ -147,10 +113,7 @@ func CreateMemoryDB(
 	// group can't be updated in place.
 	var subnetGroupName pulumi.StringPtrOutput
 	if privateSubnetIDs != nil {
-		sgOpts, err := withRedisAliases(ctx, serviceName, "subnetGroup", opts)
-		if err != nil {
-			return nil, err
-		}
+		sgOpts := common.MergeOptions(opts, svc.AliasOptions(compose.AliasSubnetGroup)...)
 		subnetGroup, err := memorydb.NewSubnetGroup(ctx, serviceName, &memorydb.SubnetGroupArgs{
 			Description: pulumi.String(common.DefangComment),
 			SubnetIds:   privateSubnetIDs,
@@ -162,10 +125,7 @@ func CreateMemoryDB(
 		subnetGroupName = subnetGroup.Name.ToStringPtrOutput()
 	}
 
-	pgOpts, err := withRedisAliases(ctx, serviceName, "parameterGroup", opts)
-	if err != nil {
-		return nil, err
-	}
+	pgOpts := common.MergeOptions(opts, svc.AliasOptions(compose.AliasParameterGroup)...)
 	parameterGroup, err := memorydb.NewParameterGroup(ctx, serviceName, &memorydb.ParameterGroupArgs{
 		Description: pulumi.String(common.DefangComment),
 		Family:      pulumi.String(memoryDBParameterGroupFamily(engine, engineVersion)),
@@ -187,10 +147,7 @@ func CreateMemoryDB(
 	if privateSgID != nil {
 		ingressSGs = pulumi.StringArray{privateSgID.ToStringPtrOutput().Elem()}
 	}
-	secOpts, err := withRedisAliases(ctx, serviceName, "securityGroup", opts)
-	if err != nil {
-		return nil, err
-	}
+	secOpts := common.MergeOptions(opts, svc.AliasOptions(compose.AliasSecurityGroup)...)
 	cacheSG, err := ec2.NewSecurityGroup(ctx, serviceName, &ec2.SecurityGroupArgs{
 		VpcId:       vpcID.ToStringOutput(),
 		Description: pulumi.String("MemoryDB security group for " + serviceName),
@@ -256,10 +213,7 @@ func CreateMemoryDB(
 		clusterArgs.SnapshotWindow = pulumi.String("09:30-10:30")
 	}
 
-	clusterOpts, err := withRedisAliases(ctx, serviceName, "cluster", opts)
-	if err != nil {
-		return nil, err
-	}
+	clusterOpts := common.MergeOptions(opts, svc.AliasOptions(compose.AliasCluster)...)
 	clusterOpts = common.MergeOptions(clusterOpts, pulumi.IgnoreChanges([]string{
 		"finalSnapshotName",
 		"maintenanceWindow",

--- a/provider/defangaws/aws/memorydb.go
+++ b/provider/defangaws/aws/memorydb.go
@@ -188,6 +188,9 @@ func CreateMemoryDB(
 	}
 
 	clusterArgs := &memorydb.ClusterArgs{
+		// open-access = no AUTH, matching the ElastiCache path's no-authToken
+		// posture (see the authToken TODO in elasticache.go); isolation comes
+		// from private subnets + the SG below. TLS stays enabled (AWS default).
 		AclName:                 pulumi.String("open-access"),
 		AutoMinorVersionUpgrade: pulumi.Bool(true),
 		Description:             pulumi.String(common.DefangComment),

--- a/provider/defangaws/aws/memorydb_test.go
+++ b/provider/defangaws/aws/memorydb_test.go
@@ -76,5 +76,38 @@ func TestGetSecretID_ConfigPathRecipe(t *testing.T) {
 		}, pulumi.WithMocks("myproj", "mystack", ssmMocks{}))
 		require.NoError(t, err)
 	})
+
+	t.Run("config-path override without trailing slash", func(t *testing.T) {
+		t.Setenv("PULUMI_CONFIG", `{"defang-aws:config-path": "/defang/ecs/prod"}`)
+		err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+			cp := NewConfigProvider("myproj")
+			assert.Equal(t, "/defang/ecs/prod/KEY", cp.getSecretID(ctx, "KEY"))
+			return nil
+		}, pulumi.WithMocks("myproj", "mystack", ssmMocks{}))
+		require.NoError(t, err)
+	})
 }
 
+func TestDetectRedisEngine(t *testing.T) {
+	tests := []struct {
+		image       string
+		wantEngine  string
+		wantVersion string
+	}{
+		{"redis", "redis", ""},
+		{"redis:7.1", "redis", "7.1"},
+		{"valkey/valkey:8.0", "valkey", "8.0"},
+		{"redis@sha256:0123456789abcdef", "redis", ""}, // digest is not a version
+		{"myregistry:5000/redis:7.2", "redis", "7.2"},  // registry port is not a tag
+		{"myregistry:5000/redis", "redis", ""},         // registry port only
+		{"public.ecr.aws/docker/library/redis:6.2", "redis", "6.2"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.image, func(t *testing.T) {
+			svc := compose.ServiceConfig{Image: pulumi.String(tt.image)}
+			engine, version := detectRedisEngine(svc)
+			assert.Equal(t, tt.wantEngine, engine)
+			assert.Equal(t, tt.wantVersion, version)
+		})
+	}
+}

--- a/provider/defangaws/aws/memorydb_test.go
+++ b/provider/defangaws/aws/memorydb_test.go
@@ -1,9 +1,9 @@
 package aws
 
 import (
-	"encoding/json"
 	"testing"
 
+	"github.com/DefangLabs/pulumi-defang/provider/compose"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -40,67 +40,21 @@ func TestMemoryDBParameterGroupFamily(t *testing.T) {
 	assert.Equal(t, "memorydb_valkey7", memoryDBParameterGroupFamily("valkey", ""))
 }
 
-func TestRedisAliasURNs(t *testing.T) {
-	tests := []struct {
-		name    string
-		config  string // value for defang-aws:redis-aliases
-		service string
-		kind    string
-		want    string // expected URN, "" for no alias
-		wantErr bool
-	}{
-		{name: "unset yields no aliases"},
-		{
-			name:    "returns URN for configured service and kind",
-			config:  `{"redis":{"cluster":"urn:pulumi:staging::ecs::aws:memorydb/cluster:Cluster::fabric"}}`,
-			service: "redis",
-			kind:    "cluster",
-			want:    "urn:pulumi:staging::ecs::aws:memorydb/cluster:Cluster::fabric",
-		},
-		{
-			name:    "no alias for other service",
-			config:  `{"redis":{"cluster":"urn:x"}}`,
-			service: "other",
-			kind:    "cluster",
-		},
-		{
-			name:    "no alias for other kind",
-			config:  `{"redis":{"cluster":"urn:x"}}`,
-			service: "redis",
-			kind:    "subnetGroup",
-		},
-		{
-			name:    "invalid JSON errors",
-			config:  `{not json`,
-			service: "redis",
-			kind:    "cluster",
-			wantErr: true,
+func TestAliasOptions(t *testing.T) {
+	urn := "urn:pulumi:staging::ecs::aws:memorydb/cluster:Cluster::fabric"
+	svc := compose.ServiceConfig{
+		Aliases: map[string]string{
+			compose.AliasCluster:     urn,
+			compose.AliasSubnetGroup: "",
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.config != "" {
-				t.Setenv("PULUMI_CONFIG", `{"defang-aws:redis-aliases": `+mustJSONString(t, tt.config)+`}`)
-			}
-			err := pulumi.RunErr(func(ctx *pulumi.Context) error {
-				aliases, err := redisAliasURNs(ctx, tt.service, tt.kind)
-				if tt.wantErr {
-					require.Error(t, err)
-					return nil
-				}
-				require.NoError(t, err)
-				if tt.want == "" {
-					assert.Empty(t, aliases)
-				} else {
-					require.Len(t, aliases, 1)
-					assert.Equal(t, pulumi.URN(tt.want), aliases[0].URN)
-				}
-				return nil
-			}, pulumi.WithMocks("ecs", "staging", ssmMocks{}))
-			require.NoError(t, err)
-		})
-	}
+	assert.Len(t, svc.AliasOptions(compose.AliasCluster), 1)
+	assert.Empty(t, svc.AliasOptions(compose.AliasSubnetGroup), "empty URN yields no alias")
+	assert.Empty(t, svc.AliasOptions(compose.AliasParameterGroup), "unset kind yields no alias")
+
+	var none compose.ServiceConfig
+	assert.Empty(t, none.AliasOptions(compose.AliasCluster), "nil map yields no alias")
 }
 
 func TestGetSecretID_ConfigPathRecipe(t *testing.T) {
@@ -124,10 +78,3 @@ func TestGetSecretID_ConfigPathRecipe(t *testing.T) {
 	})
 }
 
-// mustJSONString wraps a raw string as a JSON string literal.
-func mustJSONString(t *testing.T, s string) string {
-	t.Helper()
-	b, err := json.Marshal(s)
-	require.NoError(t, err)
-	return string(b)
-}

--- a/provider/defangaws/aws/memorydb_test.go
+++ b/provider/defangaws/aws/memorydb_test.go
@@ -1,0 +1,133 @@
+package aws
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemoryDBNodeType(t *testing.T) {
+	tests := []struct {
+		name     string
+		cpus     float64
+		memMiB   int
+		nodeType string
+		expected string
+	}{
+		{name: "no reservations picks smallest burstable", nodeType: "burstable", expected: "db.t4g.small"},
+		{name: "unknown catalog falls back to burstable", nodeType: "bogus", expected: "db.t4g.small"},
+		{name: "medium memory fits t4g.medium", memMiB: 2048, nodeType: "burstable", expected: "db.t4g.medium"},
+		{name: "burstable overflows into memory-optimized", memMiB: 8192, nodeType: "burstable", expected: "db.r6g.large"},
+		{name: "memory-optimized skips burstable", nodeType: "memory-optimized", expected: "db.r6g.large"},
+		{name: "large memory scales up", memMiB: 100 * 1024, nodeType: "memory-optimized", expected: "db.r6g.4xlarge"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, memoryDBNodeType(tt.cpus, tt.memMiB, tt.nodeType))
+		})
+	}
+}
+
+func TestMemoryDBParameterGroupFamily(t *testing.T) {
+	assert.Equal(t, "memorydb_redis7", memoryDBParameterGroupFamily("redis", ""))
+	assert.Equal(t, "memorydb_redis7", memoryDBParameterGroupFamily("redis", "7.1"))
+	assert.Equal(t, "memorydb_redis6", memoryDBParameterGroupFamily("redis", "6.2"))
+	assert.Equal(t, "memorydb_valkey8", memoryDBParameterGroupFamily("valkey", "8.0"))
+	assert.Equal(t, "memorydb_valkey7", memoryDBParameterGroupFamily("valkey", ""))
+}
+
+func TestRedisAliasURNs(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  string // value for defang-aws:redis-aliases
+		service string
+		kind    string
+		want    string // expected URN, "" for no alias
+		wantErr bool
+	}{
+		{name: "unset yields no aliases"},
+		{
+			name:    "returns URN for configured service and kind",
+			config:  `{"redis":{"cluster":"urn:pulumi:staging::ecs::aws:memorydb/cluster:Cluster::fabric"}}`,
+			service: "redis",
+			kind:    "cluster",
+			want:    "urn:pulumi:staging::ecs::aws:memorydb/cluster:Cluster::fabric",
+		},
+		{
+			name:    "no alias for other service",
+			config:  `{"redis":{"cluster":"urn:x"}}`,
+			service: "other",
+			kind:    "cluster",
+		},
+		{
+			name:    "no alias for other kind",
+			config:  `{"redis":{"cluster":"urn:x"}}`,
+			service: "redis",
+			kind:    "subnetGroup",
+		},
+		{
+			name:    "invalid JSON errors",
+			config:  `{not json`,
+			service: "redis",
+			kind:    "cluster",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.config != "" {
+				t.Setenv("PULUMI_CONFIG", `{"defang-aws:redis-aliases": `+mustJSONString(t, tt.config)+`}`)
+			}
+			err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+				aliases, err := redisAliasURNs(ctx, tt.service, tt.kind)
+				if tt.wantErr {
+					require.Error(t, err)
+					return nil
+				}
+				require.NoError(t, err)
+				if tt.want == "" {
+					assert.Empty(t, aliases)
+				} else {
+					require.Len(t, aliases, 1)
+					assert.Equal(t, pulumi.URN(tt.want), aliases[0].URN)
+				}
+				return nil
+			}, pulumi.WithMocks("ecs", "staging", ssmMocks{}))
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestGetSecretID_ConfigPathRecipe(t *testing.T) {
+	t.Run("default path", func(t *testing.T) {
+		err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+			cp := NewConfigProvider("myproj")
+			assert.Equal(t, "/Defang/myproj/mystack/KEY", cp.getSecretID(ctx, "KEY"))
+			return nil
+		}, pulumi.WithMocks("myproj", "mystack", ssmMocks{}))
+		require.NoError(t, err)
+	})
+
+	t.Run("config-path override", func(t *testing.T) {
+		t.Setenv("PULUMI_CONFIG", `{"defang-aws:config-path": "/defang/ecs/prod/"}`)
+		err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+			cp := NewConfigProvider("myproj")
+			assert.Equal(t, "/defang/ecs/prod/KEY", cp.getSecretID(ctx, "KEY"))
+			return nil
+		}, pulumi.WithMocks("myproj", "mystack", ssmMocks{}))
+		require.NoError(t, err)
+	})
+}
+
+// mustJSONString wraps a raw string as a JSON string literal.
+func mustJSONString(t *testing.T, s string) string {
+	t.Helper()
+	b, err := json.Marshal(s)
+	require.NoError(t, err)
+	return string(b)
+}

--- a/provider/defangaws/aws/parameters.go
+++ b/provider/defangaws/aws/parameters.go
@@ -61,7 +61,7 @@ func (cp *ConfigProvider) getParametersByPath(
 	ctx *pulumi.Context,
 	opts ...pulumi.InvokeOption,
 ) (map[string]string, error) {
-	path := cp.getSecretID(ctx.Stack(), "")
+	path := cp.getSecretID(ctx, "")
 	withDecryption := true
 
 	gpr, err := ssm.GetParametersByPath(ctx, &ssm.GetParametersByPathArgs{
@@ -81,9 +81,14 @@ func (cp *ConfigProvider) getParametersByPath(
 	return result, nil
 }
 
-func (cp *ConfigProvider) getSecretID(stackName, service string) string {
+func (cp *ConfigProvider) getSecretID(ctx *pulumi.Context, service string) string {
+	// The config-path recipe points at a pre-existing parameter namespace,
+	// e.g. a path established before migrating a deployment to this provider.
+	if path := ConfigPath.Get(ctx); path != "" {
+		return path + service
+	}
 	// Same as CLI
-	return fmt.Sprintf("/%s/%s/%s/%s", cp.prefix, cp.projectName, stackName, service)
+	return fmt.Sprintf("/%s/%s/%s/%s", cp.prefix, cp.projectName, ctx.Stack(), service)
 }
 
 // GetSecretRef returns the full SSM parameter ARN for a config key, so ECS can
@@ -97,6 +102,6 @@ func (cp *ConfigProvider) GetSecretRef(ctx *pulumi.Context, key string, opts ...
 	if err != nil {
 		return "", fmt.Errorf("getting account ID for secret ARN: %w", err)
 	}
-	id := cp.getSecretID(ctx.Stack(), key)
+	id := cp.getSecretID(ctx, key)
 	return fmt.Sprintf("arn:aws:ssm:%s:%s:parameter%s", region, accountId, id), nil
 }

--- a/provider/defangaws/aws/parameters.go
+++ b/provider/defangaws/aws/parameters.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/DefangLabs/pulumi-defang/provider/common"
@@ -85,7 +86,7 @@ func (cp *ConfigProvider) getSecretID(ctx *pulumi.Context, service string) strin
 	// The config-path recipe points at a pre-existing parameter namespace,
 	// e.g. a path established before migrating a deployment to this provider.
 	if path := ConfigPath.Get(ctx); path != "" {
-		return path + service
+		return strings.TrimSuffix(path, "/") + "/" + service
 	}
 	// Same as CLI
 	return fmt.Sprintf("/%s/%s/%s/%s", cp.prefix, cp.projectName, ctx.Stack(), service)

--- a/provider/defangaws/aws/recipe.go
+++ b/provider/defangaws/aws/recipe.go
@@ -11,6 +11,10 @@ var (
 	BackupRetentionDays       = recipe.Int("backup-retention-days", 0)
 	BackupWindow              = recipe.String("backup-window", "04:00-05:00")
 	BucketKeyEnabled          = recipe.Bool("bucket-key-enabled", true) // minimize KMS costs in non-prod environments
+	// ConfigPath is the SSM path prefix ("/…/") for ${VAR} config resolution;
+	// empty means the default "/Defang/<project>/<stack>/". Lets deployments
+	// keep consuming parameters at a pre-existing path.
+	ConfigPath                = recipe.String("config-path", "")
 	CreateApexRecord          = recipe.Bool("create-apex-record", true)
 	DeletionProtection        = recipe.Bool("deletion-protection", false)
 	DeregistrationDelay       = recipe.Int("deregistration-delay", 0)
@@ -25,7 +29,13 @@ var (
 	NatGatewayStrategy        = recipe.String("nat-gateway-strategy", "None") // None, Single, or OnePerAz
 	NumberOfAvailabilityZones = recipe.Int("number-of-availability-zones", 2)
 	RDSNodeType               = recipe.String("rds-node-type", "burstable")
-	RetainBucketOnDelete      = recipe.Bool("retain-bucket-on-delete", false)
+	// RedisAliases maps a Redis service name to the Pulumi URNs of pre-migration
+	// resources so the engine adopts them instead of replacing (JSON, e.g.
+	// {"redis":{"cluster":"urn:…","subnetGroup":"urn:…","parameterGroup":"urn:…","securityGroup":"urn:…"}}).
+	RedisAliases = recipe.String("redis-aliases", "")
+	// RedisEngine selects the managed Redis implementation: "elasticache" or "memorydb".
+	RedisEngine          = recipe.String("redis-engine", "elasticache")
+	RetainBucketOnDelete = recipe.Bool("retain-bucket-on-delete", false)
 	Route53SidecarLogs        = recipe.Bool("route53-sidecar-logs", false)
 	RetainDnsOnDelete         = recipe.Bool("retain-dns-on-delete", false)
 )

--- a/provider/defangaws/aws/recipe.go
+++ b/provider/defangaws/aws/recipe.go
@@ -29,10 +29,6 @@ var (
 	NatGatewayStrategy        = recipe.String("nat-gateway-strategy", "None") // None, Single, or OnePerAz
 	NumberOfAvailabilityZones = recipe.Int("number-of-availability-zones", 2)
 	RDSNodeType               = recipe.String("rds-node-type", "burstable")
-	// RedisAliases maps a Redis service name to the Pulumi URNs of pre-migration
-	// resources so the engine adopts them instead of replacing (JSON, e.g.
-	// {"redis":{"cluster":"urn:…","subnetGroup":"urn:…","parameterGroup":"urn:…","securityGroup":"urn:…"}}).
-	RedisAliases = recipe.String("redis-aliases", "")
 	// RedisEngine selects the managed Redis implementation: "elasticache" or "memorydb".
 	RedisEngine          = recipe.String("redis-engine", "elasticache")
 	RetainBucketOnDelete = recipe.Bool("retain-bucket-on-delete", false)

--- a/provider/defangaws/redis.go
+++ b/provider/defangaws/redis.go
@@ -29,6 +29,9 @@ type RedisInputs struct {
 type RedisOutputs struct {
 	pulumi.ResourceState
 	Endpoint pulumi.StringOutput `pulumi:"endpoint"`
+	// ClusterId is the ElastiCache replication group ID or the MemoryDB
+	// cluster name, for downstream consumers such as CloudWatch alarms.
+	ClusterId pulumi.StringOutput `pulumi:"clusterId"`
 	// Dependency is an internal-only handle (CNAME record when a private zone
 	// exists, otherwise nil) used by downstream services for ordering. Untagged —
 	// not part of the SDK schema.
@@ -66,9 +69,11 @@ func (*Redis) Construct(
 	return comp, nil
 }
 
-// createRedis creates the ElastiCache cluster (plus optional private-zone CNAME)
-// under an already-registered Redis component, sets its Endpoint/Dependency, and
-// registers its outputs. Shared between Construct and the project-level dispatcher.
+// createRedis creates the managed Redis cluster (ElastiCache, or MemoryDB when
+// the redis-engine recipe says so), plus an optional private-zone CNAME, under
+// an already-registered Redis component, sets its Endpoint/ClusterId/Dependency,
+// and registers its outputs. Shared between Construct and the project-level
+// dispatcher.
 func createRedis(
 	ctx *pulumi.Context,
 	comp *RedisOutputs,
@@ -79,7 +84,11 @@ func createRedis(
 ) error {
 	childOpt := pulumi.Parent(comp)
 
-	redisResult, err := provideraws.CreateElasticache(
+	createCluster := provideraws.CreateElasticache
+	if provideraws.RedisEngine.Get(ctx) == "memorydb" {
+		createCluster = provideraws.CreateMemoryDB
+	}
+	redisResult, err := createCluster(
 		ctx, serviceName, svc, infra.VpcID, infra.PrivateSubnetIDs, infra.PrivateSgID, deps, childOpt,
 	)
 	if err != nil {
@@ -108,8 +117,12 @@ func createRedis(
 	comp.Endpoint = pulumi.StringOutput(pulumix.Apply(redisResult.Address, func(addr string) string {
 		return fmt.Sprintf("%s:%d", addr, port)
 	}))
+	comp.ClusterId = redisResult.ClusterID
 
-	if err := ctx.RegisterResourceOutputs(comp, pulumi.Map{"endpoint": comp.Endpoint}); err != nil {
+	if err := ctx.RegisterResourceOutputs(comp, pulumi.Map{
+		"endpoint":  comp.Endpoint,
+		"clusterId": comp.ClusterId,
+	}); err != nil {
 		return fmt.Errorf("registering outputs for %s: %w", serviceName, err)
 	}
 	return nil

--- a/provider/defangaws/redis.go
+++ b/provider/defangaws/redis.go
@@ -23,6 +23,9 @@ type RedisInputs struct {
 	Deploy      *compose.DeployConfig       `pulumi:"deploy,optional"`
 	Environment compose.Environment             `pulumi:"environment,optional"`
 	AWS         *provideraws.SharedInfra    `pulumi:"aws,optional"`
+	// Aliases maps child resource kinds to pre-migration URNs; see
+	// compose.ServiceConfig.Aliases (x-defang-aliases).
+	Aliases map[string]string `pulumi:"aliases,optional"`
 }
 
 // RedisOutputs holds the outputs of an AWS Redis component.
@@ -61,6 +64,7 @@ func (*Redis) Construct(
 		Ports:       inputs.Ports,
 		Deploy:      inputs.Deploy,
 		Environment: inputs.Environment,
+		Aliases:     inputs.Aliases,
 	}
 
 	if err := createRedis(ctx, comp, name, svc, inputs.AWS, nil); err != nil {

--- a/sdk/v2/go/defang-aws/compose/pulumiTypes.go
+++ b/sdk/v2/go/defang-aws/compose/pulumiTypes.go
@@ -1382,6 +1382,7 @@ func (o ResourcesPtrOutput) Reservations() ResourceConfigPtrOutput {
 }
 
 type ServiceConfig struct {
+	Aliases         map[string]string               `pulumi:"aliases"`
 	Autoscaling     *bool                           `pulumi:"autoscaling"`
 	Build           *BuildConfig                    `pulumi:"build"`
 	Command         []string                        `pulumi:"command"`
@@ -1420,6 +1421,7 @@ type ServiceConfigInput interface {
 }
 
 type ServiceConfigArgs struct {
+	Aliases         pulumi.StringMapInput         `pulumi:"aliases"`
 	Autoscaling     pulumi.BoolPtrInput           `pulumi:"autoscaling"`
 	Build           BuildConfigPtrInput           `pulumi:"build"`
 	Command         pulumi.StringArrayInput       `pulumi:"command"`
@@ -1495,6 +1497,10 @@ func (o ServiceConfigOutput) ToServiceConfigOutput() ServiceConfigOutput {
 
 func (o ServiceConfigOutput) ToServiceConfigOutputWithContext(ctx context.Context) ServiceConfigOutput {
 	return o
+}
+
+func (o ServiceConfigOutput) Aliases() pulumi.StringMapOutput {
+	return o.ApplyT(func(v ServiceConfig) map[string]string { return v.Aliases }).(pulumi.StringMapOutput)
 }
 
 func (o ServiceConfigOutput) Autoscaling() pulumi.BoolPtrOutput {

--- a/sdk/v2/go/defang-aws/redis.go
+++ b/sdk/v2/go/defang-aws/redis.go
@@ -38,6 +38,7 @@ func NewRedis(ctx *pulumi.Context,
 }
 
 type redisArgs struct {
+	Aliases     map[string]string           `pulumi:"aliases"`
 	Aws         *aws.SharedInfra            `pulumi:"aws"`
 	Deploy      *compose.DeployConfig       `pulumi:"deploy"`
 	Environment map[string]string           `pulumi:"environment"`
@@ -49,6 +50,7 @@ type redisArgs struct {
 
 // The set of arguments for constructing a Redis resource.
 type RedisArgs struct {
+	Aliases     pulumi.StringMapInput
 	Aws         aws.SharedInfraPtrInput
 	Deploy      compose.DeployConfigPtrInput
 	Environment pulumi.StringMapInput

--- a/sdk/v2/go/defang-aws/redis.go
+++ b/sdk/v2/go/defang-aws/redis.go
@@ -17,7 +17,8 @@ import (
 type Redis struct {
 	pulumi.ResourceState
 
-	Endpoint pulumi.StringOutput `pulumi:"endpoint"`
+	ClusterId pulumi.StringOutput `pulumi:"clusterId"`
+	Endpoint  pulumi.StringOutput `pulumi:"endpoint"`
 }
 
 // NewRedis registers a new resource with the given unique name, arguments, and options.
@@ -92,6 +93,10 @@ func (o RedisOutput) ToRedisOutput() RedisOutput {
 
 func (o RedisOutput) ToRedisOutputWithContext(ctx context.Context) RedisOutput {
 	return o
+}
+
+func (o RedisOutput) ClusterId() pulumi.StringOutput {
+	return o.ApplyT(func(v *Redis) pulumi.StringOutput { return v.ClusterId }).(pulumi.StringOutput)
 }
 
 func (o RedisOutput) Endpoint() pulumi.StringOutput {

--- a/sdk/v2/go/defang-azure/compose/pulumiTypes.go
+++ b/sdk/v2/go/defang-azure/compose/pulumiTypes.go
@@ -1382,6 +1382,7 @@ func (o ResourcesPtrOutput) Reservations() ResourceConfigPtrOutput {
 }
 
 type ServiceConfig struct {
+	Aliases         map[string]string               `pulumi:"aliases"`
 	Autoscaling     *bool                           `pulumi:"autoscaling"`
 	Build           *BuildConfig                    `pulumi:"build"`
 	Command         []string                        `pulumi:"command"`
@@ -1420,6 +1421,7 @@ type ServiceConfigInput interface {
 }
 
 type ServiceConfigArgs struct {
+	Aliases         pulumi.StringMapInput         `pulumi:"aliases"`
 	Autoscaling     pulumi.BoolPtrInput           `pulumi:"autoscaling"`
 	Build           BuildConfigPtrInput           `pulumi:"build"`
 	Command         pulumi.StringArrayInput       `pulumi:"command"`
@@ -1495,6 +1497,10 @@ func (o ServiceConfigOutput) ToServiceConfigOutput() ServiceConfigOutput {
 
 func (o ServiceConfigOutput) ToServiceConfigOutputWithContext(ctx context.Context) ServiceConfigOutput {
 	return o
+}
+
+func (o ServiceConfigOutput) Aliases() pulumi.StringMapOutput {
+	return o.ApplyT(func(v ServiceConfig) map[string]string { return v.Aliases }).(pulumi.StringMapOutput)
 }
 
 func (o ServiceConfigOutput) Autoscaling() pulumi.BoolPtrOutput {

--- a/sdk/v2/go/defang-gcp/compose/pulumiTypes.go
+++ b/sdk/v2/go/defang-gcp/compose/pulumiTypes.go
@@ -1382,6 +1382,7 @@ func (o ResourcesPtrOutput) Reservations() ResourceConfigPtrOutput {
 }
 
 type ServiceConfig struct {
+	Aliases         map[string]string               `pulumi:"aliases"`
 	Autoscaling     *bool                           `pulumi:"autoscaling"`
 	Build           *BuildConfig                    `pulumi:"build"`
 	Command         []string                        `pulumi:"command"`
@@ -1420,6 +1421,7 @@ type ServiceConfigInput interface {
 }
 
 type ServiceConfigArgs struct {
+	Aliases         pulumi.StringMapInput         `pulumi:"aliases"`
 	Autoscaling     pulumi.BoolPtrInput           `pulumi:"autoscaling"`
 	Build           BuildConfigPtrInput           `pulumi:"build"`
 	Command         pulumi.StringArrayInput       `pulumi:"command"`
@@ -1495,6 +1497,10 @@ func (o ServiceConfigOutput) ToServiceConfigOutput() ServiceConfigOutput {
 
 func (o ServiceConfigOutput) ToServiceConfigOutputWithContext(ctx context.Context) ServiceConfigOutput {
 	return o
+}
+
+func (o ServiceConfigOutput) Aliases() pulumi.StringMapOutput {
+	return o.ApplyT(func(v ServiceConfig) map[string]string { return v.Aliases }).(pulumi.StringMapOutput)
 }
 
 func (o ServiceConfigOutput) Autoscaling() pulumi.BoolPtrOutput {


### PR DESCRIPTION
## Summary
Additions that let an existing (pre-provider) deployment be adopted without data migration or SSM parameter moves — needed by the defang-on-defang migration ([DefangLabs/defang-mvp#3084](https://github.com/DefangLabs/defang-mvp/pull/3084)):

- **`defang-aws:redis-engine` recipe** (`"elasticache"` default | `"memorydb"`): Compose keys managed Redis off the `image:` tag alone, so the engine is a deployment recipe, not a compose concern. `CreateMemoryDB` mirrors `CreateElasticache` — same result shape, shared `detectRedisEngine` (redis/valkey + version from the image tag) — and provisions a MemoryDB `Cluster` + `SubnetGroup` + `ParameterGroup` (`maxmemory-policy: allkeys-lru`) + `SecurityGroup` with the `open-access` ACL, a `db.*` node-type catalog (cheapest-match like ElastiCache/RDS), and the same `backup-retention-days` / `deletion-protection` (final snapshot) recipe handling. `replicas: N` maps to `numReplicasPerShard: N-1` on a single shard.

- **`x-defang-aliases` compose extension** (service-level; `aliases` input on standalone components): a map of provider-defined child resource kinds to pre-migration Pulumi URNs, e.g.
  ```yaml
  x-defang-aliases:
    cluster: "urn:pulumi:staging::ecs::aws:memorydb/cluster:Cluster::fabric"
    subnet-group: "urn:…"
    parameter-group: "urn:…"
    security-group: "urn:…"
  ```
  applied as `pulumi.Aliases` when registering the children, so the engine **adopts** existing resources instead of replacing them. The aliases have to be applied inside the provider: resource options passed to a remote component do not propagate to its children, so a consumer can't alias them from the outside. With the alias matched and the physical `name` left to autonaming, the engine keeps the existing resource (no replace) as long as create-only inputs (port, TLS, subnet group) are unchanged. This is deployment-specific state, so it lives on the service (not in a recipe, which should stay reusable). Honored today by both Redis paths (MemoryDB + ElastiCache children); the `AliasOptions` mechanism is generic and other `Create*` workers can adopt it as needed.

- **`defang-aws:config-path` recipe**: overrides the `ConfigProvider` SSM path prefix (resolves the "customizable prefix" TODO) so `${VAR}` config resolution can keep reading a pre-existing parameter namespace instead of `/Defang/<project>/<stack>/` — keeps SSM paths (and anything watching them, e.g. EventBridge parameter-change rules) unchanged across a migration.

Also: Redis components now export **`clusterId`** (ElastiCache replication group ID / MemoryDB cluster name) so consumers can attach CloudWatch alarms — the standalone-Service counterpart of `PostgresOutputs.InstanceIdentifier`.

## Notes
- Recipe keys are stack config (read at deploy time); the schema changes are the `clusterId` output, the `aliases` field on the compose service type, and the `aliases` input on standalone Redis. `sdk/v2` regenerated and committed.
- MemoryDB node-type costs are approximate and used only for cheapest-match ordering within a catalog.

## Test plan
- [x] `make lint` clean
- [x] `make test` green (unit + provider + cd suites)
- [x] New unit tests: MemoryDB node-type selection, parameter-group family (redis/valkey), `AliasOptions` lookup, `config-path` override + default path
- [ ] e2e via defang-mvp#3084 preview loop: `redis-engine: memorydb` + `x-defang-aliases` on a stack with a live pre-provider MemoryDB shows adopt (no replace) in `pulumi preview`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGtbRpbGZBevoWa6YiGE7M


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MemoryDB support for managed Redis/Valkey clusters and automatic node sizing/parameter group selection.
  * Added Redis engine selection (ElastiCache vs MemoryDB) via configuration.
  * Redis resources now expose a `clusterId` output and the Redis component schema requires `clusterId` (in addition to `endpoint`).
  * Added service/resource aliasing (`aliases`) to support migrations/adoption.
  * Added configurable SSM config path resolution (`ConfigPath`).

* **Bug Fixes**
  * Improved Redis/Valkey engine detection and consistency, including transit encryption handling.

* **Tests**
  * Added unit tests covering MemoryDB sizing/parameter mapping, alias URN extraction, and config path construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->