### PR TITLE
fix(gcp): map Postgres majors 9.6-13 to their Cloud SQL versions

### DIFF
--- a/provider/defanggcp/gcp/cloudsql.go
+++ b/provider/defanggcp/gcp/cloudsql.go
@@ -16,8 +16,19 @@ type CloudSQLResult struct {
 }
 
 // gcpPostgresVersion maps a major version number to the GCP database version string.
+// https://cloud.google.com/sql/docs/postgres/db-versions
 func gcpPostgresVersion(version int) string {
 	switch version {
+	case 9:
+		return "POSTGRES_9_6" // 9.6 was the only 9.x Cloud SQL offered
+	case 10:
+		return "POSTGRES_10"
+	case 11:
+		return "POSTGRES_11"
+	case 12:
+		return "POSTGRES_12"
+	case 13:
+		return "POSTGRES_13"
 	case 14:
 		return "POSTGRES_14"
 	case 15:

--- a/provider/defanggcp/gcp/cloudsql_test.go
+++ b/provider/defanggcp/gcp/cloudsql_test.go
@@ -1,0 +1,27 @@
+package gcp
+
+import "testing"
+
+func TestGcpPostgresVersion(t *testing.T) {
+	tests := []struct {
+		version int
+		want    string
+	}{
+		{9, "POSTGRES_9_6"},
+		{10, "POSTGRES_10"},
+		{11, "POSTGRES_11"},
+		{12, "POSTGRES_12"},
+		{13, "POSTGRES_13"},
+		{14, "POSTGRES_14"},
+		{15, "POSTGRES_15"},
+		{16, "POSTGRES_16"},
+		{17, "POSTGRES_17"},
+		{0, "POSTGRES_17"},  // unparseable tag → latest
+		{99, "POSTGRES_17"}, // unknown major → latest
+	}
+	for _, tt := range tests {
+		if got := gcpPostgresVersion(tt.version); got != tt.want {
+			t.Errorf("gcpPostgresVersion(%d) = %q, want %q", tt.version, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Found during the MVP parity audit (#81).

The old gcpcd mapped Postgres majors 9–17 to Cloud SQL `databaseVersion` strings (defang-mvp `gcpcd/postgres.go:178-189`). The Go port's `gcpPostgresVersion` only knew 14–17 and silently defaulted everything else to `POSTGRES_17` — so a compose service pinning `postgres:13` (or a 9.6–12 image) provisioned a Postgres 17 instance without warning, and an old-CD stack migrating to this provider would see its database version change.

Adds the 9.6/10/11/12/13 mappings (unchanged: unknown/unparseable still default to latest) plus a unit test for the full table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014gqWs58xiA8sVYczW4JyjG