### PR TITLE
ci: self-merge and clean up regenerate-examples PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,15 +156,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
-      - name: Commit and push updated examples
+      - name: Commit, push, and merge updated examples
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          BRANCH="chore/regenerate-examples-${{ github.ref_name }}"
           git add examples/
           if git diff --cached --quiet; then
             echo "No example changes to commit"
           else
-            BRANCH="chore/regenerate-examples-${{ github.ref_name }}"
             git checkout -b "$BRANCH"
             git commit -m "chore: regenerate examples for ${{ github.ref_name }}"
             git push origin "$BRANCH"
@@ -173,7 +173,22 @@ jobs:
               --body "Automated regeneration of examples triggered by release ${{ github.ref_name }}." \
               --base main \
               --head "$BRANCH"
+            # Merge right away: the content was produced by this release run
+            # on a green main, and bot-created PRs don't trigger the test
+            # workflows anyway. Fall back to enabling auto-merge in case
+            # branch protection is waiting on required checks.
+            gh pr merge "$BRANCH" --squash --delete-branch \
+              || gh pr merge "$BRANCH" --squash --delete-branch --auto \
+              || echo "::warning::Could not auto-merge $BRANCH; merge it manually"
           fi
+          # Regenerate-examples PRs from older releases are superseded by this
+          # run (which regenerated from current main): close them.
+          gh pr list --state open --json number,headRefName \
+            --jq '.[] | select(.headRefName | startswith("chore/regenerate-examples-")) | [.number, .headRefName] | @tsv' |
+          while IFS=$'\t' read -r num ref; do
+            [ "$ref" = "$BRANCH" ] && continue
+            gh pr close "$num" --delete-branch --comment "Superseded by the examples regeneration for ${{ github.ref_name }}"
+          done
         env:
           GH_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
## Problem
Every release opens a `chore/regenerate-examples` PR that sits until someone merges it, and stale ones pile up (320 and 323 are open right now; 312 had to be closed by hand).

## Change
In the release workflow's "Commit and push updated examples" step:

- **Merge the PR immediately after creating it** (`gh pr merge --squash --delete-branch`). Rationale: the content was generated by this very release run on a green `main`, the examples are generated files, and PRs created with `github.token` don't trigger the test workflows anyway (they only get CodeQL) — so waiting on the PR adds no validation, only latency. If branch protection rejects the direct merge because required checks are pending, it falls back to enabling auto-merge; if that's not allowed either, it emits a workflow warning and leaves the PR for a human, i.e. current behavior.
- **Close superseded PRs**: any older open `chore/regenerate-examples-*` PR is closed (with a comment, deleting its branch), since each regeneration runs against current `main`. This also runs when the regeneration produced no diff — `main` already matches, so an older open PR is stale by definition.

The workflow token already has `contents: write` and `pull-requests: write`, so no permission changes are needed.

Once this merges, the currently-open 323 (v2.5.1) still needs one last manual merge (or will be closed as superseded by the next release's regeneration); 320 is already superseded by 323.

`actionlint` passes on the modified workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGtbRpbGZBevoWa6YiGE7M