### PR TITLE
ci: group Dependabot gomod security updates per directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,3 +35,10 @@ updates:
       pulumi-azure-native-sdk:
         patterns:
           - "github.com/pulumi/pulumi-azure-native-sdk*"
+      # Security updates ignore the schedule and would otherwise open one PR
+      # per vulnerable dependency; group them so each directory gets a single
+      # security-bump PR instead.
+      gomod-security:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
Dependabot security updates bypass both the weekly schedule and the directory scoping in dependabot.yml, and without a group they arrive as one PR per vulnerable dependency (see the current queue: separate PRs for go-git, go-billy, x/net, x/crypto). This adds an `applies-to: security-updates` group to the gomod entry so the `/` and `/cd` directories each get a single grouped security PR instead.

Version updates are unaffected (the existing `pulumi-azure-native-sdk` group only applies to version updates; groups default to `applies-to: version-updates`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGtbRpbGZBevoWa6YiGE7M