### PR TITLE
fix(gcp): allow dynamic (Output-valued) sidecar images on Compute Engine

### DIFF
--- a/provider/defanggcp/gcp/compute.go
+++ b/provider/defanggcp/gcp/compute.go
@@ -653,10 +653,6 @@ func buildSidecarUnit(
 	containerName := sc.GetContainerName(sidecarName)
 	params, command := dockerRunFlags(sc, sidecars)
 	envFlags := flattenEnvFlags(nil, sc.Environment)
-	sidecarImage := "" // validated static & non-empty in createService
-	if img := sc.StaticImage(); img != nil {
-		sidecarImage = *img
-	}
 
 	var serviceSection string
 	if sc.Restart == "no" {
@@ -697,7 +693,7 @@ func buildSidecarUnit(
 		containerName,
 		strings.Join(params, " "),
 		envFlags,
-		sidecarImage,
+		sc.Image, // validated non-nil in createService; may resolve at apply time
 		strings.Join(command, " "))
 
 	runcmds = append(runcmds,

--- a/provider/defanggcp/gcp/compute_test.go
+++ b/provider/defanggcp/gcp/compute_test.go
@@ -68,8 +68,11 @@ func TestGetCloudInitConfigDefangEnv(t *testing.T) {
 // A run-once sidecar (restart: "no") must become a oneshot unit started before
 // the main service, with the main container mounting its volumes via
 // --volumes-from; '%' in env values must survive the pulumi.Sprintf pass.
+// The sidecar image is an Output (e.g. a digest resolved at apply time) to
+// cover dynamic sidecar images.
 func TestGetCloudInitConfigSidecars(t *testing.T) {
-	handlerImage := pulumi.String("region-docker.pkg.dev/proj/repo/handler:1")
+	handlerImageURI := "region-docker.pkg.dev/proj/repo/handler@sha256:0123456789abcdef"
+	handlerImage := pulumi.String(handlerImageURI).ToStringOutput() // dynamic, StaticImage() == nil
 	percentVal := "100%"
 	svc := compose.ServiceConfig{
 		Entrypoint:  []string{"/handler/handler"},
@@ -110,7 +113,7 @@ func TestGetCloudInitConfigSidecars(t *testing.T) {
 	assert.Contains(t, cloudInit, "RemainAfterExit=yes")
 	assert.Contains(t, cloudInit,
 		"--name=handler --entrypoint true -v handler:/handler:ro -v pulumi-plugins:/root/.pulumi/plugins")
-	assert.Contains(t, cloudInit, handlerImage)
+	assert.Contains(t, cloudInit, handlerImageURI)
 	// main unit: ordered after the sidecar, volumes-from it
 	assert.Contains(t, cloudInit, "Requires=cd-handler.service")
 	assert.Contains(t, cloudInit, "After=cd-handler.service")

--- a/provider/defanggcp/postgres.go
+++ b/provider/defanggcp/postgres.go
@@ -18,7 +18,7 @@ type PostgresInputs struct {
 	Postgres    *compose.PostgresConfig     `pulumi:"postgres,optional"`
 	Image       *string                     `pulumi:"image,optional"`
 	Deploy      *compose.DeployConfig       `pulumi:"deploy,optional"`
-	Environment compose.Environment             `pulumi:"environment,optional"`
+	Environment compose.Environment         `pulumi:"environment,optional"`
 	Ports       []compose.ServicePortConfig `pulumi:"ports,optional"`
 }
 

--- a/provider/defanggcp/service.go
+++ b/provider/defanggcp/service.go
@@ -14,8 +14,6 @@ var (
 	errSidecarsRequireComputeEngine = errors.New(
 		"sidecars and volumes are only supported on Compute Engine services (no single ingress port)")
 	errPoliciesUnsupported = errors.New("x-defang-policies is not supported on GCP")
-	errSidecarImageNotStatic = errors.New(
-		"sidecar image must be a static string on GCP (it is baked into a cloud-init systemd unit)")
 )
 
 // Service is the controller struct for the defang-gcp:index:Service component.
@@ -33,7 +31,7 @@ type ServiceInputs struct {
 	ProjectName string                      `pulumi:"projectName"`
 	Ports       []compose.ServicePortConfig `pulumi:"ports,optional"`
 	Deploy      *compose.DeployConfig       `pulumi:"deploy,optional"`
-	Environment compose.Environment             `pulumi:"environment,optional"`
+	Environment compose.Environment         `pulumi:"environment,optional"`
 	Command     []string                    `pulumi:"command,optional"`
 	Entrypoint  []string                    `pulumi:"entrypoint,optional"`
 	HealthCheck *compose.HealthCheckConfig  `pulumi:"healthCheck,optional"`
@@ -151,15 +149,16 @@ type serviceExtras struct {
 	Triggers            pulumi.StringMapInput
 }
 
-// validateSidecarImages requires every sidecar to have a non-empty, static
-// image: it gets baked into a cloud-init systemd unit, so Outputs won't do.
+// validateSidecarImages requires every sidecar to have an image; a static
+// image must also be non-empty. Dynamic (Output-valued) images are fine —
+// they resolve when the cloud-init systemd unit is rendered — matching the
+// AWS sidecar semantics.
 func validateSidecarImages(serviceName string, sidecars map[string]compose.ServiceConfig) error {
 	for name, sc := range sidecars {
-		img := sc.StaticImage()
-		if sc.Image != nil && img == nil {
-			return fmt.Errorf("service %s sidecar %s: %w", serviceName, name, errSidecarImageNotStatic)
+		if sc.Image == nil {
+			return fmt.Errorf("service %s sidecar %s: %w", serviceName, name, common.ErrStandaloneServiceRequiresImage)
 		}
-		if img == nil || *img == "" {
+		if img := sc.StaticImage(); img != nil && *img == "" {
 			return fmt.Errorf("service %s sidecar %s: %w", serviceName, name, common.ErrStandaloneServiceRequiresImage)
 		}
 	}


### PR DESCRIPTION
## Summary
GCP's standalone Service rejected sidecars whose `image` is a Pulumi Output ("sidecar image must be a static string"). But the sidecar systemd unit is already rendered through `pulumi.Sprintf`, so an Output-valued image resolves fine at apply time — the static-only validation was stricter than necessary and inconsistent with AWS, where dynamic sidecar images are allowed.

- `validateSidecarImages` now matches the AWS sidecar semantics exactly: nil image is an error, a *static* image must be non-empty, dynamic images pass through.
- `buildSidecarUnit` passes `sc.Image` (a `pulumi.StringInput`) straight into the existing `pulumi.Sprintf` instead of unwrapping it via `StaticImage()`.
- `TestGetCloudInitConfigSidecars` now uses an Output-valued sidecar image (a digest-style URI) to cover the dynamic path; all other assertions unchanged.
- Drive-by: gofmt the `Environment` field alignment in `service.go`/`postgres.go` left over from the `map[string]StringInput` rename.

No schema change (the SDK's sidecar `image` was already `Input<string>`).

## Motivation
DefangLabs/defang-mvp#3084 migrates the GCP CD service to `defang-gcp:index:Service` with a `handler` sidecar whose image URI is an Output (digest resolved by an ECR→Artifact Registry copy step, or an upstream stack reference). The static-only validation blocked that.

## Test plan
- [x] `go test ./provider/defanggcp/...` green, including the updated dynamic-image sidecar test
- [x] `gofmt`/`go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGtbRpbGZBevoWa6YiGE7M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sidecar containers can now use dynamically resolved image references, including digest-based images.
  * Dynamic sidecar image values are supported during deployment while retaining validation for missing or empty images.

* **Bug Fixes**
  * Updated cloud-init configuration to use the resolved sidecar image correctly.

* **Style**
  * Minor formatting improvements to service and database configuration definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->