### PR TITLE
fix(gcp): strip reserved PORT env var on Cloud Run

### DIFF
--- a/provider/defanggcp/gcp/cloudrun.go
+++ b/provider/defanggcp/gcp/cloudrun.go
@@ -2,6 +2,7 @@ package gcp
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/DefangLabs/pulumi-defang/provider/common"
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
@@ -115,6 +116,22 @@ func buildEnvVars(
 		})
 	}
 	for k, v := range common.Sorted(svc.Environment) {
+		// Cloud Run reserves the PORT env var (it injects the container port
+		// itself) and rejects revisions that set it, so drop it here:
+		// https://cloud.google.com/run/docs/configuring/services/containers#configure-port
+		if k == "PORT" {
+			sv, static := compose.StaticEnvValue(v)
+			port := -1
+			if static && sv != nil {
+				port, _ = strconv.Atoi(*sv)
+			}
+			if len(svc.Ports) == 0 || port != int(svc.Ports[0].Target) {
+				msg := fmt.Sprintf("service %q: the PORT environment variable is reserved on Cloud Run"+
+					" and must match the container's port; the value has been ignored", serviceName)
+				_ = ctx.Log.Warn(msg, nil)
+			}
+			continue
+		}
 		if secretVar := compose.GetConfigName2(k, v); secretVar != "" && configProvider != nil {
 			secretId, _ := configProvider.GetSecretRef(ctx, secretVar)
 			envs = append(envs, &cloudrunv2.ServiceTemplateContainerEnvArgs{

--- a/provider/defanggcp/gcp/cloudrun_test.go
+++ b/provider/defanggcp/gcp/cloudrun_test.go
@@ -1,0 +1,65 @@
+package gcp
+
+import (
+	"testing"
+
+	"github.com/DefangLabs/pulumi-defang/provider/compose"
+	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/cloudrunv2"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// envNames extracts the static Name of each env var arg for assertions.
+func envNames(envs cloudrunv2.ServiceTemplateContainerEnvArray) []string {
+	names := make([]string, 0, len(envs))
+	for _, e := range envs {
+		args := e.(*cloudrunv2.ServiceTemplateContainerEnvArgs)
+		names = append(names, string(args.Name.(pulumi.String)))
+	}
+	return names
+}
+
+func TestBuildEnvVarsStripsReservedPort(t *testing.T) {
+	tests := []struct {
+		name string
+		port pulumi.StringInput
+	}{
+		{"matching port", pulumi.String("8080")},
+		{"mismatching port", pulumi.String("9999")},
+		{"non-numeric port", pulumi.String("http")},
+		{"nil value", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+				svc := compose.ServiceConfig{
+					Environment: compose.Environment{
+						"PORT": tt.port,
+						"FOO":  pulumi.String("bar"),
+					},
+					Ports: []compose.ServicePortConfig{{Target: 8080}},
+				}
+				envs, secretIds := buildEnvVars(ctx, nil, "app", "etag1", "", svc)
+				if len(secretIds) != 0 {
+					t.Errorf("expected no secret IDs, got %v", secretIds)
+				}
+				names := envNames(envs)
+				for _, n := range names {
+					if n == "PORT" {
+						t.Errorf("PORT env var should have been stripped, got %v", names)
+					}
+				}
+				want := map[string]bool{"DEFANG_SERVICE": true, "DEFANG_ETAG": true, "FOO": true}
+				for _, n := range names {
+					delete(want, n)
+				}
+				if len(want) != 0 {
+					t.Errorf("missing expected env vars %v in %v", want, names)
+				}
+				return nil
+			}, pulumi.WithMocks("proj", "stack", testMocks{}))
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Found during the MVP parity audit (#81).

Cloud Run reserves the `PORT` environment variable and rejects revisions that set it ([docs](https://cloud.google.com/run/docs/configuring/services/containers#configure-port)). The old gcpcd dropped it, warning when the value didn't match the container port (defang-mvp `gcpcd/cloudrun.go:189-203`); the Go port passed every env var through verbatim, so a compose service with `environment: PORT=...` fails to deploy on Cloud Run.

This restores the old behavior in `buildEnvVars`: `PORT` is always dropped, with a warning unless the static value matches the container's first port target.

Unit test covers matching/mismatching/non-numeric/nil values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014gqWs58xiA8sVYczW4JyjG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cloud Run deployments by preventing conflicting or invalid `PORT` environment variables from being passed to containers.
  * Added warnings when the configured `PORT` value is missing or does not match the service’s configured container port.
  * Preserved other environment variables during Cloud Run configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->