### PR TITLE
feat(gcp): stamp defang-* log labels in Compute Engine cloud-init

### DIFF
--- a/provider/defanggcp/gcp/compute.go
+++ b/provider/defanggcp/gcp/compute.go
@@ -78,7 +78,8 @@ func CreateComputeEngine(
 	// provisioned in alb.go and resolves within the VPC. See common.ServiceFQDN.
 	fqdn := common.ServiceFQDN(serviceName, svc, gcpConfig.Domain, "google.internal")
 	cloudInit := getCloudInitConfig(
-		serviceName, image, svc, gcpConfig.Region, gcpConfig.Etag, fqdn, addHealthCheckSidecar, args.Sidecars)
+		serviceName, image, svc, gcpConfig.Region, gcpConfig.Etag, gcpConfig.ProjectName, gcpConfig.Stack, fqdn,
+		addHealthCheckSidecar, args.Sidecars)
 
 	instanceTemplate, err := createInstanceTemplate(
 		ctx, serviceName, serviceName, machineType, getComputeBootImage(svc), cloudInit,
@@ -531,7 +532,7 @@ func getCloudInitConfig(
 	serviceName string,
 	image pulumi.StringInput,
 	svc compose.ServiceConfig,
-	region, etag, fqdn string,
+	region, etag, projectName, stack, fqdn string,
 	addHealthCheckSidecar bool,
 	sidecars map[string]compose.ServiceConfig,
 ) pulumi.StringOutput {
@@ -561,10 +562,12 @@ func getCloudInitConfig(
 		fmt.Fprintf(&dependencies, "\n      Requires=%s.service\n      After=%s.service", unit, unit)
 	}
 
-	runcmds := make([]string, 0, 3+4+2*len(sidecars)+2)
+	runcmds := make([]string, 0, 5+4+2*len(sidecars)+2)
 	runcmds = append(runcmds,
 		`echo 'DOCKER_OPTS="--registry-mirror=https://mirror.gcr.io"' | tee /etc/default/docker`,
+		fluentBitLabelsCmd(serviceName, etag, projectName, stack),
 		"systemctl daemon-reload",
+		"systemctl restart fluent-bit",
 		"systemctl restart docker",
 	)
 
@@ -627,6 +630,28 @@ runcmd:
 	// extra units — the Inputs that may resolve at apply time); all other
 	// dynamic text had its '%' doubled.
 	return pulumi.Sprintf(buf.String(), envFlags, image, extraUnits)
+}
+
+// fluentBitLabelsCmd returns the runcmd that stamps the defang-* LogEntry
+// labels the Defang CLI (and Fabric) filter their Cloud Logging tail queries
+// on. COS's fluent-bit ships container logs to Cloud Logging (logName
+// cos_containers); the 4-space indent lands the `labels` key inside the
+// stackdriver [OUTPUT] section of its config. Empty values are omitted so the
+// matching query clause can be omitted too.
+// TODO: find a more reliable way to add labels
+func fluentBitLabelsCmd(serviceName, etag, projectName, stack string) string {
+	labels := make([]string, 0, 4)
+	if etag != "" {
+		labels = append(labels, "defang-etag="+SafeLabelValue(etag))
+	}
+	if projectName != "" {
+		labels = append(labels, "defang-project="+SafeLabelValue(projectName))
+	}
+	labels = append(labels, "defang-service="+SafeLabelValue(serviceName))
+	if stack != "" {
+		labels = append(labels, "defang-stack="+SafeLabelValue(stack))
+	}
+	return fmt.Sprintf(`echo "    labels %s" >> /etc/fluent-bit/fluent-bit.conf`, strings.Join(labels, ","))
 }
 
 // escapePercent doubles '%' so text survives the final pulumi.Sprintf pass

--- a/provider/defanggcp/gcp/compute_test.go
+++ b/provider/defanggcp/gcp/compute_test.go
@@ -44,7 +44,8 @@ func TestGetCloudInitConfigDefangEnv(t *testing.T) {
 			var wg sync.WaitGroup
 			wg.Add(1)
 			err := pulumi.RunErr(func(ctx *pulumi.Context) error {
-				out := getCloudInitConfig("api", pulumi.String("img:latest"), svc, "us-central1", tt.etag, tt.fqdn, false, nil)
+				out := getCloudInitConfig(
+					"api", pulumi.String("img:latest"), svc, "us-central1", tt.etag, "", "", tt.fqdn, false, nil)
 				out.ApplyT(func(s string) string {
 					defer wg.Done()
 					cloudInit = s
@@ -61,6 +62,57 @@ func TestGetCloudInitConfigDefangEnv(t *testing.T) {
 			for _, notWant := range tt.absent {
 				assert.NotContains(t, cloudInit, notWant)
 			}
+		})
+	}
+}
+
+// getCloudInitConfig must stamp the defang-* LogEntry labels into the COS
+// fluent-bit config so the Defang CLI's (and Fabric's) Cloud Logging tail
+// queries match Compute Engine logs. Values are SafeLabelValue-normalized;
+// empty etag/project/stack are omitted.
+func TestGetCloudInitConfigLogLabels(t *testing.T) {
+	svc := compose.ServiceConfig{
+		Ports: []compose.ServicePortConfig{{Target: 8080, Mode: compose.PortModeHost}},
+	}
+
+	tests := []struct {
+		name                     string
+		etag, projectName, stack string
+		want                     string
+	}{
+		{
+			name:        "all set, normalized",
+			etag:        "Etag123",
+			projectName: "My Project",
+			stack:       "beta",
+			want: `echo "    labels defang-etag=etag123,defang-project=my-project,defang-service=api,defang-stack=beta"` +
+				` >> /etc/fluent-bit/fluent-bit.conf`,
+		},
+		{
+			name: "empty etag/project/stack omitted",
+			want: `echo "    labels defang-service=api" >> /etc/fluent-bit/fluent-bit.conf`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cloudInit string
+			var wg sync.WaitGroup
+			wg.Add(1)
+			err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+				out := getCloudInitConfig(
+					"api", pulumi.String("img:latest"), svc, "us-central1", tt.etag, tt.projectName, tt.stack, "", false, nil)
+				out.ApplyT(func(s string) string {
+					defer wg.Done()
+					cloudInit = s
+					return s
+				})
+				return nil
+			}, pulumi.WithMocks("proj", "stack", testMocks{}))
+			require.NoError(t, err)
+			wg.Wait()
+
+			assert.Contains(t, cloudInit, tt.want)
+			assert.Contains(t, cloudInit, "systemctl restart fluent-bit")
 		})
 	}
 }
@@ -96,7 +148,7 @@ func TestGetCloudInitConfigSidecars(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
-		out := getCloudInitConfig("cd", pulumi.String("img:latest"), svc, "us-central1", "", "", true, sidecars)
+		out := getCloudInitConfig("cd", pulumi.String("img:latest"), svc, "us-central1", "", "", "", "", true, sidecars)
 		out.ApplyT(func(s string) string {
 			defer wg.Done()
 			cloudInit = s

--- a/provider/defanggcp/gcp/gcp.go
+++ b/provider/defanggcp/gcp/gcp.go
@@ -34,6 +34,7 @@ type SharedInfra struct {
 	PrivateZone       pulumi.StringOutput                     // managed zone name for the private google.internal. zone
 	Prefix            string                                  // prefix for all resource names (e.g. "myproject")
 	Stack             string                                  // Pulumi stack name (e.g. "dev")
+	ProjectName       string                                  // compose project name (defang-project log label)
 	Repos             map[string]*artifactregistry.Repository // non-empty when services reference external registries
 	// Etag is the deployment ID supplied by the CD program; empty for
 	// standalone Service callers.
@@ -170,6 +171,7 @@ func BuildGlobalConfig(
 		Stack:       ctx.Stack(),
 		Region:      region,
 		GcpProject:  gcpProject,
+		ProjectName: projectName,
 		VpcId:       vpc.ID().ToStringOutput(),
 		SubnetId:    subnet.ID().ToStringOutput(),
 		PublicIP:    publicIP,

--- a/provider/defanggcp/gcp/labels.go
+++ b/provider/defanggcp/gcp/labels.go
@@ -1,0 +1,25 @@
+package gcp
+
+import (
+	"regexp"
+	"strings"
+)
+
+// safeLabelValueRE matches every rune that is not allowed in a GCP label
+// value: lowercase letters (\p{Ll}), caseless letters (\p{Lo}), digits,
+// underscores, and dashes.
+var safeLabelValueRE = regexp.MustCompile(`[^\p{Ll}\p{Lo}0-9_-]+`)
+
+// SafeLabelValue normalizes a string to a valid GCP label value: lowercase,
+// disallowed runes collapsed to "-", truncated to 63 characters. It MUST stay
+// byte-for-byte identical to the Defang CLI's gcp.SafeLabelValue
+// (src/pkg/clouds/gcp/label.go) — the CLI filters Cloud Logging queries on
+// exact defang-* label values, so both sides have to normalize the same way.
+func SafeLabelValue(input string) string {
+	input = strings.ToLower(input)
+	safe := safeLabelValueRE.ReplaceAllString(input, "-")
+	if len(safe) > 63 {
+		safe = safe[:63]
+	}
+	return safe
+}

--- a/provider/defanggcp/service.go
+++ b/provider/defanggcp/service.go
@@ -126,6 +126,7 @@ func (*Service) Construct(
 	infra := inputs.Infra
 	if infra == nil {
 		infra = providergcp.NewStandaloneGlobalConfig(ctx)
+		infra.ProjectName = projectName
 	}
 
 	image := inputs.Image


### PR DESCRIPTION
## Problem

The Defang CLI's GCP log tailing (`byocgcp` — and Fabric's `gcplogs`, which uses the same package) filters `gce_instance` log entries on the LogEntry labels `defang-service`, `defang-etag`, `defang-project`, and `defang-stack`. Cloud Run services get these from resource template labels, but nothing stamps them for Compute Engine services: CE container logs reach Cloud Logging (logName `cos_containers`) without the labels, so `defang tail` never matches CE logs. Concretely, this is why Fabric's CD-log tailing stopped matching after the GCP CD service moved from the old Ops-Agent-configured MIG to the provider's CE component (the gap noted in defang-mvp's migration commit).

## Fix

- `getCloudInitConfig` appends a `labels` line to the stackdriver `[OUTPUT]` section of COS's fluent-bit config via runcmd and restarts fluent-bit — the same mechanism the Defang BYOC GCP CD engine uses for tenant services on COS (including its TODO about finding something more reliable).
- Label values go through a new `SafeLabelValue`, a byte-for-byte mirror of the CLI's `gcp.SafeLabelValue` (src/pkg/clouds/gcp/label.go) — the queries match on exact normalized values, so both sides must normalize identically.
- Empty values are omitted (standalone services have no etag) so the corresponding query clause can be omitted too; `defang-service` is always stamped.
- `SharedInfra` gains `ProjectName` — set by `BuildGlobalConfig` (project scope) and by the standalone Service path — to carry the compose project name to the CE worker.

No schema change; SDKs unaffected.

## Testing

- New `TestGetCloudInitConfigLogLabels`: full label line with normalization (`Etag123`/`My Project` → `etag123`/`my-project`), empty-value omission, and the fluent-bit restart.
- Existing cloud-init env/sidecar tests updated for the new signature; `go test ./provider/...` and `golangci-lint` clean.

## Notes for consumers (defang-mvp)

- The instance-level fluent-bit labels apply to every container on the instance (sidecars included), matching the BYOC CD engine's behavior.
- Fabric tails CD logs with `project=defang` while mvp's `cd-gcp` Service is created with `projectName: defang-playground`; that mismatch predates this change (the old Ops Agent stamped `defang-project=defang-playground` too) and needs aligning on the mvp/fabric side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGtbRpbGZBevoWa6YiGE7M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project, stack, service, and deployment identifiers to Google Cloud log labels.
  * Log label values are normalized for compatibility and automatically omit unavailable information.
  * Standalone deployments now retain project context for more consistent logging.

* **Bug Fixes**
  * Improved log collection setup by applying labels before restarting the logging service and Docker.
  * Ensured logging configuration updates are applied reliably during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->