### PR TITLE
feat(cd): honor DEFANG_PULUMI_TARGETS on refresh and destroy

### DIFF
--- a/cd/TODO.md
+++ b/cd/TODO.md
@@ -47,7 +47,7 @@ Compared against `~/dev/defang-mvp/pulumi/index.ts`.
 ## Missing Pulumi options on commands
 
 - [x] **`TargetDependents` on destroy** — done: destroy passes `optdestroy.TargetDependents()` + `optdestroy.Target(pulumiTargets)`; a targeted destroy also skips `optdestroy.Remove()` so partial state isn't orphaned
-- [x] **`Target(pulumiTargets)` on refresh** — done: refresh passes `optrefresh.Target(pulumiTargets)`
+- [x] **`Target(pulumiTargets)` on refresh** — done: refresh passes `optrefresh.TargetDependents()` + `optrefresh.Target(pulumiTargets)` (old GCP `getRefreshOptions()` passed both, not just `Target`)
 - [x] **`UserAgent` on destroy/refresh** — old GCP set `UserAgent("defang/"+version)` on all commands; new only sets it on up/preview
 
 ## Missing commands (from old GCP code)

--- a/cd/TODO.md
+++ b/cd/TODO.md
@@ -46,8 +46,8 @@ Compared against `~/dev/defang-mvp/pulumi/index.ts`.
 
 ## Missing Pulumi options on commands
 
-- [ ] **`TargetDependents` on destroy** — old GCP `getDestroyOptions()` included `optdestroy.TargetDependents()` and `optdestroy.Target(pulumiTargets)`; new destroy has neither
-- [ ] **`Target(pulumiTargets)` on refresh** — old GCP `getRefreshOptions()` passed targets; new refresh doesn't
+- [x] **`TargetDependents` on destroy** — done: destroy passes `optdestroy.TargetDependents()` + `optdestroy.Target(pulumiTargets)`; a targeted destroy also skips `optdestroy.Remove()` so partial state isn't orphaned
+- [x] **`Target(pulumiTargets)` on refresh** — done: refresh passes `optrefresh.Target(pulumiTargets)`
 - [x] **`UserAgent` on destroy/refresh** — old GCP set `UserAgent("defang/"+version)` on all commands; new only sets it on up/preview
 
 ## Missing commands (from old GCP code)

--- a/cd/cd_main.go
+++ b/cd/cd_main.go
@@ -202,7 +202,13 @@ func cdMain(ctx context.Context, args ...string) error {
 			optdestroy.ErrorProgressStreams(errorProgressStream),
 			optdestroy.EventStreams(evtCh),
 			optdestroy.ContinueOnError(),
-			optdestroy.Remove(),
+			optdestroy.TargetDependents(),
+			optdestroy.Target(pulumiTargets),
+		}
+		// A targeted destroy leaves resources in the stack, so only remove
+		// the stack when destroying everything.
+		if len(pulumiTargets) == 0 {
+			destroyOpts = append(destroyOpts, optdestroy.Remove())
 		}
 		// down = refresh + destroy (consistent with legacy behavior)
 		if command == "down" {
@@ -227,6 +233,7 @@ func cdMain(ctx context.Context, args ...string) error {
 			optrefresh.ProgressStreams(progressStream),
 			optrefresh.ErrorProgressStreams(errorProgressStream),
 			optrefresh.EventStreams(evtCh),
+			optrefresh.Target(pulumiTargets),
 		}
 		if pulumiDebug {
 			refreshOpts = append(refreshOpts, optrefresh.DebugLogging(debugLog))

--- a/cd/cd_main.go
+++ b/cd/cd_main.go
@@ -233,6 +233,7 @@ func cdMain(ctx context.Context, args ...string) error {
 			optrefresh.ProgressStreams(progressStream),
 			optrefresh.ErrorProgressStreams(errorProgressStream),
 			optrefresh.EventStreams(evtCh),
+			optrefresh.TargetDependents(),
 			optrefresh.Target(pulumiTargets),
 		}
 		if pulumiDebug {


### PR DESCRIPTION
Found during the MVP parity audit (#81); checks off the two `cd/TODO.md` items under *Missing Pulumi options on commands*.

The old GCP driver's `getDestroyOptions()` passed `TargetDependents()` + `Target(targets)` and `getRefreshOptions()` passed targets; the Go port only wired `DEFANG_PULUMI_TARGETS` into up/preview. Consequence: a targeted `destroy` silently destroyed the **whole** stack.

Beyond the port, one safety gate: a targeted destroy now skips `optdestroy.Remove()` — removing the stack after destroying only a subset would orphan the remaining resources' state. Full destroys keep today's remove-the-stack behavior (whether that itself should change is #273).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014gqWs58xiA8sVYczW4JyjG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Targeted destroy now preserves the stack when resource targets are provided, while still removing only the selected resources.
  * Full destroy behavior remains unchanged and continues to remove the stack.
  * Refresh now respects configured resource targets and also includes dependent resources where applicable.
* **Documentation**
  * Updated command option documentation to reflect the finalized destroy and refresh target behavior, including notes on the targeted workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->