### PR TITLE
feat(compose): x-defang-policies via compose variables (no cross-cloud filtering)

### DIFF
--- a/provider/compose/policies.go
+++ b/provider/compose/policies.go
@@ -1,0 +1,58 @@
+package compose
+
+import "strings"
+
+// PolicyCloud identifies which cloud an x-defang-policies entry targets.
+type PolicyCloud string
+
+const (
+	PolicyCloudAWS   PolicyCloud = "aws"
+	PolicyCloudGCP   PolicyCloud = "gcp"
+	PolicyCloudAzure PolicyCloud = "azure"
+	// PolicyCloudAny is a bare name: a custom policy/role in the current
+	// account/project, applicable on whichever cloud is being deployed.
+	PolicyCloudAny PolicyCloud = "any"
+)
+
+// ClassifyPolicy determines the target cloud of an x-defang-policies entry
+// from its qualified form: AWS ARNs, GCP role names, and Azure resource IDs
+// are self-identifying; anything else is a bare name that resolves on the
+// current cloud.
+func ClassifyPolicy(entry string) PolicyCloud {
+	switch {
+	case strings.HasPrefix(entry, "arn:"):
+		return PolicyCloudAWS
+	case strings.HasPrefix(entry, "roles/"),
+		strings.HasPrefix(entry, "projects/"),
+		strings.HasPrefix(entry, "organizations/"):
+		return PolicyCloudGCP
+	case strings.HasPrefix(entry, "/"):
+		// Azure role-definition resource IDs: /subscriptions/… or /providers/…
+		return PolicyCloudAzure
+	}
+	return PolicyCloudAny
+}
+
+// PoliciesFor filters x-defang-policies entries to those that apply on the
+// given cloud: entries qualified for another cloud are dropped, so a compose
+// file targeting several clouds can list entries for each side by side; bare
+// names apply everywhere. Returns the applicable entries followed by the
+// skipped ones (for logging).
+func PoliciesFor(cloud PolicyCloud, policies []string) ([]string, []string) {
+	var applicable, skipped []string
+	for _, p := range policies {
+		if c := ClassifyPolicy(p); c == cloud || c == PolicyCloudAny {
+			applicable = append(applicable, p)
+		} else {
+			skipped = append(skipped, p)
+		}
+	}
+	return applicable, skipped
+}
+
+// SkippedPoliciesMessage formats the info-log line for x-defang-policies
+// entries that don't apply on the current cloud.
+func SkippedPoliciesMessage(serviceName string, skipped []string) string {
+	return "service " + serviceName + ": ignoring x-defang-policies entries for other clouds: " +
+		strings.Join(skipped, ", ")
+}

--- a/provider/compose/policies.go
+++ b/provider/compose/policies.go
@@ -10,15 +10,16 @@ import (
 
 var (
 	// ErrPolicyUnresolvedVariable rejects entries still containing `${…}`:
-	// the CLI substitutes `.env` values at compose-load time, and `defang
+	// compose variables are interpolated before the project reaches the
+	// provider (a CLI concern, e.g. from the stack's env files), and `defang
 	// config` is deliberately not supported for policies.
 	ErrPolicyUnresolvedVariable = errors.New(
-		"policy entries are substituted from `.env` when the compose file is loaded; " +
+		"policy variables must be resolved when the compose file is loaded; " +
 			"`defang config` is not supported for policies")
 	// ErrPolicyForeignCloud rejects an identifier whose syntax belongs to a
 	// different cloud: there is no cross-cloud filtering.
 	ErrPolicyForeignCloud = errors.New(
-		"use a ${VAR} entry with per-stack `.env` values to vary policies per cloud")
+		"use a ${VAR} entry whose per-stack value carries the identifier for the targeted cloud")
 )
 
 // PolicyCloud identifies which cloud an x-defang-policies entry targets.
@@ -35,9 +36,9 @@ const (
 
 // PolicyList holds x-defang-policies entries. In YAML it accepts a sequence
 // or a single scalar, and entries may hold several comma-separated
-// identifiers — so one `${VAR}` substituted from `.env` can carry a
-// variable-length list. Empty entries (a "${VAR:-}" the stack leaves unset)
-// are dropped.
+// identifiers — so one `${VAR}` interpolated at compose-load time can carry
+// a variable-length list. Empty entries (a "${VAR:-}" the stack leaves
+// unset) are dropped.
 type PolicyList []string
 
 // UnmarshalYAML accepts `x-defang-policies: ${POLICIES}` (scalar) in addition
@@ -95,11 +96,11 @@ func ClassifyPolicy(entry string) PolicyCloud {
 
 // ValidatePolicies rejects x-defang-policies entries that cannot apply on the
 // given cloud. Entries must be literals by the time they reach the provider:
-// the CLI substitutes `${VAR}` from `.env` at compose-load time, and `defang
-// config` is deliberately not supported for policies — so an unresolved
-// variable is an error, as is an identifier whose syntax belongs to a
-// different cloud (there is no cross-cloud filtering; per-cloud values come
-// from per-stack `.env` files).
+// compose variables are interpolated at compose-load time — by the CLI, not
+// by the CD/providers — and `defang config` is deliberately not supported
+// for policies, so an unresolved variable is an error, as is an identifier
+// whose syntax belongs to a different cloud (there is no cross-cloud
+// filtering; vary the variable's per-stack value instead).
 func ValidatePolicies(cloud PolicyCloud, policies []string) error {
 	for _, entry := range policies {
 		if strings.Contains(entry, "${") {

--- a/provider/compose/policies.go
+++ b/provider/compose/policies.go
@@ -1,6 +1,25 @@
 package compose
 
-import "strings"
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	// ErrPolicyUnresolvedVariable rejects entries still containing `${…}`:
+	// the CLI substitutes `.env` values at compose-load time, and `defang
+	// config` is deliberately not supported for policies.
+	ErrPolicyUnresolvedVariable = errors.New(
+		"policy entries are substituted from `.env` when the compose file is loaded; " +
+			"`defang config` is not supported for policies")
+	// ErrPolicyForeignCloud rejects an identifier whose syntax belongs to a
+	// different cloud: there is no cross-cloud filtering.
+	ErrPolicyForeignCloud = errors.New(
+		"use a ${VAR} entry with per-stack `.env` values to vary policies per cloud")
+)
 
 // PolicyCloud identifies which cloud an x-defang-policies entry targets.
 type PolicyCloud string
@@ -13,6 +32,47 @@ const (
 	// account/project, applicable on whichever cloud is being deployed.
 	PolicyCloudAny PolicyCloud = "any"
 )
+
+// PolicyList holds x-defang-policies entries. In YAML it accepts a sequence
+// or a single scalar, and entries may hold several comma-separated
+// identifiers — so one `${VAR}` substituted from `.env` can carry a
+// variable-length list. Empty entries (a "${VAR:-}" the stack leaves unset)
+// are dropped.
+type PolicyList []string
+
+// UnmarshalYAML accepts `x-defang-policies: ${POLICIES}` (scalar) in addition
+// to the list form, normalizing either into individual entries.
+func (p *PolicyList) UnmarshalYAML(value *yaml.Node) error {
+	var entries []string
+	if value.Kind == yaml.ScalarNode {
+		var s string
+		if err := value.Decode(&s); err != nil {
+			return err
+		}
+		entries = []string{s}
+	} else if err := value.Decode(&entries); err != nil {
+		return err
+	}
+	*p = NormalizePolicies(entries)
+	return nil
+}
+
+// NormalizePolicies flattens x-defang-policies entries: comma-separated
+// identifiers within an entry are split out, whitespace is trimmed, and empty
+// entries are dropped. Idempotent; call sites normalize again because inputs
+// can also arrive as plain lists from Pulumi programs, bypassing the YAML
+// path.
+func NormalizePolicies(entries []string) []string {
+	var out []string
+	for _, entry := range entries {
+		for _, part := range strings.Split(entry, ",") {
+			if part = strings.TrimSpace(part); part != "" {
+				out = append(out, part)
+			}
+		}
+	}
+	return out
+}
 
 // ClassifyPolicy determines the target cloud of an x-defang-policies entry
 // from its qualified form: AWS ARNs, GCP role names, and Azure resource IDs
@@ -33,26 +93,23 @@ func ClassifyPolicy(entry string) PolicyCloud {
 	return PolicyCloudAny
 }
 
-// PoliciesFor filters x-defang-policies entries to those that apply on the
-// given cloud: entries qualified for another cloud are dropped, so a compose
-// file targeting several clouds can list entries for each side by side; bare
-// names apply everywhere. Returns the applicable entries followed by the
-// skipped ones (for logging).
-func PoliciesFor(cloud PolicyCloud, policies []string) ([]string, []string) {
-	var applicable, skipped []string
-	for _, p := range policies {
-		if c := ClassifyPolicy(p); c == cloud || c == PolicyCloudAny {
-			applicable = append(applicable, p)
-		} else {
-			skipped = append(skipped, p)
+// ValidatePolicies rejects x-defang-policies entries that cannot apply on the
+// given cloud. Entries must be literals by the time they reach the provider:
+// the CLI substitutes `${VAR}` from `.env` at compose-load time, and `defang
+// config` is deliberately not supported for policies — so an unresolved
+// variable is an error, as is an identifier whose syntax belongs to a
+// different cloud (there is no cross-cloud filtering; per-cloud values come
+// from per-stack `.env` files).
+func ValidatePolicies(cloud PolicyCloud, policies []string) error {
+	for _, entry := range policies {
+		if strings.Contains(entry, "${") {
+			return fmt.Errorf("x-defang-policies entry %q has an unresolved variable: %w",
+				entry, ErrPolicyUnresolvedVariable)
+		}
+		if c := ClassifyPolicy(entry); c != cloud && c != PolicyCloudAny {
+			return fmt.Errorf("x-defang-policies entry %q is a %s identifier but this deployment targets %s: %w",
+				entry, c, cloud, ErrPolicyForeignCloud)
 		}
 	}
-	return applicable, skipped
-}
-
-// SkippedPoliciesMessage formats the info-log line for x-defang-policies
-// entries that don't apply on the current cloud.
-func SkippedPoliciesMessage(serviceName string, skipped []string) string {
-	return "service " + serviceName + ": ignoring x-defang-policies entries for other clouds: " +
-		strings.Join(skipped, ", ")
+	return nil
 }

--- a/provider/compose/policies_test.go
+++ b/provider/compose/policies_test.go
@@ -1,0 +1,57 @@
+package compose
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClassifyPolicy(t *testing.T) {
+	tests := []struct {
+		entry string
+		want  PolicyCloud
+	}{
+		{"arn:aws:iam::123456789012:policy/deployer", PolicyCloudAWS},
+		{"arn:aws-us-gov:iam::123456789012:policy/deployer", PolicyCloudAWS},
+		{"roles/run.developer", PolicyCloudGCP},
+		{"projects/myproj/roles/deployer", PolicyCloudGCP},
+		{"organizations/123/roles/deployer", PolicyCloudGCP},
+		{"/subscriptions/000/providers/Microsoft.Authorization/roleDefinitions/abc", PolicyCloudAzure},
+		{"/providers/Microsoft.Authorization/roleDefinitions/abc", PolicyCloudAzure},
+		{"deployer", PolicyCloudAny},
+		{"Storage Blob Data Contributor", PolicyCloudAny},
+	}
+	for _, tt := range tests {
+		t.Run(tt.entry, func(t *testing.T) {
+			assert.Equal(t, tt.want, ClassifyPolicy(tt.entry))
+		})
+	}
+}
+
+func TestPoliciesFor(t *testing.T) {
+	const awsArn = "arn:aws:iam::123456789012:policy/deployer"
+	const gcpRole = "roles/run.developer"
+	const azureID = "/subscriptions/000/providers/Microsoft.Authorization/roleDefinitions/abc"
+	policies := []string{awsArn, gcpRole, azureID, "deployer"}
+
+	tests := []struct {
+		cloud          PolicyCloud
+		wantApplicable []string
+		wantSkipped    []string
+	}{
+		{PolicyCloudAWS, []string{awsArn, "deployer"}, []string{gcpRole, azureID}},
+		{PolicyCloudGCP, []string{gcpRole, "deployer"}, []string{awsArn, azureID}},
+		{PolicyCloudAzure, []string{azureID, "deployer"}, []string{awsArn, gcpRole}},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.cloud), func(t *testing.T) {
+			applicable, skipped := PoliciesFor(tt.cloud, policies)
+			assert.Equal(t, tt.wantApplicable, applicable)
+			assert.Equal(t, tt.wantSkipped, skipped)
+		})
+	}
+
+	applicable, skipped := PoliciesFor(PolicyCloudAWS, nil)
+	assert.Empty(t, applicable)
+	assert.Empty(t, skipped)
+}

--- a/provider/compose/policies_test.go
+++ b/provider/compose/policies_test.go
@@ -29,7 +29,7 @@ func TestClassifyPolicy(t *testing.T) {
 }
 
 func TestNormalizePolicies(t *testing.T) {
-	// Comma-separated entries split (one ${VAR} from .env can carry a list),
+	// Comma-separated entries split (one interpolated ${VAR} can carry a list),
 	// whitespace trims, empties drop (a "${VAR:-}" the stack leaves unset).
 	got := NormalizePolicies([]string{
 		"arn:aws:iam::aws:policy/A, arn:aws:iam::aws:policy/B",
@@ -65,11 +65,11 @@ func TestValidatePolicies(t *testing.T) {
 	err = ValidatePolicies(PolicyCloudGCP, []string{"arn:aws:iam::aws:policy/A"})
 	require.ErrorContains(t, err, "aws identifier")
 
-	// An unresolved variable means the CLI found no .env value; defang
-	// config is deliberately unsupported for policies.
+	// An unresolved variable means compose-load interpolation had no value
+	// for it; defang config is deliberately unsupported for policies.
 	err = ValidatePolicies(PolicyCloudAWS, []string{"${POLICIES}"})
 	require.ErrorContains(t, err, "unresolved variable")
-	require.ErrorContains(t, err, ".env")
+	require.ErrorContains(t, err, "defang config")
 }
 
 func TestPolicyListUnmarshalYAML(t *testing.T) {

--- a/provider/compose/policies_test.go
+++ b/provider/compose/policies_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestClassifyPolicy(t *testing.T) {
@@ -11,47 +13,93 @@ func TestClassifyPolicy(t *testing.T) {
 		entry string
 		want  PolicyCloud
 	}{
+		{"arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess", PolicyCloudAWS},
 		{"arn:aws:iam::123456789012:policy/deployer", PolicyCloudAWS},
-		{"arn:aws-us-gov:iam::123456789012:policy/deployer", PolicyCloudAWS},
 		{"roles/run.developer", PolicyCloudGCP},
-		{"projects/myproj/roles/deployer", PolicyCloudGCP},
-		{"organizations/123/roles/deployer", PolicyCloudGCP},
-		{"/subscriptions/000/providers/Microsoft.Authorization/roleDefinitions/abc", PolicyCloudAzure},
-		{"/providers/Microsoft.Authorization/roleDefinitions/abc", PolicyCloudAzure},
+		{"projects/my-proj/roles/deployer", PolicyCloudGCP},
+		{"organizations/123/roles/auditor", PolicyCloudGCP},
+		{"/subscriptions/sub-id/providers/Microsoft.Authorization/roleDefinitions/x", PolicyCloudAzure},
+		{"/providers/Microsoft.Authorization/roleDefinitions/x", PolicyCloudAzure},
 		{"deployer", PolicyCloudAny},
-		{"Storage Blob Data Contributor", PolicyCloudAny},
+		{"AmazonS3ReadOnlyAccess", PolicyCloudAny},
 	}
 	for _, tt := range tests {
-		t.Run(tt.entry, func(t *testing.T) {
-			assert.Equal(t, tt.want, ClassifyPolicy(tt.entry))
-		})
+		assert.Equal(t, tt.want, ClassifyPolicy(tt.entry), "entry %q", tt.entry)
 	}
 }
 
-func TestPoliciesFor(t *testing.T) {
-	const awsArn = "arn:aws:iam::123456789012:policy/deployer"
-	const gcpRole = "roles/run.developer"
-	const azureID = "/subscriptions/000/providers/Microsoft.Authorization/roleDefinitions/abc"
-	policies := []string{awsArn, gcpRole, azureID, "deployer"}
+func TestNormalizePolicies(t *testing.T) {
+	// Comma-separated entries split (one ${VAR} from .env can carry a list),
+	// whitespace trims, empties drop (a "${VAR:-}" the stack leaves unset).
+	got := NormalizePolicies([]string{
+		"arn:aws:iam::aws:policy/A, arn:aws:iam::aws:policy/B",
+		"",
+		"  deployer  ",
+		",",
+	})
+	assert.Equal(t, []string{
+		"arn:aws:iam::aws:policy/A",
+		"arn:aws:iam::aws:policy/B",
+		"deployer",
+	}, got)
 
-	tests := []struct {
-		cloud          PolicyCloud
-		wantApplicable []string
-		wantSkipped    []string
-	}{
-		{PolicyCloudAWS, []string{awsArn, "deployer"}, []string{gcpRole, azureID}},
-		{PolicyCloudGCP, []string{gcpRole, "deployer"}, []string{awsArn, azureID}},
-		{PolicyCloudAzure, []string{azureID, "deployer"}, []string{awsArn, gcpRole}},
-	}
-	for _, tt := range tests {
-		t.Run(string(tt.cloud), func(t *testing.T) {
-			applicable, skipped := PoliciesFor(tt.cloud, policies)
-			assert.Equal(t, tt.wantApplicable, applicable)
-			assert.Equal(t, tt.wantSkipped, skipped)
-		})
-	}
+	assert.Nil(t, NormalizePolicies(nil))
+	assert.Nil(t, NormalizePolicies([]string{"", " ", ","}))
+}
 
-	applicable, skipped := PoliciesFor(PolicyCloudAWS, nil)
-	assert.Empty(t, applicable)
-	assert.Empty(t, skipped)
+func TestValidatePolicies(t *testing.T) {
+	// Current-cloud and bare entries pass.
+	require.NoError(t, ValidatePolicies(PolicyCloudAWS, []string{
+		"arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess", "deployer",
+	}))
+	require.NoError(t, ValidatePolicies(PolicyCloudGCP, []string{
+		"roles/run.developer", "deployer",
+	}))
+
+	// A foreign identifier is a hard error (no cross-cloud filtering).
+	err := ValidatePolicies(PolicyCloudAWS, []string{"roles/run.developer"})
+	require.ErrorContains(t, err, "gcp identifier")
+	require.ErrorContains(t, err, "targets aws")
+	require.ErrorContains(t, err, "${VAR}")
+
+	err = ValidatePolicies(PolicyCloudGCP, []string{"arn:aws:iam::aws:policy/A"})
+	require.ErrorContains(t, err, "aws identifier")
+
+	// An unresolved variable means the CLI found no .env value; defang
+	// config is deliberately unsupported for policies.
+	err = ValidatePolicies(PolicyCloudAWS, []string{"${POLICIES}"})
+	require.ErrorContains(t, err, "unresolved variable")
+	require.ErrorContains(t, err, ".env")
+}
+
+func TestPolicyListUnmarshalYAML(t *testing.T) {
+	// List form: entries normalized (split, trimmed, empties dropped).
+	var list PolicyList
+	require.NoError(t, yaml.Unmarshal([]byte(
+		"- arn:aws:iam::aws:policy/A\n- \"\"\n- roles/run.developer, deployer\n"), &list))
+	assert.Equal(t, PolicyList{
+		"arn:aws:iam::aws:policy/A", "roles/run.developer", "deployer",
+	}, list)
+
+	// Scalar form: `x-defang-policies: ${POLICIES}` post-substitution is a
+	// single comma-separated string.
+	var scalar PolicyList
+	require.NoError(t, yaml.Unmarshal([]byte(
+		`"arn:aws:iam::aws:policy/A,arn:aws:iam::aws:policy/B"`), &scalar))
+	assert.Equal(t, PolicyList{
+		"arn:aws:iam::aws:policy/A", "arn:aws:iam::aws:policy/B",
+	}, scalar)
+}
+
+func TestServiceConfigUnmarshalYAMLPoliciesScalar(t *testing.T) {
+	// The scalar form must work through the full service decode, which uses
+	// a methodless alias of ServiceConfig (PolicyList's own UnmarshalYAML
+	// still applies to the field).
+	input := `
+image: myapp:latest
+x-defang-policies: "roles/run.developer, deployer"
+`
+	var svc ServiceConfig
+	require.NoError(t, yaml.Unmarshal([]byte(input), &svc))
+	assert.Equal(t, PolicyList{"roles/run.developer", "deployer"}, svc.Policies)
 }

--- a/provider/compose/types.go
+++ b/provider/compose/types.go
@@ -117,7 +117,7 @@ type ServiceConfig struct {
 	// rejects it. Cannot be combined with a caller-supplied task role /
 	// service account. Matches the x-defang-policies extension; see
 	// PolicyList for the accepted forms (scalar or list, comma-separated,
-	// `${VAR}` from `.env`).
+	// `${VAR}` interpolated at compose-load time).
 	Policies PolicyList `pulumi:"policies,optional" yaml:"x-defang-policies,omitempty"`
 
 	// Aliases maps this service's child cloud resources — by provider-defined

--- a/provider/compose/types.go
+++ b/provider/compose/types.go
@@ -111,11 +111,14 @@ type ServiceConfig struct {
 	// Enable autoscaling. Matches the x-defang-autoscaling extension.
 	Autoscaling bool `pulumi:"autoscaling,optional" yaml:"x-defang-autoscaling,omitempty"`
 
-	// Extra IAM policies to attach to the task role created for this service;
-	// each entry is a full policy ARN or a customer-managed policy name.
-	// Matches the x-defang-policies extension. AWS-only: other providers
-	// reject it, and it cannot be combined with a caller-supplied task role.
-	Policies []string `pulumi:"policies,optional" yaml:"x-defang-policies,omitempty"`
+	// Extra IAM policies/roles for the identity created for this service: on
+	// AWS each entry is a policy ARN or customer-managed policy name attached
+	// to the task role; on GCP a role granted to the service account; Azure
+	// rejects it. Cannot be combined with a caller-supplied task role /
+	// service account. Matches the x-defang-policies extension; see
+	// PolicyList for the accepted forms (scalar or list, comma-separated,
+	// `${VAR}` from `.env`).
+	Policies PolicyList `pulumi:"policies,optional" yaml:"x-defang-policies,omitempty"`
 
 	// Aliases maps this service's child cloud resources — by provider-defined
 	// kind, e.g. "cluster", "subnet-group", "parameter-group",

--- a/provider/compose/yaml_test.go
+++ b/provider/compose/yaml_test.go
@@ -106,7 +106,7 @@ networks:
 	assert.True(t, *db.Postgres.AllowDowntime)
 
 	worker := p.Services["worker"]
-	assert.Equal(t, []string{
+	assert.Equal(t, PolicyList{
 		"arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
 		"MyCustomPolicy",
 	}, worker.Policies)

--- a/provider/defangaws/aws/ecs.go
+++ b/provider/defangaws/aws/ecs.go
@@ -504,9 +504,9 @@ func CreateECSService(
 		}
 
 		// Attach caller-specified policies (x-defang-policies). Entries are
-		// literals by now — the CLI substitutes ${VAR} from .env at load —
-		// so anything unresolved or qualified for a different cloud is a
-		// hard error; per-cloud values come from per-stack .env files.
+		// literals by now — compose variables were interpolated before the
+		// project reached the provider — so anything unresolved or qualified
+		// for a different cloud is a hard error.
 		policies := compose.NormalizePolicies(svc.Policies)
 		if err := compose.ValidatePolicies(compose.PolicyCloudAWS, policies); err != nil {
 			return nil, fmt.Errorf("service %s: %w", serviceName, err)

--- a/provider/defangaws/aws/ecs.go
+++ b/provider/defangaws/aws/ecs.go
@@ -503,8 +503,14 @@ func CreateECSService(
 			lbDependsOn = append(lbDependsOn, dep)
 		}
 
-		// Attach caller-specified policies (x-defang-policies)
-		for _, policy := range svc.Policies {
+		// Attach caller-specified policies (x-defang-policies); entries
+		// qualified for another cloud are skipped, so multi-cloud compose
+		// files can list entries for each target side by side.
+		policies, skipped := compose.PoliciesFor(compose.PolicyCloudAWS, svc.Policies)
+		if len(skipped) > 0 {
+			_ = ctx.Log.Info(compose.SkippedPoliciesMessage(serviceName, skipped), nil)
+		}
+		for _, policy := range policies {
 			policyArn, err := resolvePolicyArn(ctx, policy, parentOpt)
 			if err != nil {
 				return nil, fmt.Errorf("resolving policy %q: %w", policy, err)
@@ -519,7 +525,7 @@ func CreateECSService(
 			}
 			lbDependsOn = append(lbDependsOn, dep)
 		}
-	} else if len(svc.Policies) > 0 {
+	} else if policies, _ := compose.PoliciesFor(compose.PolicyCloudAWS, svc.Policies); len(policies) > 0 {
 		// A caller-supplied task role's policies are owned by the caller.
 		return nil, fmt.Errorf("service %s: %w", serviceName, errPoliciesWithTaskRole)
 	}

--- a/provider/defangaws/aws/ecs.go
+++ b/provider/defangaws/aws/ecs.go
@@ -503,12 +503,13 @@ func CreateECSService(
 			lbDependsOn = append(lbDependsOn, dep)
 		}
 
-		// Attach caller-specified policies (x-defang-policies); entries
-		// qualified for another cloud are skipped, so multi-cloud compose
-		// files can list entries for each target side by side.
-		policies, skipped := compose.PoliciesFor(compose.PolicyCloudAWS, svc.Policies)
-		if len(skipped) > 0 {
-			_ = ctx.Log.Info(compose.SkippedPoliciesMessage(serviceName, skipped), nil)
+		// Attach caller-specified policies (x-defang-policies). Entries are
+		// literals by now — the CLI substitutes ${VAR} from .env at load —
+		// so anything unresolved or qualified for a different cloud is a
+		// hard error; per-cloud values come from per-stack .env files.
+		policies := compose.NormalizePolicies(svc.Policies)
+		if err := compose.ValidatePolicies(compose.PolicyCloudAWS, policies); err != nil {
+			return nil, fmt.Errorf("service %s: %w", serviceName, err)
 		}
 		// Dedup repeated entries: the attachment URN embeds policyName(policy),
 		// so a duplicate entry would collide on it.
@@ -532,7 +533,7 @@ func CreateECSService(
 			}
 			lbDependsOn = append(lbDependsOn, dep)
 		}
-	} else if policies, _ := compose.PoliciesFor(compose.PolicyCloudAWS, svc.Policies); len(policies) > 0 {
+	} else if len(compose.NormalizePolicies(svc.Policies)) > 0 {
 		// A caller-supplied task role's policies are owned by the caller.
 		return nil, fmt.Errorf("service %s: %w", serviceName, errPoliciesWithTaskRole)
 	}

--- a/provider/defangaws/aws/ecs.go
+++ b/provider/defangaws/aws/ecs.go
@@ -510,7 +510,14 @@ func CreateECSService(
 		if len(skipped) > 0 {
 			_ = ctx.Log.Info(compose.SkippedPoliciesMessage(serviceName, skipped), nil)
 		}
+		// Dedup repeated entries: the attachment URN embeds policyName(policy),
+		// so a duplicate entry would collide on it.
+		seenPolicies := make(map[string]struct{}, len(policies))
 		for _, policy := range policies {
+			if _, dup := seenPolicies[policy]; dup {
+				continue
+			}
+			seenPolicies[policy] = struct{}{}
 			policyArn, err := resolvePolicyArn(ctx, policy, parentOpt)
 			if err != nil {
 				return nil, fmt.Errorf("resolving policy %q: %w", policy, err)

--- a/provider/defangazure/service.go
+++ b/provider/defangazure/service.go
@@ -133,7 +133,14 @@ func createContainerApp(
 	managedEndpoints map[string]pulumi.StringOutput,
 	serviceHosts map[string]pulumi.StringOutput,
 ) error {
-	if len(svc.Policies) > 0 {
+	// Entries qualified for another cloud are ignored, so a multi-cloud
+	// compose file with AWS/GCP policies still deploys here; only entries
+	// that would apply on Azure hit the unsupported error.
+	policies, skipped := compose.PoliciesFor(compose.PolicyCloudAzure, svc.Policies)
+	if len(skipped) > 0 {
+		_ = ctx.Log.Info(compose.SkippedPoliciesMessage(serviceName, skipped), nil)
+	}
+	if len(policies) > 0 {
 		return fmt.Errorf("service %s: %w", serviceName, errPoliciesUnsupported)
 	}
 	caResult, err := azure.CreateContainerApp(

--- a/provider/defangazure/service.go
+++ b/provider/defangazure/service.go
@@ -133,12 +133,13 @@ func createContainerApp(
 	managedEndpoints map[string]pulumi.StringOutput,
 	serviceHosts map[string]pulumi.StringOutput,
 ) error {
-	// Entries qualified for another cloud are ignored, so a multi-cloud
-	// compose file with AWS/GCP policies still deploys here; only entries
-	// that would apply on Azure hit the unsupported error.
-	policies, skipped := compose.PoliciesFor(compose.PolicyCloudAzure, svc.Policies)
-	if len(skipped) > 0 {
-		_ = ctx.Log.Info(compose.SkippedPoliciesMessage(serviceName, skipped), nil)
+	// Policies aren't supported on Azure yet. Entries a stack leaves empty
+	// ("${EXTRA:-}") normalize away, so a compose file parameterized per
+	// stack still deploys here; a foreign-cloud literal gets the validation
+	// error (with the ${VAR} hint), any other entry the unsupported error.
+	policies := compose.NormalizePolicies(svc.Policies)
+	if err := compose.ValidatePolicies(compose.PolicyCloudAzure, policies); err != nil {
+		return fmt.Errorf("service %s: %w", serviceName, err)
 	}
 	if len(policies) > 0 {
 		return fmt.Errorf("service %s: %w", serviceName, errPoliciesUnsupported)

--- a/provider/defanggcp/gcp/cloudrun.go
+++ b/provider/defanggcp/gcp/cloudrun.go
@@ -32,7 +32,9 @@ func cloudRunLimits(cpus float64, memMiB int) (string, string) {
 	return fmt.Sprintf("%g", cpu), fmt.Sprintf("%dMi", mem)
 }
 
-// CreateCloudRunService creates a Cloud Run service.
+// CreateCloudRunService creates a Cloud Run service. extraIAMDeps are IAM
+// bindings created by the caller (e.g. x-defang-policies grants) that the
+// service must wait for — the container may need them at startup.
 func CreateCloudRunService(
 	ctx *pulumi.Context,
 	configProvider compose.ConfigProvider,
@@ -41,12 +43,14 @@ func CreateCloudRunService(
 	svc compose.ServiceConfig,
 	sa *ServiceIdentity,
 	gcpConfig *SharedInfra,
+	extraIAMDeps []pulumi.Resource,
 	parentOpt pulumi.ResourceOrInvokeOption,
 ) (*CloudRunResult, error) {
 	template, secretIds := buildTemplate(ctx, configProvider, serviceName, image, svc, sa, gcpConfig, parentOpt)
 
 	// Grant the service account access to each referenced secret
-	iamDeps := make([]pulumi.Resource, 0, len(secretIds))
+	iamDeps := make([]pulumi.Resource, 0, len(secretIds)+len(extraIAMDeps))
+	iamDeps = append(iamDeps, extraIAMDeps...)
 	for _, sid := range secretIds {
 		opts := append([]pulumi.ResourceOption{parentOpt}, sa.deleteOpts()...)
 		member, err := secretmanager.NewSecretIamMember(ctx, serviceName+"-secret-"+sid, &secretmanager.SecretIamMemberArgs{

--- a/provider/defanggcp/gcp/compute.go
+++ b/provider/defanggcp/gcp/compute.go
@@ -46,7 +46,7 @@ func CreateComputeEngine(
 
 	var iamDeps pulumi.ResourceArrayOutput
 	if args.SA.Account != nil {
-		iamDeps = addRolesToServiceAccount(ctx, args.SA, []string{
+		iamDeps = AddRolesToServiceAccount(ctx, args.SA, []string{
 			"roles/artifactregistry.reader",
 			"roles/logging.logWriter",
 			"roles/monitoring.metricWriter",
@@ -332,9 +332,9 @@ func buildMIGUpdatePolicy(numZones, targetSize int) *compute.RegionInstanceGroup
 	return policy
 }
 
-// addRolesToServiceAccount grants IAM roles to a service account at the project level.
+// AddRolesToServiceAccount grants IAM roles to a service account at the project level.
 // Returns a resource array output that can be used as a dependency.
-func addRolesToServiceAccount(
+func AddRolesToServiceAccount(
 	ctx *pulumi.Context,
 	sa *ServiceIdentity,
 	roles []string,

--- a/provider/defanggcp/gcp/compute.go
+++ b/provider/defanggcp/gcp/compute.go
@@ -28,6 +28,10 @@ type ComputeEngineArgs struct {
 	// Triggers force an instance template replacement (and thus a rolling
 	// update) when any value changes.
 	Triggers pulumi.StringMapInput
+	// PolicyDeps are IAM bindings created by the caller (x-defang-policies
+	// grants) the instances must wait for — the container may need the
+	// permissions at startup.
+	PolicyDeps []pulumi.Resource
 }
 
 // CreateComputeEngine deploys a container service as a Compute Engine Managed Instance Group
@@ -81,9 +85,13 @@ func CreateComputeEngine(
 		serviceName, image, svc, gcpConfig.Region, gcpConfig.Etag, gcpConfig.ProjectName, gcpConfig.Stack, fqdn,
 		addHealthCheckSidecar, args.Sidecars)
 
+	templateOpts := []pulumi.ResourceOption{parentOpt}
+	if len(args.PolicyDeps) > 0 {
+		templateOpts = append(templateOpts, pulumi.DependsOn(args.PolicyDeps))
+	}
 	instanceTemplate, err := createInstanceTemplate(
 		ctx, serviceName, serviceName, machineType, getComputeBootImage(svc), cloudInit,
-		args.SA, args.Triggers, gcpConfig, iamDeps, parentOpt)
+		args.SA, args.Triggers, gcpConfig, iamDeps, templateOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/defanggcp/gcp/iam.go
+++ b/provider/defanggcp/gcp/iam.go
@@ -24,7 +24,9 @@ func ResolvePolicyRole(gcpProject, policy string) string {
 // member names derive from the account email), members are named
 // <service>-policy-<role> so a policy that repeats one of the platform-granted
 // roles (e.g. the Compute Engine logging/monitoring set) cannot collide on the
-// URN; the duplicate binding itself is idempotent on GCP.
+// URN; the duplicate binding itself is idempotent on GCP. The created members
+// are returned so the service's compute resources can DependsOn them — the
+// container may need the granted permissions at startup.
 func GrantPolicyRoles(
 	ctx *pulumi.Context,
 	serviceName string,
@@ -32,9 +34,10 @@ func GrantPolicyRoles(
 	roles []string,
 	gcpConfig *SharedInfra,
 	opts ...pulumi.ResourceOption,
-) error {
+) ([]pulumi.Resource, error) {
+	members := make([]pulumi.Resource, 0, len(roles))
 	for _, role := range roles {
-		_, err := projects.NewIAMMember(ctx, serviceName+"-policy-"+role,
+		member, err := projects.NewIAMMember(ctx, serviceName+"-policy-"+role,
 			&projects.IAMMemberArgs{
 				Project: pulumi.String(gcpConfig.GcpProject),
 				Role:    pulumi.String(role),
@@ -43,8 +46,9 @@ func GrantPolicyRoles(
 			append(opts, sa.deleteOpts()...)...,
 		)
 		if err != nil {
-			return err
+			return nil, err
 		}
+		members = append(members, member)
 	}
-	return nil
+	return members, nil
 }

--- a/provider/defanggcp/gcp/iam.go
+++ b/provider/defanggcp/gcp/iam.go
@@ -1,0 +1,15 @@
+package gcp
+
+import "strings"
+
+// ResolvePolicyRole turns an x-defang-policies entry into an IAM role name for
+// a project-level binding. Qualified names (`roles/…`, `projects/…/roles/…`,
+// `organizations/…/roles/…`) pass through; a bare name resolves to a custom
+// role in the given project (the GCP analogue of AWS resolvePolicyArn, which
+// resolves bare names to a customer-managed policy in the caller's account).
+func ResolvePolicyRole(gcpProject, policy string) string {
+	if strings.Contains(policy, "/") {
+		return policy
+	}
+	return "projects/" + gcpProject + "/roles/" + policy
+}

--- a/provider/defanggcp/gcp/iam.go
+++ b/provider/defanggcp/gcp/iam.go
@@ -1,6 +1,11 @@
 package gcp
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/projects"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
 
 // ResolvePolicyRole turns an x-defang-policies entry into an IAM role name for
 // a project-level binding. Qualified names (`roles/…`, `projects/…/roles/…`,
@@ -12,4 +17,34 @@ func ResolvePolicyRole(gcpProject, policy string) string {
 		return policy
 	}
 	return "projects/" + gcpProject + "/roles/" + policy
+}
+
+// GrantPolicyRoles grants x-defang-policies roles to a provider-created
+// service account at project level. Unlike AddRolesToServiceAccount (whose
+// member names derive from the account email), members are named
+// <service>-policy-<role> so a policy that repeats one of the platform-granted
+// roles (e.g. the Compute Engine logging/monitoring set) cannot collide on the
+// URN; the duplicate binding itself is idempotent on GCP.
+func GrantPolicyRoles(
+	ctx *pulumi.Context,
+	serviceName string,
+	sa *ServiceIdentity,
+	roles []string,
+	gcpConfig *SharedInfra,
+	opts ...pulumi.ResourceOption,
+) error {
+	for _, role := range roles {
+		_, err := projects.NewIAMMember(ctx, serviceName+"-policy-"+role,
+			&projects.IAMMemberArgs{
+				Project: pulumi.String(gcpConfig.GcpProject),
+				Role:    pulumi.String(role),
+				Member:  pulumi.Sprintf("serviceAccount:%v", sa.Email),
+			},
+			append(opts, sa.deleteOpts()...)...,
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/provider/defanggcp/gcp/iam_test.go
+++ b/provider/defanggcp/gcp/iam_test.go
@@ -1,0 +1,23 @@
+package gcp
+
+import "testing"
+
+func TestResolvePolicyRole(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy string
+		want   string
+	}{
+		{"predefined role", "roles/run.developer", "roles/run.developer"},
+		{"project custom role", "projects/other/roles/deployer", "projects/other/roles/deployer"},
+		{"organization custom role", "organizations/123/roles/deployer", "organizations/123/roles/deployer"},
+		{"bare name resolves in current project", "deployer", "projects/myproj/roles/deployer"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ResolvePolicyRole("myproj", tt.policy); got != tt.want {
+				t.Errorf("ResolvePolicyRole(%q) = %q, want %q", tt.policy, got, tt.want)
+			}
+		})
+	}
+}

--- a/provider/defanggcp/service.go
+++ b/provider/defanggcp/service.go
@@ -13,7 +13,9 @@ import (
 var (
 	errSidecarsRequireComputeEngine = errors.New(
 		"sidecars and volumes are only supported on Compute Engine services (no single ingress port)")
-	errPoliciesUnsupported = errors.New("x-defang-policies is not supported on GCP")
+	// A caller-supplied service account's IAM role grants are owned by the
+	// caller (the analogue of AWS errPoliciesWithTaskRole).
+	errPoliciesWithServiceAccount = errors.New("policies cannot be combined with serviceAccountEmail")
 )
 
 // Service is the controller struct for the defang-gcp:index:Service component.
@@ -150,6 +152,27 @@ type serviceExtras struct {
 	Triggers            pulumi.StringMapInput
 }
 
+// grantPolicies grants caller-specified IAM roles (x-defang-policies) on the
+// project to the service account created for the service. The grant is on the
+// service account, so it applies identically to the Cloud Run and Compute
+// Engine paths.
+func grantPolicies(
+	ctx *pulumi.Context,
+	identity *providergcp.ServiceIdentity,
+	policies []string,
+	infra *providergcp.SharedInfra,
+	opts []pulumi.ResourceOption,
+) {
+	if len(policies) == 0 {
+		return
+	}
+	roles := make([]string, len(policies))
+	for i, policy := range policies {
+		roles[i] = providergcp.ResolvePolicyRole(infra.GcpProject, policy)
+	}
+	providergcp.AddRolesToServiceAccount(ctx, identity, roles, infra, opts...)
+}
+
 // validateSidecarImages requires every sidecar to have an image; a static
 // image must also be non-empty. Dynamic (Output-valued) images are fine —
 // they resolve when the cloud-init systemd unit is rendered — matching the
@@ -186,15 +209,15 @@ func createService(
 	if extras == nil {
 		extras = &serviceExtras{}
 	}
-	if len(svc.Policies) > 0 {
-		return fmt.Errorf("service %s: %w", serviceName, errPoliciesUnsupported)
-	}
 	if err := validateSidecarImages(serviceName, extras.Sidecars); err != nil {
 		return err
 	}
 
 	var identity *providergcp.ServiceIdentity
 	if extras.ServiceAccountEmail != nil {
+		if len(svc.Policies) > 0 {
+			return fmt.Errorf("service %s: %w", serviceName, errPoliciesWithServiceAccount)
+		}
 		identity = &providergcp.ServiceIdentity{Email: extras.ServiceAccountEmail}
 	} else {
 		sa, err := createServiceAccount(ctx, projectName, serviceName, infra, childOpts)
@@ -202,6 +225,7 @@ func createService(
 			return err
 		}
 		identity = &providergcp.ServiceIdentity{Account: sa, Email: sa.Email}
+		grantPolicies(ctx, identity, svc.Policies, infra, childOpts)
 	}
 
 	if svc.LLM != nil {

--- a/provider/defanggcp/service.go
+++ b/provider/defanggcp/service.go
@@ -158,19 +158,23 @@ type serviceExtras struct {
 // Engine paths.
 func grantPolicies(
 	ctx *pulumi.Context,
+	serviceName string,
 	identity *providergcp.ServiceIdentity,
 	policies []string,
 	infra *providergcp.SharedInfra,
 	opts []pulumi.ResourceOption,
-) {
+) error {
 	if len(policies) == 0 {
-		return
+		return nil
 	}
 	roles := make([]string, len(policies))
 	for i, policy := range policies {
 		roles[i] = providergcp.ResolvePolicyRole(infra.GcpProject, policy)
 	}
-	providergcp.AddRolesToServiceAccount(ctx, identity, roles, infra, opts...)
+	if err := providergcp.GrantPolicyRoles(ctx, serviceName, identity, roles, infra, opts...); err != nil {
+		return fmt.Errorf("granting policies for service %s: %w", serviceName, err)
+	}
+	return nil
 }
 
 // validateSidecarImages requires every sidecar to have an image; a static
@@ -225,7 +229,9 @@ func createService(
 			return err
 		}
 		identity = &providergcp.ServiceIdentity{Account: sa, Email: sa.Email}
-		grantPolicies(ctx, identity, svc.Policies, infra, childOpts)
+		if err := grantPolicies(ctx, serviceName, identity, svc.Policies, infra, childOpts); err != nil {
+			return err
+		}
 	}
 
 	if svc.LLM != nil {

--- a/provider/defanggcp/service.go
+++ b/provider/defanggcp/service.go
@@ -155,7 +155,8 @@ type serviceExtras struct {
 // grantPolicies grants caller-specified IAM roles (x-defang-policies) on the
 // project to the service account created for the service. The grant is on the
 // service account, so it applies identically to the Cloud Run and Compute
-// Engine paths.
+// Engine paths. Returns the created IAM members so the compute resources can
+// DependsOn them — the container may need the permissions at startup.
 func grantPolicies(
 	ctx *pulumi.Context,
 	serviceName string,
@@ -163,22 +164,31 @@ func grantPolicies(
 	policies []string,
 	infra *providergcp.SharedInfra,
 	opts []pulumi.ResourceOption,
-) error {
+) ([]pulumi.Resource, error) {
 	policies, skipped := compose.PoliciesFor(compose.PolicyCloudGCP, policies)
 	if len(skipped) > 0 {
 		_ = ctx.Log.Info(compose.SkippedPoliciesMessage(serviceName, skipped), nil)
 	}
 	if len(policies) == 0 {
-		return nil
+		return nil, nil
 	}
-	roles := make([]string, len(policies))
-	for i, policy := range policies {
-		roles[i] = providergcp.ResolvePolicyRole(infra.GcpProject, policy)
+	// Dedup by resolved role: the member URN embeds the role, so a repeated
+	// entry (or a bare name alongside its qualified form) would collide.
+	roles := make([]string, 0, len(policies))
+	seen := make(map[string]struct{}, len(policies))
+	for _, policy := range policies {
+		role := providergcp.ResolvePolicyRole(infra.GcpProject, policy)
+		if _, dup := seen[role]; dup {
+			continue
+		}
+		seen[role] = struct{}{}
+		roles = append(roles, role)
 	}
-	if err := providergcp.GrantPolicyRoles(ctx, serviceName, identity, roles, infra, opts...); err != nil {
-		return fmt.Errorf("granting policies for service %s: %w", serviceName, err)
+	deps, err := providergcp.GrantPolicyRoles(ctx, serviceName, identity, roles, infra, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("granting policies for service %s: %w", serviceName, err)
 	}
-	return nil
+	return deps, nil
 }
 
 // validateSidecarImages requires every sidecar to have an image; a static
@@ -222,6 +232,7 @@ func createService(
 	}
 
 	var identity *providergcp.ServiceIdentity
+	var policyDeps []pulumi.Resource
 	if extras.ServiceAccountEmail != nil {
 		if policies, _ := compose.PoliciesFor(compose.PolicyCloudGCP, svc.Policies); len(policies) > 0 {
 			return fmt.Errorf("service %s: %w", serviceName, errPoliciesWithServiceAccount)
@@ -233,7 +244,8 @@ func createService(
 			return err
 		}
 		identity = &providergcp.ServiceIdentity{Account: sa, Email: sa.Email}
-		if err := grantPolicies(ctx, serviceName, identity, svc.Policies, infra, childOpts); err != nil {
+		policyDeps, err = grantPolicies(ctx, serviceName, identity, svc.Policies, infra, childOpts)
+		if err != nil {
 			return err
 		}
 	}
@@ -263,7 +275,7 @@ func createService(
 			return fmt.Errorf("service %s: %w", serviceName, errSidecarsRequireComputeEngine)
 		}
 		crResult, crErr := providergcp.CreateCloudRunService(
-			ctx, configProvider, serviceName, image, svc, identity, infra, parentOpt,
+			ctx, configProvider, serviceName, image, svc, identity, infra, policyDeps, parentOpt,
 		)
 		if crErr != nil {
 			return fmt.Errorf("creating Cloud Run service %s: %w", serviceName, crErr)
@@ -272,9 +284,10 @@ func createService(
 		lbEntry = &providergcp.LBServiceEntry{Name: serviceName, CloudRunService: crResult.Service, Config: svc}
 	} else {
 		ceArgs := &providergcp.ComputeEngineArgs{
-			SA:       identity,
-			Sidecars: extras.Sidecars,
-			Triggers: extras.Triggers,
+			SA:         identity,
+			Sidecars:   extras.Sidecars,
+			Triggers:   extras.Triggers,
+			PolicyDeps: policyDeps,
 		}
 		ceResult, ceErr := providergcp.CreateComputeEngine(
 			ctx, serviceName, image, svc, ceArgs, infra, parentOpt,

--- a/provider/defanggcp/service.go
+++ b/provider/defanggcp/service.go
@@ -167,7 +167,7 @@ func serviceIdentity(
 	childOpts []pulumi.ResourceOption,
 ) (*providergcp.ServiceIdentity, []pulumi.Resource, error) {
 	if serviceAccountEmail != nil {
-		if policies, _ := compose.PoliciesFor(compose.PolicyCloudGCP, policies); len(policies) > 0 {
+		if len(compose.NormalizePolicies(policies)) > 0 {
 			return nil, nil, fmt.Errorf("service %s: %w", serviceName, errPoliciesWithServiceAccount)
 		}
 		return &providergcp.ServiceIdentity{Email: serviceAccountEmail}, nil, nil
@@ -197,9 +197,9 @@ func grantPolicies(
 	infra *providergcp.SharedInfra,
 	opts []pulumi.ResourceOption,
 ) ([]pulumi.Resource, error) {
-	policies, skipped := compose.PoliciesFor(compose.PolicyCloudGCP, policies)
-	if len(skipped) > 0 {
-		_ = ctx.Log.Info(compose.SkippedPoliciesMessage(serviceName, skipped), nil)
+	policies = compose.NormalizePolicies(policies)
+	if err := compose.ValidatePolicies(compose.PolicyCloudGCP, policies); err != nil {
+		return nil, fmt.Errorf("service %s: %w", serviceName, err)
 	}
 	if len(policies) == 0 {
 		return nil, nil

--- a/provider/defanggcp/service.go
+++ b/provider/defanggcp/service.go
@@ -164,6 +164,10 @@ func grantPolicies(
 	infra *providergcp.SharedInfra,
 	opts []pulumi.ResourceOption,
 ) error {
+	policies, skipped := compose.PoliciesFor(compose.PolicyCloudGCP, policies)
+	if len(skipped) > 0 {
+		_ = ctx.Log.Info(compose.SkippedPoliciesMessage(serviceName, skipped), nil)
+	}
 	if len(policies) == 0 {
 		return nil
 	}
@@ -219,7 +223,7 @@ func createService(
 
 	var identity *providergcp.ServiceIdentity
 	if extras.ServiceAccountEmail != nil {
-		if len(svc.Policies) > 0 {
+		if policies, _ := compose.PoliciesFor(compose.PolicyCloudGCP, svc.Policies); len(policies) > 0 {
 			return fmt.Errorf("service %s: %w", serviceName, errPoliciesWithServiceAccount)
 		}
 		identity = &providergcp.ServiceIdentity{Email: extras.ServiceAccountEmail}

--- a/provider/defanggcp/service.go
+++ b/provider/defanggcp/service.go
@@ -152,6 +152,38 @@ type serviceExtras struct {
 	Triggers            pulumi.StringMapInput
 }
 
+// serviceIdentity returns the identity the service runs as: the
+// caller-supplied service account when given (its IAM is owned by the caller,
+// so x-defang-policies is an error), else a provider-created account with the
+// policies granted on it. The returned deps are the policy IAM members the
+// compute resources must wait for.
+func serviceIdentity(
+	ctx *pulumi.Context,
+	projectName string,
+	serviceName string,
+	policies []string,
+	serviceAccountEmail pulumi.StringInput,
+	infra *providergcp.SharedInfra,
+	childOpts []pulumi.ResourceOption,
+) (*providergcp.ServiceIdentity, []pulumi.Resource, error) {
+	if serviceAccountEmail != nil {
+		if policies, _ := compose.PoliciesFor(compose.PolicyCloudGCP, policies); len(policies) > 0 {
+			return nil, nil, fmt.Errorf("service %s: %w", serviceName, errPoliciesWithServiceAccount)
+		}
+		return &providergcp.ServiceIdentity{Email: serviceAccountEmail}, nil, nil
+	}
+	sa, err := createServiceAccount(ctx, projectName, serviceName, infra, childOpts)
+	if err != nil {
+		return nil, nil, err
+	}
+	identity := &providergcp.ServiceIdentity{Account: sa, Email: sa.Email}
+	policyDeps, err := grantPolicies(ctx, serviceName, identity, policies, infra, childOpts)
+	if err != nil {
+		return nil, nil, err
+	}
+	return identity, policyDeps, nil
+}
+
 // grantPolicies grants caller-specified IAM roles (x-defang-policies) on the
 // project to the service account created for the service. The grant is on the
 // service account, so it applies identically to the Cloud Run and Compute
@@ -231,23 +263,9 @@ func createService(
 		return err
 	}
 
-	var identity *providergcp.ServiceIdentity
-	var policyDeps []pulumi.Resource
-	if extras.ServiceAccountEmail != nil {
-		if policies, _ := compose.PoliciesFor(compose.PolicyCloudGCP, svc.Policies); len(policies) > 0 {
-			return fmt.Errorf("service %s: %w", serviceName, errPoliciesWithServiceAccount)
-		}
-		identity = &providergcp.ServiceIdentity{Email: extras.ServiceAccountEmail}
-	} else {
-		sa, err := createServiceAccount(ctx, projectName, serviceName, infra, childOpts)
-		if err != nil {
-			return err
-		}
-		identity = &providergcp.ServiceIdentity{Account: sa, Email: sa.Email}
-		policyDeps, err = grantPolicies(ctx, serviceName, identity, svc.Policies, infra, childOpts)
-		if err != nil {
-			return err
-		}
+	identity, policyDeps, err := serviceIdentity(ctx, projectName, serviceName, svc.Policies, extras.ServiceAccountEmail, infra, childOpts)
+	if err != nil {
+		return err
 	}
 
 	if svc.LLM != nil {

--- a/provider/defanggcp/service.go
+++ b/provider/defanggcp/service.go
@@ -263,7 +263,8 @@ func createService(
 		return err
 	}
 
-	identity, policyDeps, err := serviceIdentity(ctx, projectName, serviceName, svc.Policies, extras.ServiceAccountEmail, infra, childOpts)
+	identity, policyDeps, err := serviceIdentity(
+		ctx, projectName, serviceName, svc.Policies, extras.ServiceAccountEmail, infra, childOpts)
 	if err != nil {
 		return err
 	}

--- a/tests/aws/project_test.go
+++ b/tests/aws/project_test.go
@@ -243,3 +243,41 @@ func TestConstructAwsProjectSkipsForeignPolicies(t *testing.T) {
 		assert.NotContains(t, arn, "run.developer", "GCP-qualified policy must be skipped on AWS")
 	}
 }
+
+func TestConstructAwsProjectDuplicatePoliciesDeduped(t *testing.T) {
+	var attachments []property.Map
+	mock := &integration.MockResourceMonitor{
+		NewResourceF: func(args integration.MockResourceArgs) (string, property.Map, error) {
+			if string(args.TypeToken) == "aws:iam/rolePolicyAttachment:RolePolicyAttachment" {
+				attachments = append(attachments, args.Inputs)
+			}
+			return args.Name, args.Inputs, nil
+		},
+	}
+	server := testutil.MakeAwsTestServer(integration.WithMocks(mock))
+
+	// The attachment URN embeds policyName(policy), so without dedup a
+	// repeated entry would collide.
+	const awsPolicy = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+	_, err := server.Construct(p.ConstructRequest{
+		Urn: testutil.AwsURN("Project"),
+		Inputs: testutil.ServicesMap(map[string]property.Value{
+			"app": property.New(property.NewMap(map[string]property.Value{
+				"image": property.New("myapp:latest"),
+				"policies": property.New(property.NewArray([]property.Value{
+					property.New(awsPolicy),
+					property.New(awsPolicy),
+				})),
+			})),
+		}),
+	})
+	require.NoError(t, err)
+
+	count := 0
+	for _, a := range attachments {
+		if a.Get("policyArn").AsString() == awsPolicy {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "duplicate x-defang-policies entries must be deduped")
+}

--- a/tests/aws/project_test.go
+++ b/tests/aws/project_test.go
@@ -206,3 +206,40 @@ func TestConstructAwsProjectAllResourcesAreChildren(t *testing.T) {
 
 	tracker.AssertAllDescendFrom(t, testutil.AwsURN("Project"))
 }
+
+func TestConstructAwsProjectSkipsForeignPolicies(t *testing.T) {
+	var attachments []property.Map
+	mock := &integration.MockResourceMonitor{
+		NewResourceF: func(args integration.MockResourceArgs) (string, property.Map, error) {
+			if string(args.TypeToken) == "aws:iam/rolePolicyAttachment:RolePolicyAttachment" {
+				attachments = append(attachments, args.Inputs)
+			}
+			return args.Name, args.Inputs, nil
+		},
+	}
+	server := testutil.MakeAwsTestServer(integration.WithMocks(mock))
+
+	const awsPolicy = "arn:aws:iam::123456789012:policy/deployer"
+	_, err := server.Construct(p.ConstructRequest{
+		Urn: testutil.AwsURN("Project"),
+		Inputs: testutil.ServicesMap(map[string]property.Value{
+			"app": property.New(property.NewMap(map[string]property.Value{
+				"image": property.New("myapp:latest"),
+				"policies": property.New(property.NewArray([]property.Value{
+					property.New(awsPolicy),
+					property.New("roles/run.developer"), // GCP entry: skipped on AWS
+				})),
+			})),
+		}),
+	})
+	require.NoError(t, err)
+
+	var arns []string
+	for _, a := range attachments {
+		arns = append(arns, a.Get("policyArn").AsString())
+	}
+	assert.Contains(t, arns, awsPolicy)
+	for _, arn := range arns {
+		assert.NotContains(t, arn, "run.developer", "GCP-qualified policy must be skipped on AWS")
+	}
+}

--- a/tests/aws/project_test.go
+++ b/tests/aws/project_test.go
@@ -211,7 +211,7 @@ func TestConstructAwsProjectRejectsForeignPolicies(t *testing.T) {
 	server := testutil.MakeAwsTestServer()
 
 	// No cross-cloud filtering: a GCP-qualified entry on an AWS deploy is a
-	// hard error pointing at per-stack .env variables instead.
+	// hard error pointing at per-stack variable values instead.
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.AwsURN("Project"),
 		Inputs: testutil.ServicesMap(map[string]property.Value{
@@ -240,7 +240,7 @@ func TestConstructAwsProjectPoliciesNormalized(t *testing.T) {
 	}
 	server := testutil.MakeAwsTestServer(integration.WithMocks(mock))
 
-	// One comma-separated entry — a single ${VAR} from .env carrying a
+	// One comma-separated entry — a single interpolated ${VAR} carrying a
 	// variable-length list — splits into individual attachments; an empty
 	// entry (a "${EXTRA:-}" the stack leaves unset) is dropped.
 	const policyA = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"

--- a/tests/aws/project_test.go
+++ b/tests/aws/project_test.go
@@ -207,7 +207,28 @@ func TestConstructAwsProjectAllResourcesAreChildren(t *testing.T) {
 	tracker.AssertAllDescendFrom(t, testutil.AwsURN("Project"))
 }
 
-func TestConstructAwsProjectSkipsForeignPolicies(t *testing.T) {
+func TestConstructAwsProjectRejectsForeignPolicies(t *testing.T) {
+	server := testutil.MakeAwsTestServer()
+
+	// No cross-cloud filtering: a GCP-qualified entry on an AWS deploy is a
+	// hard error pointing at per-stack .env variables instead.
+	_, err := server.Construct(p.ConstructRequest{
+		Urn: testutil.AwsURN("Project"),
+		Inputs: testutil.ServicesMap(map[string]property.Value{
+			"app": property.New(property.NewMap(map[string]property.Value{
+				"image": property.New("myapp:latest"),
+				"policies": property.New(property.NewArray([]property.Value{
+					property.New("arn:aws:iam::123456789012:policy/deployer"),
+					property.New("roles/run.developer"), // GCP entry: rejected on AWS
+				})),
+			})),
+		}),
+	})
+	require.ErrorContains(t, err, "gcp identifier")
+	require.ErrorContains(t, err, "targets aws")
+}
+
+func TestConstructAwsProjectPoliciesNormalized(t *testing.T) {
 	var attachments []property.Map
 	mock := &integration.MockResourceMonitor{
 		NewResourceF: func(args integration.MockResourceArgs) (string, property.Map, error) {
@@ -219,29 +240,31 @@ func TestConstructAwsProjectSkipsForeignPolicies(t *testing.T) {
 	}
 	server := testutil.MakeAwsTestServer(integration.WithMocks(mock))
 
-	const awsPolicy = "arn:aws:iam::123456789012:policy/deployer"
+	// One comma-separated entry — a single ${VAR} from .env carrying a
+	// variable-length list — splits into individual attachments; an empty
+	// entry (a "${EXTRA:-}" the stack leaves unset) is dropped.
+	const policyA = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+	const policyB = "arn:aws:iam::aws:policy/AmazonSQSFullAccess"
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.AwsURN("Project"),
 		Inputs: testutil.ServicesMap(map[string]property.Value{
 			"app": property.New(property.NewMap(map[string]property.Value{
 				"image": property.New("myapp:latest"),
 				"policies": property.New(property.NewArray([]property.Value{
-					property.New(awsPolicy),
-					property.New("roles/run.developer"), // GCP entry: skipped on AWS
+					property.New(policyA + "," + policyB),
+					property.New(""),
 				})),
 			})),
 		}),
 	})
 	require.NoError(t, err)
 
-	var arns []string
+	arns := make([]string, 0, len(attachments))
 	for _, a := range attachments {
 		arns = append(arns, a.Get("policyArn").AsString())
 	}
-	assert.Contains(t, arns, awsPolicy)
-	for _, arn := range arns {
-		assert.NotContains(t, arn, "run.developer", "GCP-qualified policy must be skipped on AWS")
-	}
+	assert.Contains(t, arns, policyA)
+	assert.Contains(t, arns, policyB)
 }
 
 func TestConstructAwsProjectDuplicatePoliciesDeduped(t *testing.T) {

--- a/tests/azure/project_test.go
+++ b/tests/azure/project_test.go
@@ -69,7 +69,7 @@ func TestConstructAzureProjectRejectsForeignPolicies(t *testing.T) {
 	server := testutil.MakeAzureTestServer()
 
 	// No cross-cloud filtering: an AWS-qualified entry on an Azure deploy is
-	// a validation error pointing at per-stack .env variables. Entries a
+	// a validation error pointing at per-stack variable values. Entries a
 	// stack leaves empty ("${EXTRA:-}") normalize away and don't trip it.
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.AzureURN("Project"),

--- a/tests/azure/project_test.go
+++ b/tests/azure/project_test.go
@@ -64,3 +64,46 @@ func TestConstructAzureProjectAllResourcesAreChildren(t *testing.T) {
 
 	tracker.AssertAllDescendFrom(t, testutil.AzureURN("Project"))
 }
+
+func TestConstructAzureProjectIgnoresForeignPolicies(t *testing.T) {
+	server := testutil.MakeAzureTestServer()
+
+	// AWS/GCP-qualified x-defang-policies entries don't apply on Azure and
+	// must not trip the unsupported error.
+	_, err := server.Construct(p.ConstructRequest{
+		Urn: testutil.AzureURN("Project"),
+		Inputs: testutil.ServicesMap(map[string]property.Value{
+			"app": property.New(property.NewMap(map[string]property.Value{
+				"image": property.New("myapp:latest"),
+				"ports": property.New(property.NewArray([]property.Value{testutil.IngressPort(8080)})),
+				"policies": property.New(property.NewArray([]property.Value{
+					property.New("arn:aws:iam::123456789012:policy/deployer"),
+					property.New("roles/run.developer"),
+				})),
+			})),
+		}),
+	})
+
+	require.NoError(t, err)
+}
+
+func TestConstructAzureProjectRejectsApplicablePolicies(t *testing.T) {
+	server := testutil.MakeAzureTestServer()
+
+	// A bare name applies on the current cloud, and Azure doesn't support
+	// policies yet.
+	_, err := server.Construct(p.ConstructRequest{
+		Urn: testutil.AzureURN("Project"),
+		Inputs: testutil.ServicesMap(map[string]property.Value{
+			"app": property.New(property.NewMap(map[string]property.Value{
+				"image": property.New("myapp:latest"),
+				"ports": property.New(property.NewArray([]property.Value{testutil.IngressPort(8080)})),
+				"policies": property.New(property.NewArray([]property.Value{
+					property.New("Contributor"),
+				})),
+			})),
+		}),
+	})
+
+	require.ErrorContains(t, err, "x-defang-policies is not supported on Azure")
+}

--- a/tests/azure/project_test.go
+++ b/tests/azure/project_test.go
@@ -65,11 +65,12 @@ func TestConstructAzureProjectAllResourcesAreChildren(t *testing.T) {
 	tracker.AssertAllDescendFrom(t, testutil.AzureURN("Project"))
 }
 
-func TestConstructAzureProjectIgnoresForeignPolicies(t *testing.T) {
+func TestConstructAzureProjectRejectsForeignPolicies(t *testing.T) {
 	server := testutil.MakeAzureTestServer()
 
-	// AWS/GCP-qualified x-defang-policies entries don't apply on Azure and
-	// must not trip the unsupported error.
+	// No cross-cloud filtering: an AWS-qualified entry on an Azure deploy is
+	// a validation error pointing at per-stack .env variables. Entries a
+	// stack leaves empty ("${EXTRA:-}") normalize away and don't trip it.
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.AzureURN("Project"),
 		Inputs: testutil.ServicesMap(map[string]property.Value{
@@ -78,7 +79,29 @@ func TestConstructAzureProjectIgnoresForeignPolicies(t *testing.T) {
 				"ports": property.New(property.NewArray([]property.Value{testutil.IngressPort(8080)})),
 				"policies": property.New(property.NewArray([]property.Value{
 					property.New("arn:aws:iam::123456789012:policy/deployer"),
-					property.New("roles/run.developer"),
+					property.New(""),
+				})),
+			})),
+		}),
+	})
+
+	require.ErrorContains(t, err, "aws identifier")
+	require.ErrorContains(t, err, "targets azure")
+}
+
+func TestConstructAzureProjectEmptyPoliciesDeploy(t *testing.T) {
+	server := testutil.MakeAzureTestServer()
+
+	// A policies list that normalizes to nothing (all entries are unset
+	// "${VAR:-}" substitutions) must not trip the unsupported error.
+	_, err := server.Construct(p.ConstructRequest{
+		Urn: testutil.AzureURN("Project"),
+		Inputs: testutil.ServicesMap(map[string]property.Value{
+			"app": property.New(property.NewMap(map[string]property.Value{
+				"image": property.New("myapp:latest"),
+				"ports": property.New(property.NewArray([]property.Value{testutil.IngressPort(8080)})),
+				"policies": property.New(property.NewArray([]property.Value{
+					property.New(""),
 				})),
 			})),
 		}),

--- a/tests/gcp/project_test.go
+++ b/tests/gcp/project_test.go
@@ -1167,6 +1167,7 @@ func TestConstructGcpProjectServiceWithPoliciesGrantsRoles(t *testing.T) {
 					property.New("roles/run.developer"),
 					property.New("roles/storage.objectAdmin"),
 					property.New("deployer"),
+					property.New("arn:aws:iam::123456789012:policy/deployer"), // AWS entry: skipped on GCP
 				})),
 			})),
 		}),
@@ -1185,6 +1186,11 @@ func TestConstructGcpProjectServiceWithPoliciesGrantsRoles(t *testing.T) {
 		return strings.HasSuffix(m.Get("role").AsString(), "/roles/deployer")
 	})
 	require.NotNil(t, custom, "expected a bare policy name to resolve to a project custom role")
+
+	foreign := findTypeWhere(*records, "gcp:projects/iAMMember:IAMMember", func(m property.Map) bool {
+		return strings.Contains(m.Get("role").AsString(), "arn:")
+	})
+	assert.Nil(t, foreign, "AWS-qualified policy must be skipped on GCP")
 }
 
 func TestConstructGcpProjectPolicyRepeatingPlatformRoleDoesNotCollide(t *testing.T) {

--- a/tests/gcp/project_test.go
+++ b/tests/gcp/project_test.go
@@ -1167,7 +1167,6 @@ func TestConstructGcpProjectServiceWithPoliciesGrantsRoles(t *testing.T) {
 					property.New("roles/run.developer"),
 					property.New("roles/storage.objectAdmin"),
 					property.New("deployer"),
-					property.New("arn:aws:iam::123456789012:policy/deployer"), // AWS entry: skipped on GCP
 				})),
 			})),
 		}),
@@ -1186,11 +1185,26 @@ func TestConstructGcpProjectServiceWithPoliciesGrantsRoles(t *testing.T) {
 		return strings.HasSuffix(m.Get("role").AsString(), "/roles/deployer")
 	})
 	require.NotNil(t, custom, "expected a bare policy name to resolve to a project custom role")
+}
 
-	foreign := findTypeWhere(*records, "gcp:projects/iAMMember:IAMMember", func(m property.Map) bool {
-		return strings.Contains(m.Get("role").AsString(), "arn:")
+func TestConstructGcpProjectRejectsForeignPolicies(t *testing.T) {
+	server := testutil.MakeGcpTestServer()
+
+	// No cross-cloud filtering: an AWS-qualified entry on a GCP deploy is a
+	// hard error pointing at per-stack .env variables instead.
+	_, err := server.Construct(p.ConstructRequest{
+		Urn: testutil.GcpURN("Project"),
+		Inputs: testutil.ServicesMap(map[string]property.Value{
+			"app": property.New(property.NewMap(map[string]property.Value{
+				"image": property.New("myapp:latest"),
+				"policies": property.New(property.NewArray([]property.Value{
+					property.New("arn:aws:iam::123456789012:policy/deployer"),
+				})),
+			})),
+		}),
 	})
-	assert.Nil(t, foreign, "AWS-qualified policy must be skipped on GCP")
+	require.ErrorContains(t, err, "aws identifier")
+	require.ErrorContains(t, err, "targets gcp")
 }
 
 func TestConstructGcpProjectPolicyRepeatingPlatformRoleDoesNotCollide(t *testing.T) {

--- a/tests/gcp/project_test.go
+++ b/tests/gcp/project_test.go
@@ -1191,7 +1191,7 @@ func TestConstructGcpProjectRejectsForeignPolicies(t *testing.T) {
 	server := testutil.MakeGcpTestServer()
 
 	// No cross-cloud filtering: an AWS-qualified entry on a GCP deploy is a
-	// hard error pointing at per-stack .env variables instead.
+	// hard error pointing at per-stack variable values instead.
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.GcpURN("Project"),
 		Inputs: testutil.ServicesMap(map[string]property.Value{

--- a/tests/gcp/project_test.go
+++ b/tests/gcp/project_test.go
@@ -1153,3 +1153,36 @@ func TestConstructProjectWithLLMPreservesExistingEnvVars(t *testing.T) {
 	assert.Equal(t, "my-custom-project", env.AsMap().Get("value").AsString(),
 		"enableLLM should not overwrite a pre-existing GOOGLE_VERTEX_PROJECT value")
 }
+
+func TestConstructGcpProjectServiceWithPoliciesGrantsRoles(t *testing.T) {
+	mock, records := collectResources()
+	server := testutil.MakeGcpTestServer(integration.WithMocks(mock))
+
+	_, err := server.Construct(p.ConstructRequest{
+		Urn: testutil.GcpURN("Project"),
+		Inputs: testutil.ServicesMap(map[string]property.Value{
+			"redeployer": property.New(property.NewMap(map[string]property.Value{
+				"image": property.New("defangio/cli:latest"),
+				"policies": property.New(property.NewArray([]property.Value{
+					property.New("roles/run.developer"),
+					property.New("roles/storage.objectAdmin"),
+					property.New("deployer"),
+				})),
+			})),
+		}),
+	})
+
+	require.NoError(t, err)
+
+	for _, role := range []string{"roles/run.developer", "roles/storage.objectAdmin"} {
+		found := findTypeWhere(*records, "gcp:projects/iAMMember:IAMMember", func(m property.Map) bool {
+			return m.Get("role").AsString() == role
+		})
+		require.NotNil(t, found, "expected an IAM member for x-defang-policies role %s", role)
+	}
+
+	custom := findTypeWhere(*records, "gcp:projects/iAMMember:IAMMember", func(m property.Map) bool {
+		return strings.HasSuffix(m.Get("role").AsString(), "/roles/deployer")
+	})
+	require.NotNil(t, custom, "expected a bare policy name to resolve to a project custom role")
+}

--- a/tests/gcp/project_test.go
+++ b/tests/gcp/project_test.go
@@ -1220,3 +1220,31 @@ func TestConstructGcpProjectPolicyRepeatingPlatformRoleDoesNotCollide(t *testing
 	})
 	assert.Equal(t, 2, members, "expected both the platform grant and the policy grant to be registered")
 }
+
+func TestConstructGcpProjectDuplicatePoliciesDeduped(t *testing.T) {
+	mock, records := collectResources()
+	server := testutil.MakeGcpTestServer(integration.WithMocks(mock))
+
+	// Repeated entries resolve to the same role; the member URN embeds the
+	// role, so without dedup the second entry would collide.
+	_, err := server.Construct(p.ConstructRequest{
+		Urn: testutil.GcpURN("Project"),
+		Inputs: testutil.ServicesMap(map[string]property.Value{
+			"app": property.New(property.NewMap(map[string]property.Value{
+				"image": property.New("myapp:latest"),
+				"ports": property.New(property.NewArray([]property.Value{testutil.IngressPort(8080)})),
+				"policies": property.New(property.NewArray([]property.Value{
+					property.New("roles/run.developer"),
+					property.New("roles/run.developer"),
+				})),
+			})),
+		}),
+	})
+
+	require.NoError(t, err)
+
+	members := countTypeWhere(*records, "gcp:projects/iAMMember:IAMMember", func(m property.Map) bool {
+		return m.Get("role").AsString() == "roles/run.developer"
+	})
+	assert.Equal(t, 1, members, "duplicate x-defang-policies entries must be deduped")
+}

--- a/tests/gcp/project_test.go
+++ b/tests/gcp/project_test.go
@@ -1186,3 +1186,31 @@ func TestConstructGcpProjectServiceWithPoliciesGrantsRoles(t *testing.T) {
 	})
 	require.NotNil(t, custom, "expected a bare policy name to resolve to a project custom role")
 }
+
+func TestConstructGcpProjectPolicyRepeatingPlatformRoleDoesNotCollide(t *testing.T) {
+	mock, records := collectResources()
+	server := testutil.MakeGcpTestServer(integration.WithMocks(mock))
+
+	// A portless worker runs on Compute Engine, which grants a platform role
+	// set (logging, monitoring, ...) on the same service account. Repeating
+	// one of those roles in x-defang-policies must not abort the deployment
+	// with a duplicate URN.
+	_, err := server.Construct(p.ConstructRequest{
+		Urn: testutil.GcpURN("Project"),
+		Inputs: testutil.ServicesMap(map[string]property.Value{
+			"worker": property.New(property.NewMap(map[string]property.Value{
+				"image": property.New("myapp:worker"),
+				"policies": property.New(property.NewArray([]property.Value{
+					property.New("roles/logging.logWriter"),
+				})),
+			})),
+		}),
+	})
+
+	require.NoError(t, err)
+
+	members := countTypeWhere(*records, "gcp:projects/iAMMember:IAMMember", func(m property.Map) bool {
+		return m.Get("role").AsString() == "roles/logging.logWriter"
+	})
+	assert.Equal(t, 2, members, "expected both the platform grant and the policy grant to be registered")
+}


### PR DESCRIPTION
Reworked per review: **no cross-cloud filtering** — multi-cloud compose files parameterize `x-defang-policies` with `${VAR}` entries. Variable interpolation is a **CLI concern**: it happens at compose-load time, before the project ever reaches the CD/providers. This provider only enforces its own contract — entries must be literal on arrival — and stays agnostic about where the values come from. (On the CLI side, DefangLabs/defang#2187 adds the natural companion: `.env` → `.env.<provider>` → `.env.<stack>` layering, so per-stack values need no flags. But nothing here depends on that mechanism, and it can evolve independently.)

`defang config` is deliberately **not** supported for policies: an entry still containing `${…}` when it reaches the provider is a hard error.

~~Stacked on PR 350~~ — **PR 350 has since merged**, so this PR now stands alone. The reworked implementation is commits `2d7a9aa` + `b0f9b6d`; `75d89a1` (the original filter) plus fixups are superseded. The effective delta on top of merged main is small: `provider/compose/policies.go` (+tests), `PolicyList` in `types.go`, validation call sites in the three providers, and provider tests.

## Semantics

```yaml
# fixed slots, per-stack optional extras
x-defang-policies:
  - "${BASE_POLICY}"
  - "${EXTRA_POLICY:-}"   # unset in this stack → dropped

# variable length: one variable carries the whole list
x-defang-policies: ${POLICIES}
# e.g. POLICIES=arn:aws:iam::aws:policy/A,arn:aws:iam::aws:policy/B
```

- **Normalization** (`NormalizePolicies`): comma-separated identifiers split, whitespace trimmed, empty entries dropped. The extension accepts a scalar or a list (`PolicyList`); the Pulumi schema is unchanged (still `array<string>`, verified via `make schema` — no diff).
- **Validation** (`ValidatePolicies`) replaces filtering: an unresolved `${…}` errors (interpolate at compose-load time; `defang config` unsupported); an identifier whose syntax belongs to a different cloud errors with the `${VAR}` hint. This also fixes the pre-existing silent mangling of a GCP `roles/…` entry into `arn:aws:iam::<acct>:policy/roles/…` on AWS.
- **Azure**: applicable entries still hit the unsupported error; a policies list that normalizes to nothing (all `"${VAR:-}"` unset) deploys fine.

## Tests

Classifier/normalize/validate unit tests, `PolicyList` scalar+list YAML decoding (incl. through the full `ServiceConfig` decode), and provider tests on all three clouds: reject-foreign (AWS/GCP/Azure), comma-split + empty-drop (AWS), empty-normalized deploys (Azure), plus the pre-existing dedup/custom-role/platform-role tests unchanged. `make lint` clean; unit + provider (`-short`) + cd (`-race`) suites all pass.
