### PR TITLE
fix: per-provider release archives; registry docs for the split packages

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,25 @@
 version: 2
 
+# One archive per provider build: pulumi's github:// plugin source resolves
+# release assets by name (pulumi-resource-defang-<cloud>-<tag>-<os>-<arch>),
+# so each plugin needs its own correctly-named archive. A single archive spec
+# bundles ALL builds' binaries under the first build's name, which left the
+# gcp/azure plugins uninstallable (registry PR 11614).
 archives:
-  - id: archive
+  - id: defang-aws
+    ids: [pulumi-resource-defang-aws]
+    name_template: '{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}'
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+  - id: defang-gcp
+    ids: [pulumi-resource-defang-gcp]
+    name_template: '{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}'
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+  - id: defang-azure
+    ids: [pulumi-resource-defang-azure]
     name_template: '{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}'
     format_overrides:
       - goos: windows

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -1,32 +1,45 @@
 ---
-title: Defang Provider
+title: Defang Providers
 meta_desc: Take your app from Docker Compose to a secure and scalable cloud deployment with Pulumi.
 layout: package
 ---
-# Defang Pulumi Provider
+# Defang Pulumi Providers
 
 ![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/DefangLabs/pulumi-defang?label=Version)
 
-The Pulumi Provider for [Defang](https://defang.io) — Take your app from Docker Compose to a secure and scalable cloud deployment with Pulumi.
+The Pulumi Providers for [Defang](https://defang.io) — Take your app from Docker Compose to a secure and scalable cloud deployment with Pulumi.
+
+Defang ships one provider package per cloud, all with the same Compose-shaped inputs:
+
+- **`defang-aws`** — deploys to AWS (ECS Fargate, ALB, RDS, ElastiCache, …)
+- **`defang-gcp`** — deploys to Google Cloud (Cloud Run / Compute Engine, Cloud SQL, Memorystore, …)
+- **`defang-azure`** — deploys to Azure (Container Apps, Azure Database, Azure Cache, …)
+
+The examples below use `defang-aws`; swap in the `defang-gcp` or `defang-azure` package of your language to target another cloud — the `Project` inputs are the same.
 
 ## Example usage
 
-You can find complete working TypeScript, Python, Go, .NET, and Yaml code samples in the [`./examples`](https://github.com/DefangLabs/pulumi-defang/tree/main/examples) directory, and some example snippets below:
+You can find complete working TypeScript, Python, Go, .NET, and Yaml code samples for every cloud in the [`./examples`](https://github.com/DefangLabs/pulumi-defang/tree/main/examples) directory, and some example snippets below:
 
 {{< chooser language "typescript,python,go,dotnet,yaml" >}}
 {{% choosable language typescript %}}
 ```typescript
 import * as pulumi from "@pulumi/pulumi";
-import * as defang from "@defang-io/pulumi-defang";
+import * as defang_aws from "@defang-io/pulumi-defang-aws";
 
-const myProject = new defang.Project("myProject", {
-    providerID: "aws",
-    configPaths: ["compose.yaml"],
+const awsDemo = new defang_aws.Project("aws-demo", {
+    services: {
+        app: {
+            image: "nginx",
+            ports: [{
+                target: 80,
+                mode: "ingress",
+                appProtocol: "http",
+            }],
+        },
+    },
 });
-export const output = {
-    albArn: myProject.albArn,
-    etag: myProject.etag,
-};
+export const endpoints = awsDemo.endpoints;
 ```
 
 {{% /choosable %}}
@@ -34,15 +47,19 @@ export const output = {
 {{% choosable language python %}}
 ```python
 import pulumi
-import pulumi_defang as defang
+import pulumi_defang_aws as defang_aws
 
-my_project = defang.Project("myProject",
-    provider_id="aws",
-    config_paths=["compose.yaml"])
-pulumi.export("output", {
-    "albArn": my_project.alb_arn,
-    "etag": my_project.etag,
+aws_demo = defang_aws.Project("aws-demo", services={
+    "app": {
+        "image": "nginx",
+        "ports": [{
+            "target": 80,
+            "mode": "ingress",
+            "app_protocol": "http",
+        }],
+    },
 })
+pulumi.export("endpoints", aws_demo.endpoints)
 ```
 
 {{% /choosable %}}
@@ -52,25 +69,31 @@ pulumi.export("output", {
 package main
 
 import (
-	"example.com/pulumi-defang/sdk/go/defang"
+	defangaws "github.com/DefangLabs/pulumi-defang/sdk/v2/go/defang-aws"
+	"github.com/DefangLabs/pulumi-defang/sdk/v2/go/defang-aws/compose"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		myProject, err := defang.NewProject(ctx, "myProject", &defang.ProjectArgs{
-			ProviderID: pulumi.String("aws"),
-			ConfigPaths: pulumi.StringArray{
-				pulumi.String("compose.yaml"),
+		awsDemo, err := defangaws.NewProject(ctx, "aws-demo", &defangaws.ProjectArgs{
+			Services: compose.ServiceConfigMap{
+				"app": &compose.ServiceConfigArgs{
+					Image: pulumi.String("nginx"),
+					Ports: compose.ServicePortConfigArray{
+						&compose.ServicePortConfigArgs{
+							Target:      pulumi.Int(80),
+							Mode:        pulumi.String("ingress"),
+							AppProtocol: pulumi.String("http"),
+						},
+					},
+				},
 			},
 		})
 		if err != nil {
 			return err
 		}
-		ctx.Export("output", pulumi.StringMap{
-			"albArn": myProject.AlbArn,
-			"etag":   myProject.Etag,
-		})
+		ctx.Export("endpoints", awsDemo.Endpoints)
 		return nil
 	})
 }
@@ -79,47 +102,62 @@ func main() {
 {{% /choosable %}}
 
 {{% choosable language dotnet %}}
-```dotnet
+```csharp
 using System.Collections.Generic;
-using System.Linq;
 using Pulumi;
-using Defang = DefangLabs.Defang;
+using DefangAws = DefangLabs.DefangAws;
 
 return await Deployment.RunAsync(() =>
 {
-    var myProject = new Defang.Project("myProject", new()
+    var awsDemo = new DefangAws.Project("aws-demo", new()
     {
-        ProviderID = "aws",
-        ConfigPaths = new[]
+        Services =
         {
-            "./compose.yaml",
+            { "app", new DefangAws.Compose.Inputs.ServiceConfigArgs
+            {
+                Image = "nginx",
+                Ports = new[]
+                {
+                    new DefangAws.Compose.Inputs.ServicePortConfigArgs
+                    {
+                        Target = 80,
+                        Mode = "ingress",
+                        AppProtocol = "http",
+                    },
+                },
+            } },
         },
     });
 
     return new Dictionary<string, object?>
     {
-        ["output"] =
-        {
-            { "albArn", myProject.AlbArn },
-            { "etag", myProject.Etag },
-        },
+        ["endpoints"] = awsDemo.Endpoints,
     };
 });
-
 ```
 
 {{% /choosable %}}
 
 {{% choosable language yaml %}}
 ```yaml
-# Pulumi.yaml provider configuration file
-name: configuration-example
+name: defang-aws-example
 runtime: yaml
-config:
-    defang:Project:
-        providerID: aws
-        configPaths:
-            - ./compose.yaml
+description: Example using defang-aws to deploy services to AWS
+
+resources:
+  aws-demo:
+    type: defang-aws:index:Project
+    properties:
+      services:
+        app:
+          image: nginx
+          ports:
+            - target: 80
+              mode: ingress
+              appProtocol: http
+
+outputs:
+  endpoints: ${aws-demo.endpoints}
 ```
 
 {{% /choosable %}}
@@ -127,7 +165,7 @@ config:
 
 ## Installation and Configuration
 
-See our [Installation and Configuration](https://pulumi.com/registry/packages/defang/installation-configuration/) docs
+See our [Installation and Configuration](./installation-configuration/) docs
 
 ## Development
 

--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -17,9 +17,9 @@ The Defang Pulumi Provider is available as separate packages per cloud (AWS, GCP
 
 ### Installing the Pulumi Plugins directly
 ```
-pulumi plugin install resource defang-aws --server github://api.github.com/DefangLabs
-pulumi plugin install resource defang-gcp --server github://api.github.com/DefangLabs
-pulumi plugin install resource defang-azure --server github://api.github.com/DefangLabs
+pulumi plugin install resource defang-aws --server github://api.github.com/DefangLabs/pulumi-defang
+pulumi plugin install resource defang-gcp --server github://api.github.com/DefangLabs/pulumi-defang
+pulumi plugin install resource defang-azure --server github://api.github.com/DefangLabs/pulumi-defang
 ```
 
 ## Authentication
@@ -54,4 +54,4 @@ Defang runs the Pulumi CLI in your cloud account. You can use [Pulumi Cloud](htt
 
 ## Reference
 
-For detailed reference documentation, please visit [the Pulumi registry](https://www.pulumi.com/registry/packages/defang/).
+For detailed reference documentation, please visit the Pulumi registry: [defang-aws](https://www.pulumi.com/registry/packages/defang-aws/), [defang-gcp](https://www.pulumi.com/registry/packages/defang-gcp/), [defang-azure](https://www.pulumi.com/registry/packages/defang-azure/).


### PR DESCRIPTION
## Summary
Unblocks [pulumi/registry#11614](https://github.com/pulumi/registry/pull/11614) (the defang-aws/gcp/azure registry split, driven by @fnune). Two of the blockers there are on our side; this PR fixes both:

- **goreleaser: one archive spec per provider build.** The single `archives` spec bundled all three provider binaries into archives named after the first build — every release (incl. v2.4.0) ships only `pulumi-resource-defang-aws-*` assets, each secretly containing all three binaries. Pulumi's `github://` plugin source resolves assets **by name**, so `pulumi plugin install resource defang-gcp` / `defang-azure` 404s on every release. Now each build gets its own correctly-named archive. Verified with `goreleaser release --snapshot`: 18 archives (`pulumi-resource-defang-{aws,gcp,azure}-<tag>-{linux,darwin,windows}-{amd64,arm64}`), each containing only its own binary.

- **Registry docs fixes** (these two files are rendered verbatim on all three registry package pages):
  - `installation-configuration.md`: the `pulumi plugin install … --server github://api.github.com/DefangLabs` commands were missing the repo segment (defaults to repo `pulumi-<plugin-name>`, which doesn't exist) → `…/DefangLabs/pulumi-defang`. Reference link now points at the three per-cloud registry pages instead of the soon-delisted `/registry/packages/defang/`.
  - `_index.md`: rewritten for the split packages — it still showed the retired umbrella API (`defang.Project` with `providerID: "aws"` and a bogus Go import). Snippets now mirror `examples/aws-*` (compose-shaped `Project`), with a note that `defang-gcp`/`defang-azure` take the same inputs. The installation link is relative (`./installation-configuration/`) so it resolves under whichever package slug the page renders on.

## After merge
Cut a release (e.g. **v2.4.1**) from main so a tag exists whose assets include all three plugin sets + the docs fixes, then hand the tag to fnune on pulumi/registry#11614 — he'll bump the pinned version, regen metadata, and merge. (The remaining blockers there — the deprecated `defang` content stub and a `package-list.json` rebase — are on the Pulumi side.)

## Test plan
- [x] `goreleaser check` passes (v2.17)
- [x] `goreleaser release --snapshot --clean --skip=publish`: 18 correctly-named single-binary archives
- [x] docs-only changes otherwise; `make lint` untouched Go code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGtbRpbGZBevoWa6YiGE7M