### PR TITLE
fix: boot the arm64 COS image for ARM Compute Engine services

### DIFF
--- a/provider/defanggcp/gcp/compute.go
+++ b/provider/defanggcp/gcp/compute.go
@@ -81,7 +81,8 @@ func CreateComputeEngine(
 		serviceName, image, svc, gcpConfig.Region, gcpConfig.Etag, fqdn, addHealthCheckSidecar, args.Sidecars)
 
 	instanceTemplate, err := createInstanceTemplate(
-		ctx, serviceName, serviceName, machineType, cloudInit, args.SA, args.Triggers, gcpConfig, iamDeps, parentOpt)
+		ctx, serviceName, serviceName, machineType, getComputeBootImage(svc), cloudInit,
+		args.SA, args.Triggers, gcpConfig, iamDeps, parentOpt)
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +172,7 @@ func zonesWithMachineType(
 
 func createInstanceTemplate(
 	ctx *pulumi.Context,
-	serviceName, instanceTag, machineType string,
+	serviceName, instanceTag, machineType, bootImage string,
 	cloudInit pulumi.StringInput,
 	sa *ServiceIdentity,
 	triggers pulumi.StringMapInput,
@@ -225,7 +226,7 @@ func createInstanceTemplate(
 			Disks: compute.InstanceTemplateDiskArray{
 				&compute.InstanceTemplateDiskArgs{
 					Boot:        pulumi.Bool(true),
-					SourceImage: pulumi.String("projects/cos-cloud/global/images/family/cos-stable"),
+					SourceImage: pulumi.String(bootImage),
 					DiskSizeGb:  pulumi.Int(21),
 				},
 			},
@@ -398,6 +399,16 @@ var t2aMachineTypes = []machineTypeEntry{
 	{"t2a-standard-16", 16, 64 * 1024},
 	{"t2a-standard-32", 32, 128 * 1024},
 	{"t2a-standard-48", 48, 192 * 1024},
+}
+
+// getComputeBootImage returns the Container-Optimized OS boot image family
+// matching the service's platform: ARM machine types (T2A) can only boot the
+// arm64 COS family; everything else uses the x86 family.
+func getComputeBootImage(svc compose.ServiceConfig) string {
+	if strings.Contains(svc.GetPlatform(), "arm64") {
+		return "projects/cos-cloud/global/images/family/cos-arm64-stable"
+	}
+	return "projects/cos-cloud/global/images/family/cos-stable"
 }
 
 // getComputeMachineType selects the smallest machine type that satisfies the

--- a/provider/defanggcp/gcp/compute_boot_image_test.go
+++ b/provider/defanggcp/gcp/compute_boot_image_test.go
@@ -1,0 +1,23 @@
+package gcp
+
+import (
+	"testing"
+
+	"github.com/DefangLabs/pulumi-defang/provider/compose"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetComputeBootImage(t *testing.T) {
+	arm := "linux/arm64"
+	amd := "linux/amd64"
+
+	svc := compose.ServiceConfig{Platform: &arm}
+	assert.Equal(t, "projects/cos-cloud/global/images/family/cos-arm64-stable", getComputeBootImage(svc),
+		"ARM platforms must boot the arm64 COS family (T2A cannot boot x86 images)")
+
+	svc = compose.ServiceConfig{Platform: &amd}
+	assert.Equal(t, "projects/cos-cloud/global/images/family/cos-stable", getComputeBootImage(svc))
+
+	assert.Equal(t, "projects/cos-cloud/global/images/family/cos-stable", getComputeBootImage(compose.ServiceConfig{}),
+		"no platform defaults to x86")
+}


### PR DESCRIPTION
## Summary
`getComputeMachineType` selects T2A (Ampere ARM) machine types when the service platform is `linux/arm64`, but `createInstanceTemplate` unconditionally booted `cos-cloud/…/cos-stable` — the x86-only COS family — so an arm64 Compute Engine service could never boot. Select the boot image family from the platform: `cos-arm64-stable` for arm64, `cos-stable` otherwise.

Found while migrating defang-mvp's GCP CD (an arm64 CE workload) to the defang-gcp Service component ([DefangLabs/defang-mvp#3084](https://github.com/DefangLabs/defang-mvp/pull/3084)).

Bug fix only — fine to include in the registry-unblock release alongside #314, or after; no schema change.

## Test plan
- [x] `make test` green; new unit test pins the platform → image-family mapping
- [x] `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGtbRpbGZBevoWa6YiGE7M