### PR TITLE
ci: make regen and image jobs work on fork PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,7 +112,10 @@ jobs:
       - name: Checkout PR branch or pushed ref
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          # Same-repo PRs check out the branch (needed to auto-commit); fork
+          # PRs check out the head SHA — the branch only exists on the fork,
+          # but GitHub mirrors PR head commits into the base repo.
+          ref: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.ref || github.event.pull_request.head.sha || github.ref }}
 
       - name: Setup Go build environment
         uses: ./.github/actions/setup-go
@@ -163,6 +166,8 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Log in to GHCR
+        # Fork-PR tokens can't write org packages; forks build without pushing.
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
@@ -186,7 +191,7 @@ jobs:
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: . # build context must be repo root to include generated Go SDK
-          push: true
+          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
           target: all
           tags: ${{ env.IMAGE_REPO }}:${{ env.IMAGE_TAG }}
           cache-from: type=gha,scope=${{ github.workflow }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,6 +116,9 @@ jobs:
           # PRs check out the head SHA — the branch only exists on the fork,
           # but GitHub mirrors PR head commits into the base repo.
           ref: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.ref || github.event.pull_request.head.sha || github.ref }}
+          # Only same-repo PRs push (the auto-commit); fork PRs and direct
+          # pushes never do, so don't leave the token in .git/config there.
+          persist-credentials: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
 
       - name: Setup Go build environment
         uses: ./.github/actions/setup-go


### PR DESCRIPTION
## Summary
"Regenerate schema and Go SDK" and "Build Docker Image" have failed spuriously on every cross-fork PR (310, 313, 314, 315), forcing manual overrides:

- **regen** checked out `github.event.pull_request.head.ref`, which only exists on the fork — the checkout failed before the schema-drift check ever ran. Fork PRs now check out the head **SHA** (GitHub mirrors PR head commits into the base repo), so the drift validation actually runs for forks; the existing final step already fails-with-diff on forks and only auto-commits on same-repo branches. Same-repo PRs still check out the branch (needed for the auto-commit push).
- **build_image** pushed `ghcr.io/defanglabs/cd:pr-N`, which fork-PR tokens are denied (`installation not allowed to Write organization package`). Fork PRs now still **build** the image — keeping the Dockerfile + generated-SDK validation — but skip the GHCR login and the push. Push events and same-repo PRs are unchanged.

Note: since these jobs run the **base** repo's workflow definition on `pull_request`, this only takes effect for fork PRs opened/synchronized after merge — this PR's own run will still show the two legacy failures.

## Test plan
- [x] `actionlint` clean
- [ ] Next fork PR (or a re-push to an open one, e.g. 313/315) shows regen running the real drift check and build_image completing without a push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGtbRpbGZBevoWa6YiGE7M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request workflows for contributions from forked repositories.
  * Ensured code generation and build steps run against the correct pull request revision.
  * Prevented container images from being pushed and avoided registry credential usage for forked pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->