### PR TITLE
feat(aws): recipe-gated CloudWatch alarms for managed databases

### DIFF
--- a/provider/cmd/pulumi-resource-defang-aws/schema.json
+++ b/provider/cmd/pulumi-resource-defang-aws/schema.json
@@ -34,6 +34,9 @@
   "types": {
     "defang-aws:aws:SharedInfra": {
       "properties": {
+        "alarmTopicArn": {
+          "type": "string"
+        },
         "clusterArn": {
           "type": "string"
         },
@@ -375,6 +378,9 @@
     },
     "defang-aws:index:AWSConfig": {
       "properties": {
+        "alarmTopicArn": {
+          "type": "string"
+        },
         "albCertificateArn": {
           "type": "string"
         },

--- a/provider/defangaws/aws/alarms.go
+++ b/provider/defangaws/aws/alarms.go
@@ -25,15 +25,16 @@ const (
 )
 
 // createDBAlarms creates CloudWatch alarms for a managed database when the
-// alarms recipe is enabled; a no-op under the affordable default. When the
-// alarm-topic-arn recipe is set, each alarm notifies that SNS topic on both
-// the ALARM and OK transitions.
+// alarms recipe is enabled; a no-op under the affordable default. When
+// alarmTopicArn is non-nil, each alarm notifies that SNS topic on both the
+// ALARM and OK transitions.
 func createDBAlarms(
 	ctx *pulumi.Context,
 	name string,
 	namespace string,
 	dimensions pulumi.StringMapInput,
 	tags pulumi.StringMapInput,
+	alarmTopicArn pulumi.StringInput,
 	alarms []dbAlarm,
 	opts ...pulumi.ResourceOption,
 ) error {
@@ -42,8 +43,8 @@ func createDBAlarms(
 	}
 
 	var actions pulumi.ArrayInput
-	if arn := AlarmTopicArn.Get(ctx); arn != "" {
-		actions = pulumi.Array{pulumi.String(arn)}
+	if alarmTopicArn != nil {
+		actions = pulumi.Array{alarmTopicArn}
 	}
 
 	for _, alarm := range alarms {

--- a/provider/defangaws/aws/alarms.go
+++ b/provider/defangaws/aws/alarms.go
@@ -1,0 +1,67 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/cloudwatch"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// dbAlarm describes one CloudWatch metric alarm attached to a managed database.
+type dbAlarm struct {
+	suffix             string // appended to the resource name, e.g. "memory-usage"
+	metricName         string
+	comparisonOperator string
+	threshold          float64
+	statistic          string
+	description        string
+}
+
+// Shared alarm cadence matching the pre-migration fabric alarms in defang-mvp
+// pulumi/ecs/alarms.ts: 2 five-minute periods.
+const (
+	alarmPeriod            = 300
+	alarmEvaluationPeriods = 2
+)
+
+// createDBAlarms creates CloudWatch alarms for a managed database when the
+// alarms recipe is enabled; a no-op under the affordable default. When the
+// alarm-topic-arn recipe is set, each alarm notifies that SNS topic on both
+// the ALARM and OK transitions.
+func createDBAlarms(
+	ctx *pulumi.Context,
+	name string,
+	namespace string,
+	dimensions pulumi.StringMapInput,
+	alarms []dbAlarm,
+	opts ...pulumi.ResourceOption,
+) error {
+	if !Alarms.Get(ctx) {
+		return nil
+	}
+
+	var actions pulumi.ArrayInput
+	if arn := AlarmTopicArn.Get(ctx); arn != "" {
+		actions = pulumi.Array{pulumi.String(arn)}
+	}
+
+	for _, alarm := range alarms {
+		_, err := cloudwatch.NewMetricAlarm(ctx, name+"-"+alarm.suffix, &cloudwatch.MetricAlarmArgs{
+			AlarmDescription:   pulumi.String(alarm.description),
+			AlarmActions:       actions,
+			OkActions:          actions,
+			ComparisonOperator: pulumi.String(alarm.comparisonOperator),
+			Dimensions:         dimensions,
+			EvaluationPeriods:  pulumi.Int(alarmEvaluationPeriods),
+			MetricName:         pulumi.String(alarm.metricName),
+			Namespace:          pulumi.String(namespace),
+			Period:             pulumi.Int(alarmPeriod),
+			Statistic:          pulumi.String(alarm.statistic),
+			Threshold:          pulumi.Float64(alarm.threshold),
+		}, opts...)
+		if err != nil {
+			return fmt.Errorf("creating %s alarm: %w", alarm.suffix, err)
+		}
+	}
+	return nil
+}

--- a/provider/defangaws/aws/alarms.go
+++ b/provider/defangaws/aws/alarms.go
@@ -33,6 +33,7 @@ func createDBAlarms(
 	name string,
 	namespace string,
 	dimensions pulumi.StringMapInput,
+	tags pulumi.StringMapInput,
 	alarms []dbAlarm,
 	opts ...pulumi.ResourceOption,
 ) error {
@@ -57,6 +58,7 @@ func createDBAlarms(
 			Namespace:          pulumi.String(namespace),
 			Period:             pulumi.Int(alarmPeriod),
 			Statistic:          pulumi.String(alarm.statistic),
+			Tags:               tags,
 			Threshold:          pulumi.Float64(alarm.threshold),
 		}, opts...)
 		if err != nil {

--- a/provider/defangaws/aws/alarms_test.go
+++ b/provider/defangaws/aws/alarms_test.go
@@ -49,7 +49,8 @@ func runCreateDBAlarms(t *testing.T) []pulumi.MockResourceArgs {
 	var created []pulumi.MockResourceArgs
 	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
 		return createDBAlarms(ctx, "cache", "AWS/MemoryDB",
-			pulumi.StringMap{"ClusterName": pulumi.String("cache-abc")}, testAlarms)
+			pulumi.StringMap{"ClusterName": pulumi.String("cache-abc")},
+			pulumi.StringMap{"defang:service": pulumi.String("cache")}, testAlarms)
 	}, pulumi.WithMocks("myproj", "mystack", alarmMocks{alarms: &created}))
 	require.NoError(t, err)
 	return created
@@ -75,6 +76,7 @@ func TestCreateDBAlarms_Enabled(t *testing.T) {
 	assert.InDelta(t, 300, memory["period"].NumberValue(), 0)
 	assert.InDelta(t, 2, memory["evaluationPeriods"].NumberValue(), 0)
 	assert.Equal(t, "cache-abc", memory["dimensions"].ObjectValue()["ClusterName"].StringValue())
+	assert.Equal(t, "cache", memory["tags"].ObjectValue()["defang:service"].StringValue())
 	assert.False(t, memory.HasValue("alarmActions"), "no actions without alarm-topic-arn")
 
 	assert.Equal(t, "cache-cpu-usage", created[1].Name)

--- a/provider/defangaws/aws/alarms_test.go
+++ b/provider/defangaws/aws/alarms_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -9,14 +10,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// alarmMocks records every MetricAlarm registration.
+// alarmMocks records every MetricAlarm registration by resource name.
+// Registrations arrive on concurrent goroutines, so guard with a mutex and
+// don't assume ordering.
 type alarmMocks struct {
-	alarms *[]pulumi.MockResourceArgs
+	mu     *sync.Mutex
+	alarms map[string]resource.PropertyMap
 }
 
 func (m alarmMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
 	if args.TypeToken == "aws:cloudwatch/metricAlarm:MetricAlarm" {
-		*m.alarms = append(*m.alarms, args)
+		m.mu.Lock()
+		m.alarms[args.Name] = args.Inputs
+		m.mu.Unlock()
 	}
 	return args.Name + "_id", args.Inputs, nil
 }
@@ -44,14 +50,14 @@ var testAlarms = []dbAlarm{
 	},
 }
 
-func runCreateDBAlarms(t *testing.T) []pulumi.MockResourceArgs {
+func runCreateDBAlarms(t *testing.T) map[string]resource.PropertyMap {
 	t.Helper()
-	var created []pulumi.MockResourceArgs
+	created := map[string]resource.PropertyMap{}
 	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
 		return createDBAlarms(ctx, "cache", "AWS/MemoryDB",
 			pulumi.StringMap{"ClusterName": pulumi.String("cache-abc")},
 			pulumi.StringMap{"defang:service": pulumi.String("cache")}, testAlarms)
-	}, pulumi.WithMocks("myproj", "mystack", alarmMocks{alarms: &created}))
+	}, pulumi.WithMocks("myproj", "mystack", alarmMocks{mu: &sync.Mutex{}, alarms: created}))
 	require.NoError(t, err)
 	return created
 }
@@ -66,8 +72,8 @@ func TestCreateDBAlarms_Enabled(t *testing.T) {
 	created := runCreateDBAlarms(t)
 	require.Len(t, created, 2)
 
-	memory := created[0].Inputs
-	assert.Equal(t, "cache-memory-usage", created[0].Name)
+	memory, ok := created["cache-memory-usage"]
+	require.True(t, ok)
 	assert.Equal(t, "AWS/MemoryDB", memory["namespace"].StringValue())
 	assert.Equal(t, "DatabaseCapacityUsagePercentage", memory["metricName"].StringValue())
 	assert.Equal(t, "GreaterThanThreshold", memory["comparisonOperator"].StringValue())
@@ -79,8 +85,9 @@ func TestCreateDBAlarms_Enabled(t *testing.T) {
 	assert.Equal(t, "cache", memory["tags"].ObjectValue()["defang:service"].StringValue())
 	assert.False(t, memory.HasValue("alarmActions"), "no actions without alarm-topic-arn")
 
-	assert.Equal(t, "cache-cpu-usage", created[1].Name)
-	assert.Equal(t, "CPUUtilization", created[1].Inputs["metricName"].StringValue())
+	cpu, ok := created["cache-cpu-usage"]
+	require.True(t, ok)
+	assert.Equal(t, "CPUUtilization", cpu["metricName"].StringValue())
 }
 
 func TestCreateDBAlarms_TopicArn(t *testing.T) {
@@ -89,12 +96,12 @@ func TestCreateDBAlarms_TopicArn(t *testing.T) {
 	created := runCreateDBAlarms(t)
 	require.Len(t, created, 2)
 
-	for _, alarm := range created {
-		alarmActions := alarm.Inputs["alarmActions"].ArrayValue()
-		require.Len(t, alarmActions, 1)
-		assert.Equal(t, arn, alarmActions[0].StringValue())
-		okActions := alarm.Inputs["okActions"].ArrayValue()
-		require.Len(t, okActions, 1)
-		assert.Equal(t, arn, okActions[0].StringValue())
+	for name, alarm := range created {
+		alarmActions := alarm["alarmActions"].ArrayValue()
+		require.Len(t, alarmActions, 1, name)
+		assert.Equal(t, arn, alarmActions[0].StringValue(), name)
+		okActions := alarm["okActions"].ArrayValue()
+		require.Len(t, okActions, 1, name)
+		assert.Equal(t, arn, okActions[0].StringValue(), name)
 	}
 }

--- a/provider/defangaws/aws/alarms_test.go
+++ b/provider/defangaws/aws/alarms_test.go
@@ -50,26 +50,26 @@ var testAlarms = []dbAlarm{
 	},
 }
 
-func runCreateDBAlarms(t *testing.T) map[string]resource.PropertyMap {
+func runCreateDBAlarms(t *testing.T, alarmTopicArn pulumi.StringInput) map[string]resource.PropertyMap {
 	t.Helper()
 	created := map[string]resource.PropertyMap{}
 	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
 		return createDBAlarms(ctx, "cache", "AWS/MemoryDB",
 			pulumi.StringMap{"ClusterName": pulumi.String("cache-abc")},
-			pulumi.StringMap{"defang:service": pulumi.String("cache")}, testAlarms)
+			pulumi.StringMap{"defang:service": pulumi.String("cache")}, alarmTopicArn, testAlarms)
 	}, pulumi.WithMocks("myproj", "mystack", alarmMocks{mu: &sync.Mutex{}, alarms: created}))
 	require.NoError(t, err)
 	return created
 }
 
 func TestCreateDBAlarms_AffordableDefaultCreatesNone(t *testing.T) {
-	created := runCreateDBAlarms(t)
+	created := runCreateDBAlarms(t, nil)
 	assert.Empty(t, created, "affordable default must not create alarms")
 }
 
 func TestCreateDBAlarms_Enabled(t *testing.T) {
 	t.Setenv("PULUMI_CONFIG", `{"defang-aws:alarms": "true"}`)
-	created := runCreateDBAlarms(t)
+	created := runCreateDBAlarms(t, nil)
 	require.Len(t, created, 2)
 
 	memory, ok := created["cache-memory-usage"]
@@ -83,7 +83,7 @@ func TestCreateDBAlarms_Enabled(t *testing.T) {
 	assert.InDelta(t, 2, memory["evaluationPeriods"].NumberValue(), 0)
 	assert.Equal(t, "cache-abc", memory["dimensions"].ObjectValue()["ClusterName"].StringValue())
 	assert.Equal(t, "cache", memory["tags"].ObjectValue()["defang:service"].StringValue())
-	assert.False(t, memory.HasValue("alarmActions"), "no actions without alarm-topic-arn")
+	assert.False(t, memory.HasValue("alarmActions"), "no actions without an alarm topic input")
 
 	cpu, ok := created["cache-cpu-usage"]
 	require.True(t, ok)
@@ -92,8 +92,8 @@ func TestCreateDBAlarms_Enabled(t *testing.T) {
 
 func TestCreateDBAlarms_TopicArn(t *testing.T) {
 	arn := "arn:aws:sns:us-west-2:123456789012:slackbot-alarms"
-	t.Setenv("PULUMI_CONFIG", `{"defang-aws:alarms": "true", "defang-aws:alarm-topic-arn": "`+arn+`"}`)
-	created := runCreateDBAlarms(t)
+	t.Setenv("PULUMI_CONFIG", `{"defang-aws:alarms": "true"}`)
+	created := runCreateDBAlarms(t, pulumi.String(arn))
 	require.Len(t, created, 2)
 
 	for name, alarm := range created {

--- a/provider/defangaws/aws/alarms_test.go
+++ b/provider/defangaws/aws/alarms_test.go
@@ -1,0 +1,98 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// alarmMocks records every MetricAlarm registration.
+type alarmMocks struct {
+	alarms *[]pulumi.MockResourceArgs
+}
+
+func (m alarmMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+	if args.TypeToken == "aws:cloudwatch/metricAlarm:MetricAlarm" {
+		*m.alarms = append(*m.alarms, args)
+	}
+	return args.Name + "_id", args.Inputs, nil
+}
+
+func (m alarmMocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
+	return args.Args, nil
+}
+
+var testAlarms = []dbAlarm{
+	{
+		suffix:             "memory-usage",
+		metricName:         "DatabaseCapacityUsagePercentage",
+		comparisonOperator: "GreaterThanThreshold",
+		threshold:          80,
+		statistic:          "Maximum",
+		description:        "memory usage has exceeded 80%",
+	},
+	{
+		suffix:             "cpu-usage",
+		metricName:         "CPUUtilization",
+		comparisonOperator: "GreaterThanThreshold",
+		threshold:          80,
+		statistic:          "Maximum",
+		description:        "CPU usage has exceeded 80%",
+	},
+}
+
+func runCreateDBAlarms(t *testing.T) []pulumi.MockResourceArgs {
+	t.Helper()
+	var created []pulumi.MockResourceArgs
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		return createDBAlarms(ctx, "cache", "AWS/MemoryDB",
+			pulumi.StringMap{"ClusterName": pulumi.String("cache-abc")}, testAlarms)
+	}, pulumi.WithMocks("myproj", "mystack", alarmMocks{alarms: &created}))
+	require.NoError(t, err)
+	return created
+}
+
+func TestCreateDBAlarms_AffordableDefaultCreatesNone(t *testing.T) {
+	created := runCreateDBAlarms(t)
+	assert.Empty(t, created, "affordable default must not create alarms")
+}
+
+func TestCreateDBAlarms_Enabled(t *testing.T) {
+	t.Setenv("PULUMI_CONFIG", `{"defang-aws:alarms": "true"}`)
+	created := runCreateDBAlarms(t)
+	require.Len(t, created, 2)
+
+	memory := created[0].Inputs
+	assert.Equal(t, "cache-memory-usage", created[0].Name)
+	assert.Equal(t, "AWS/MemoryDB", memory["namespace"].StringValue())
+	assert.Equal(t, "DatabaseCapacityUsagePercentage", memory["metricName"].StringValue())
+	assert.Equal(t, "GreaterThanThreshold", memory["comparisonOperator"].StringValue())
+	assert.InDelta(t, 80, memory["threshold"].NumberValue(), 0)
+	assert.Equal(t, "Maximum", memory["statistic"].StringValue())
+	assert.InDelta(t, 300, memory["period"].NumberValue(), 0)
+	assert.InDelta(t, 2, memory["evaluationPeriods"].NumberValue(), 0)
+	assert.Equal(t, "cache-abc", memory["dimensions"].ObjectValue()["ClusterName"].StringValue())
+	assert.False(t, memory.HasValue("alarmActions"), "no actions without alarm-topic-arn")
+
+	assert.Equal(t, "cache-cpu-usage", created[1].Name)
+	assert.Equal(t, "CPUUtilization", created[1].Inputs["metricName"].StringValue())
+}
+
+func TestCreateDBAlarms_TopicArn(t *testing.T) {
+	arn := "arn:aws:sns:us-west-2:123456789012:slackbot-alarms"
+	t.Setenv("PULUMI_CONFIG", `{"defang-aws:alarms": "true", "defang-aws:alarm-topic-arn": "`+arn+`"}`)
+	created := runCreateDBAlarms(t)
+	require.Len(t, created, 2)
+
+	for _, alarm := range created {
+		alarmActions := alarm.Inputs["alarmActions"].ArrayValue()
+		require.Len(t, alarmActions, 1)
+		assert.Equal(t, arn, alarmActions[0].StringValue())
+		okActions := alarm.Inputs["okActions"].ArrayValue()
+		require.Len(t, okActions, 1)
+		assert.Equal(t, arn, okActions[0].StringValue())
+	}
+}

--- a/provider/defangaws/aws/config.go
+++ b/provider/defangaws/aws/config.go
@@ -12,6 +12,12 @@ type AWSConfig struct {
 	// account.
 	DnsRoleArn pulumi.StringInput `pulumi:"dnsRoleArn,optional" yaml:"dnsRoleArn,omitempty"`
 
+	// AlarmTopicArn is a pre-existing SNS topic attached as the alarm/OK
+	// action of every provider-created database alarm (created when the
+	// alarms recipe is enabled). Unset means alarms are still created
+	// (console-visible) but don't notify.
+	AlarmTopicArn pulumi.StringInput `pulumi:"alarmTopicArn,optional" yaml:"alarmTopicArn,omitempty"`
+
 	// AlbCertificateArn is the default certificate for the ALB's HTTPS
 	// listener when the project doesn't manage its own domain (i.e. no
 	// projectDomain/publicZoneId). Services can still bring their own domain

--- a/provider/defangaws/aws/ecs.go
+++ b/provider/defangaws/aws/ecs.go
@@ -57,11 +57,14 @@ type SharedInfra struct {
 	ProjectDomain    string
 	ZoneId           pulumi.StringPtrInput // Route53 zone ID for public DNS records (empty if no public DNS)
 	// shared "private SG" — attached to all services, no ingress rules
-	PrivateSgID    pulumi.StringPtrInput `pulumi:"privateSgID,optional"`
-	AlbSG          *ec2.SecurityGroup    // nil if no ALB
-	HttpListener   *lb.Listener          // nil if no ALB
-	HttpsListener  *lb.Listener          // nil if no ALB
-	Alb            *lb.LoadBalancer      // nil if no ALB
+	PrivateSgID pulumi.StringPtrInput `pulumi:"privateSgID,optional"`
+	// SNS topic notified by provider-created database alarms (see the alarms
+	// recipe); nil means the alarms don't notify.
+	AlarmTopicArn  pulumi.StringInput `pulumi:"alarmTopicArn,optional"`
+	AlbSG          *ec2.SecurityGroup // nil if no ALB
+	HttpListener   *lb.Listener       // nil if no ALB
+	HttpsListener  *lb.Listener       // nil if no ALB
+	Alb            *lb.LoadBalancer   // nil if no ALB
 	Region         string
 	BuildInfra     *BuildInfra       // nil if no builds needed
 	PublicEcrCache *PullThroughCache // ECR public pull-through cache

--- a/provider/defangaws/aws/elasticache.go
+++ b/provider/defangaws/aws/elasticache.go
@@ -213,6 +213,7 @@ func CreateElasticache(
 	vpcID pulumi.StringInput,
 	privateSubnetIDs pulumi.StringArrayInput,
 	privateSgID pulumi.StringPtrInput,
+	alarmTopicArn pulumi.StringInput,
 	deps []pulumi.Resource,
 	opts ...pulumi.ResourceOption,
 ) (*ElasticacheResult, error) {
@@ -361,7 +362,7 @@ func CreateElasticache(
 	// on multi-vCPU nodes.
 	for i := range replicas {
 		err = createDBAlarms(ctx, fmt.Sprintf("%s-%03d", serviceName, i+1), "AWS/ElastiCache",
-			pulumi.StringMap{"CacheClusterId": rg.MemberClusters.Index(pulumi.Int(i))}, tags, []dbAlarm{
+			pulumi.StringMap{"CacheClusterId": rg.MemberClusters.Index(pulumi.Int(i))}, tags, alarmTopicArn, []dbAlarm{
 				{
 					suffix:             "memory-usage",
 					metricName:         "DatabaseMemoryUsagePercentage",

--- a/provider/defangaws/aws/elasticache.go
+++ b/provider/defangaws/aws/elasticache.go
@@ -353,12 +353,15 @@ func CreateElasticache(
 		return nil, fmt.Errorf("creating ElastiCache replication group: %w", err)
 	}
 
-	// ElastiCache metrics are per member cache cluster ("<rg-id>-00N"), not per
-	// replication group. EngineCPUUtilization tracks the (single) Redis thread,
-	// which saturates well before host CPUUtilization on multi-vCPU nodes.
-	for i := int32(1); i <= replicas; i++ {
-		err = createDBAlarms(ctx, fmt.Sprintf("%s-%03d", serviceName, i), "AWS/ElastiCache",
-			pulumi.StringMap{"CacheClusterId": pulumi.Sprintf("%s-%03d", rg.ReplicationGroupId, i)}, []dbAlarm{
+	// ElastiCache metrics are per member cache cluster, not per replication
+	// group. MemberClusters carries the actual member IDs — their naming
+	// differs between cluster-mode-disabled ("<rg-id>-00N") and "compatible"
+	// groups, so don't reconstruct them. EngineCPUUtilization tracks the
+	// (single) Redis thread, which saturates well before host CPUUtilization
+	// on multi-vCPU nodes.
+	for i := range replicas {
+		err = createDBAlarms(ctx, fmt.Sprintf("%s-%03d", serviceName, i+1), "AWS/ElastiCache",
+			pulumi.StringMap{"CacheClusterId": rg.MemberClusters.Index(pulumi.Int(i))}, tags, []dbAlarm{
 				{
 					suffix:             "memory-usage",
 					metricName:         "DatabaseMemoryUsagePercentage",

--- a/provider/defangaws/aws/elasticache.go
+++ b/provider/defangaws/aws/elasticache.go
@@ -353,6 +353,34 @@ func CreateElasticache(
 		return nil, fmt.Errorf("creating ElastiCache replication group: %w", err)
 	}
 
+	// ElastiCache metrics are per member cache cluster ("<rg-id>-00N"), not per
+	// replication group. EngineCPUUtilization tracks the (single) Redis thread,
+	// which saturates well before host CPUUtilization on multi-vCPU nodes.
+	for i := int32(1); i <= replicas; i++ {
+		err = createDBAlarms(ctx, fmt.Sprintf("%s-%03d", serviceName, i), "AWS/ElastiCache",
+			pulumi.StringMap{"CacheClusterId": pulumi.Sprintf("%s-%03d", rg.ReplicationGroupId, i)}, []dbAlarm{
+				{
+					suffix:             "memory-usage",
+					metricName:         "DatabaseMemoryUsagePercentage",
+					comparisonOperator: "GreaterThanThreshold",
+					threshold:          80,
+					statistic:          "Maximum",
+					description:        "ElastiCache memory usage has exceeded 80%",
+				},
+				{
+					suffix:             "cpu-usage",
+					metricName:         "EngineCPUUtilization",
+					comparisonOperator: "GreaterThanThreshold",
+					threshold:          80,
+					statistic:          "Maximum",
+					description:        "ElastiCache engine CPU usage has exceeded 80%",
+				},
+			}, opts...)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// Use configuration endpoint (cluster mode enabled) if available, else primary endpoint.
 	address := pulumi.All(rg.ConfigurationEndpointAddress, rg.PrimaryEndpointAddress).
 		ApplyT(

--- a/provider/defangaws/aws/infra.go
+++ b/provider/defangaws/aws/infra.go
@@ -93,6 +93,11 @@ func CreateProjectInfra(
 		return nil, fmt.Errorf("attaching pull-through cache policy: %w", err)
 	}
 
+	var alarmTopicArn pulumi.StringInput
+	if awsConfig != nil {
+		alarmTopicArn = awsConfig.AlarmTopicArn
+	}
+
 	// Role-assuming provider for public Route53 operations in another account
 	var dnsProvider pulumi.ProviderResource
 	if awsConfig != nil && awsConfig.DnsRoleArn != nil {
@@ -199,6 +204,7 @@ func CreateProjectInfra(
 		PrivateDomain:    net.PrivateDomain,
 		ProjectDomain:    projectDomain,
 		PrivateSgID:      privateSg.ID(),
+		AlarmTopicArn:    alarmTopicArn,
 		SkipNatGW:        !net.UseNatGW,
 		Region:           region.Region,
 		BuildInfra:       imgInfra,

--- a/provider/defangaws/aws/memorydb.go
+++ b/provider/defangaws/aws/memorydb.go
@@ -90,6 +90,7 @@ func CreateMemoryDB(
 	vpcID pulumi.StringInput,
 	privateSubnetIDs pulumi.StringArrayInput,
 	privateSgID pulumi.StringPtrInput,
+	alarmTopicArn pulumi.StringInput,
 	deps []pulumi.Resource,
 	opts ...pulumi.ResourceOption,
 ) (*ElasticacheResult, error) {
@@ -231,7 +232,7 @@ func CreateMemoryDB(
 	}
 
 	err = createDBAlarms(ctx, serviceName, "AWS/MemoryDB",
-		pulumi.StringMap{"ClusterName": cluster.Name}, tags, []dbAlarm{
+		pulumi.StringMap{"ClusterName": cluster.Name}, tags, alarmTopicArn, []dbAlarm{
 			{
 				suffix:             "memory-usage",
 				metricName:         "DatabaseCapacityUsagePercentage",

--- a/provider/defangaws/aws/memorydb.go
+++ b/provider/defangaws/aws/memorydb.go
@@ -231,7 +231,7 @@ func CreateMemoryDB(
 	}
 
 	err = createDBAlarms(ctx, serviceName, "AWS/MemoryDB",
-		pulumi.StringMap{"ClusterName": cluster.Name}, []dbAlarm{
+		pulumi.StringMap{"ClusterName": cluster.Name}, tags, []dbAlarm{
 			{
 				suffix:             "memory-usage",
 				metricName:         "DatabaseCapacityUsagePercentage",

--- a/provider/defangaws/aws/memorydb.go
+++ b/provider/defangaws/aws/memorydb.go
@@ -230,6 +230,29 @@ func CreateMemoryDB(
 		return nil, fmt.Errorf("creating MemoryDB cluster: %w", err)
 	}
 
+	err = createDBAlarms(ctx, serviceName, "AWS/MemoryDB",
+		pulumi.StringMap{"ClusterName": cluster.Name}, []dbAlarm{
+			{
+				suffix:             "memory-usage",
+				metricName:         "DatabaseCapacityUsagePercentage",
+				comparisonOperator: "GreaterThanThreshold",
+				threshold:          80,
+				statistic:          "Maximum",
+				description:        "MemoryDB memory usage has exceeded 80%",
+			},
+			{
+				suffix:             "cpu-usage",
+				metricName:         "CPUUtilization",
+				comparisonOperator: "GreaterThanThreshold",
+				threshold:          80,
+				statistic:          "Maximum",
+				description:        "MemoryDB CPU usage has exceeded 80%",
+			},
+		}, opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	address := cluster.ClusterEndpoints.Index(pulumi.Int(0)).Address().Elem()
 
 	return &ElasticacheResult{Address: address, ClusterID: cluster.Name.ToStringOutput()}, nil

--- a/provider/defangaws/aws/rds.go
+++ b/provider/defangaws/aws/rds.go
@@ -296,7 +296,7 @@ func CreateRDS(
 	// autoscaling, so it only fires when autoscaling can't keep up or the
 	// maxAllocatedStorage cap is reached.
 	err = createDBAlarms(ctx, serviceName, "AWS/RDS",
-		pulumi.StringMap{"DBInstanceIdentifier": instance.Identifier}, []dbAlarm{
+		pulumi.StringMap{"DBInstanceIdentifier": instance.Identifier}, tags, []dbAlarm{
 			{
 				suffix:             "cpu-usage",
 				metricName:         "CPUUtilization",

--- a/provider/defangaws/aws/rds.go
+++ b/provider/defangaws/aws/rds.go
@@ -292,6 +292,32 @@ func CreateRDS(
 		return nil, fmt.Errorf("creating RDS instance: %w", err)
 	}
 
+	// Free-storage threshold sits below the 10%-free trigger of RDS storage
+	// autoscaling, so it only fires when autoscaling can't keep up or the
+	// maxAllocatedStorage cap is reached.
+	err = createDBAlarms(ctx, serviceName, "AWS/RDS",
+		pulumi.StringMap{"DBInstanceIdentifier": instance.Identifier}, []dbAlarm{
+			{
+				suffix:             "cpu-usage",
+				metricName:         "CPUUtilization",
+				comparisonOperator: "GreaterThanThreshold",
+				threshold:          80,
+				statistic:          "Maximum",
+				description:        "RDS CPU usage has exceeded 80%",
+			},
+			{
+				suffix:             "free-storage",
+				metricName:         "FreeStorageSpace",
+				comparisonOperator: "LessThanThreshold",
+				threshold:          1 << 30, // 1 GiB
+				statistic:          "Minimum",
+				description:        "RDS free storage space is below 1 GiB",
+			},
+		}, opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	result := &RDSResult{
 		Instance: instance,
 	}

--- a/provider/defangaws/aws/rds.go
+++ b/provider/defangaws/aws/rds.go
@@ -171,6 +171,7 @@ func CreateRDS(
 	vpcID pulumi.StringInput,
 	privateSubnetIDs pulumi.StringArrayInput,
 	privateSgID pulumi.StringPtrInput,
+	alarmTopicArn pulumi.StringInput,
 	deps []pulumi.Resource,
 	opts ...pulumi.ResourceOption,
 ) (*RDSResult, error) {
@@ -296,7 +297,7 @@ func CreateRDS(
 	// autoscaling, so it only fires when autoscaling can't keep up or the
 	// maxAllocatedStorage cap is reached.
 	err = createDBAlarms(ctx, serviceName, "AWS/RDS",
-		pulumi.StringMap{"DBInstanceIdentifier": instance.Identifier}, tags, []dbAlarm{
+		pulumi.StringMap{"DBInstanceIdentifier": instance.Identifier}, tags, alarmTopicArn, []dbAlarm{
 			{
 				suffix:             "cpu-usage",
 				metricName:         "CPUUtilization",

--- a/provider/defangaws/aws/recipe.go
+++ b/provider/defangaws/aws/recipe.go
@@ -6,11 +6,19 @@ import "github.com/DefangLabs/pulumi-defang/provider/common"
 var recipe = common.NewRecipe("defang-aws")
 
 var (
-	AllowBurstable            = recipe.Bool("allow-burstable", true)
-	AllowOverwriteRecords     = recipe.Bool("allow-overwrite-records", false)
-	BackupRetentionDays       = recipe.Int("backup-retention-days", 0)
-	BackupWindow              = recipe.String("backup-window", "04:00-05:00")
-	BucketKeyEnabled          = recipe.Bool("bucket-key-enabled", true) // minimize KMS costs in non-prod environments
+	// Alarms enables provider-created CloudWatch alarms on managed databases
+	// (Redis/MemoryDB memory+CPU, RDS CPU+storage). Off in the affordable
+	// default: alarms have a per-alarm cost and dev stacks don't need paging.
+	Alarms = recipe.Bool("alarms", false)
+	// AlarmTopicArn is a pre-existing SNS topic attached as the alarm/OK
+	// action of every provider-created alarm. Empty means alarms are still
+	// created (console-visible) but don't notify.
+	AlarmTopicArn         = recipe.String("alarm-topic-arn", "")
+	AllowBurstable        = recipe.Bool("allow-burstable", true)
+	AllowOverwriteRecords = recipe.Bool("allow-overwrite-records", false)
+	BackupRetentionDays   = recipe.Int("backup-retention-days", 0)
+	BackupWindow          = recipe.String("backup-window", "04:00-05:00")
+	BucketKeyEnabled      = recipe.Bool("bucket-key-enabled", true) // minimize KMS costs in non-prod environments
 	// ConfigPath is the SSM path prefix ("/…/") for ${VAR} config resolution;
 	// empty means the default "/Defang/<project>/<stack>/". Lets deployments
 	// keep consuming parameters at a pre-existing path.
@@ -32,6 +40,6 @@ var (
 	// RedisEngine selects the managed Redis implementation: "elasticache" or "memorydb".
 	RedisEngine          = recipe.String("redis-engine", "elasticache")
 	RetainBucketOnDelete = recipe.Bool("retain-bucket-on-delete", false)
-	Route53SidecarLogs        = recipe.Bool("route53-sidecar-logs", false)
-	RetainDnsOnDelete         = recipe.Bool("retain-dns-on-delete", false)
+	Route53SidecarLogs   = recipe.Bool("route53-sidecar-logs", false)
+	RetainDnsOnDelete    = recipe.Bool("retain-dns-on-delete", false)
 )

--- a/provider/defangaws/aws/recipe.go
+++ b/provider/defangaws/aws/recipe.go
@@ -9,11 +9,9 @@ var (
 	// Alarms enables provider-created CloudWatch alarms on managed databases
 	// (Redis/MemoryDB memory+CPU, RDS CPU+storage). Off in the affordable
 	// default: alarms have a per-alarm cost and dev stacks don't need paging.
-	Alarms = recipe.Bool("alarms", false)
-	// AlarmTopicArn is a pre-existing SNS topic attached as the alarm/OK
-	// action of every provider-created alarm. Empty means alarms are still
-	// created (console-visible) but don't notify.
-	AlarmTopicArn         = recipe.String("alarm-topic-arn", "")
+	// Notification wiring is per project, not per recipe: the SNS topic is the
+	// AWSConfig.AlarmTopicArn input.
+	Alarms                = recipe.Bool("alarms", false)
 	AllowBurstable        = recipe.Bool("allow-burstable", true)
 	AllowOverwriteRecords = recipe.Bool("allow-overwrite-records", false)
 	BackupRetentionDays   = recipe.Int("backup-retention-days", 0)

--- a/provider/defangaws/postgres.go
+++ b/provider/defangaws/postgres.go
@@ -84,7 +84,7 @@ func createPostgres(
 
 	rdsResult, err := provideraws.CreateRDS(
 		ctx, configProvider, serviceName, svc,
-		infra.VpcID, infra.PrivateSubnetIDs, infra.PrivateSgID,
+		infra.VpcID, infra.PrivateSubnetIDs, infra.PrivateSgID, infra.AlarmTopicArn,
 		deps, childOpt,
 	)
 	if err != nil {

--- a/provider/defangaws/redis.go
+++ b/provider/defangaws/redis.go
@@ -93,7 +93,7 @@ func createRedis(
 		createCluster = provideraws.CreateMemoryDB
 	}
 	redisResult, err := createCluster(
-		ctx, serviceName, svc, infra.VpcID, infra.PrivateSubnetIDs, infra.PrivateSgID, deps, childOpt,
+		ctx, serviceName, svc, infra.VpcID, infra.PrivateSubnetIDs, infra.PrivateSgID, infra.AlarmTopicArn, deps, childOpt,
 	)
 	if err != nil {
 		return fmt.Errorf("creating Redis for %s: %w", serviceName, err)

--- a/sdk/v2/go/defang-aws/aws/pulumiTypes.go
+++ b/sdk/v2/go/defang-aws/aws/pulumiTypes.go
@@ -14,6 +14,7 @@ import (
 var _ = internal.GetEnvOrDefault
 
 type SharedInfra struct {
+	AlarmTopicArn    *string  `pulumi:"alarmTopicArn"`
 	ClusterArn       *string  `pulumi:"clusterArn"`
 	ExecutionRoleArn *string  `pulumi:"executionRoleArn"`
 	LogGroupName     *string  `pulumi:"logGroupName"`
@@ -36,6 +37,7 @@ type SharedInfraInput interface {
 }
 
 type SharedInfraArgs struct {
+	AlarmTopicArn    pulumi.StringPtrInput   `pulumi:"alarmTopicArn"`
 	ClusterArn       pulumi.StringPtrInput   `pulumi:"clusterArn"`
 	ExecutionRoleArn pulumi.StringPtrInput   `pulumi:"executionRoleArn"`
 	LogGroupName     pulumi.StringPtrInput   `pulumi:"logGroupName"`
@@ -123,6 +125,10 @@ func (o SharedInfraOutput) ToSharedInfraPtrOutputWithContext(ctx context.Context
 	}).(SharedInfraPtrOutput)
 }
 
+func (o SharedInfraOutput) AlarmTopicArn() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v SharedInfra) *string { return v.AlarmTopicArn }).(pulumi.StringPtrOutput)
+}
+
 func (o SharedInfraOutput) ClusterArn() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v SharedInfra) *string { return v.ClusterArn }).(pulumi.StringPtrOutput)
 }
@@ -177,6 +183,15 @@ func (o SharedInfraPtrOutput) Elem() SharedInfraOutput {
 		var ret SharedInfra
 		return ret
 	}).(SharedInfraOutput)
+}
+
+func (o SharedInfraPtrOutput) AlarmTopicArn() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *SharedInfra) *string {
+		if v == nil {
+			return nil
+		}
+		return v.AlarmTopicArn
+	}).(pulumi.StringPtrOutput)
 }
 
 func (o SharedInfraPtrOutput) ClusterArn() pulumi.StringPtrOutput {

--- a/sdk/v2/go/defang-aws/pulumiTypes.go
+++ b/sdk/v2/go/defang-aws/pulumiTypes.go
@@ -14,6 +14,7 @@ import (
 var _ = internal.GetEnvOrDefault
 
 type AWSConfig struct {
+	AlarmTopicArn     *string  `pulumi:"alarmTopicArn"`
 	AlbCertificateArn *string  `pulumi:"albCertificateArn"`
 	DnsRoleArn        *string  `pulumi:"dnsRoleArn"`
 	PrivateSubnetIDs  []string `pulumi:"privateSubnetIDs"`
@@ -35,6 +36,7 @@ type AWSConfigInput interface {
 }
 
 type AWSConfigArgs struct {
+	AlarmTopicArn     pulumi.StringPtrInput   `pulumi:"alarmTopicArn"`
 	AlbCertificateArn pulumi.StringPtrInput   `pulumi:"albCertificateArn"`
 	DnsRoleArn        pulumi.StringPtrInput   `pulumi:"dnsRoleArn"`
 	PrivateSubnetIDs  pulumi.StringArrayInput `pulumi:"privateSubnetIDs"`
@@ -121,6 +123,10 @@ func (o AWSConfigOutput) ToAWSConfigPtrOutputWithContext(ctx context.Context) AW
 	}).(AWSConfigPtrOutput)
 }
 
+func (o AWSConfigOutput) AlarmTopicArn() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v AWSConfig) *string { return v.AlarmTopicArn }).(pulumi.StringPtrOutput)
+}
+
 func (o AWSConfigOutput) AlbCertificateArn() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v AWSConfig) *string { return v.AlbCertificateArn }).(pulumi.StringPtrOutput)
 }
@@ -171,6 +177,15 @@ func (o AWSConfigPtrOutput) Elem() AWSConfigOutput {
 		var ret AWSConfig
 		return ret
 	}).(AWSConfigOutput)
+}
+
+func (o AWSConfigPtrOutput) AlarmTopicArn() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *AWSConfig) *string {
+		if v == nil {
+			return nil
+		}
+		return v.AlarmTopicArn
+	}).(pulumi.StringPtrOutput)
 }
 
 func (o AWSConfigPtrOutput) AlbCertificateArn() pulumi.StringPtrOutput {


### PR DESCRIPTION
## What

Provider-created CloudWatch alarms for the managed databases:

- **`defang-aws:alarms`** (recipe bool, affordable default **false**) — master switch. On/off is a pure deployment-mode choice, so it lives in the recipe; the affordable default creates no alarm resources: alarms cost money and dev stacks don't need paging.
- **`alarmTopicArn`** (optional component input) — pre-existing SNS topic attached as the `alarmActions`/`okActions` of every provider-created alarm. Lives on the Project `aws` input block (alongside the other project-specific ARNs: `dnsRoleArn`, `albCertificateArn`) and on the standalone Redis/Postgres `aws` input — **not** in the recipe, because recipes must stay project agnostic and a concrete ARN is deployment-specific state. As a real input it accepts a same-stack `Output` (e.g. an SNS topic created in the same program). Unset means alarms are still created (console-visible) but don't notify.

Alarms created when enabled (all: 2 evaluation periods x 300 s, statistic Maximum unless noted):

| Database | Namespace / dimension | Metrics |
|---|---|---|
| MemoryDB | `AWS/MemoryDB` / `ClusterName` | `DatabaseCapacityUsagePercentage` > 80, `CPUUtilization` > 80 |
| ElastiCache | `AWS/ElastiCache` / `CacheClusterId` (per member, from `MemberClusters`) | `DatabaseMemoryUsagePercentage` > 80, `EngineCPUUtilization` > 80 |
| RDS Postgres | `AWS/RDS` / `DBInstanceIdentifier` | `CPUUtilization` > 80; `FreeStorageSpace` < 1 GiB (Minimum) |

The alarms are children of the DB component, so both the Project-owned and standalone paths get them. MemoryDB thresholds/cadence are metric-for-metric what defang-mvp's `pulumi/ecs/alarms.ts` had before the defang-on-defang migration removed them (DefangLabs/defang-mvp#3101). `EngineCPUUtilization` is used for ElastiCache because the single Redis thread saturates well before host CPU on multi-vCPU nodes; the RDS free-storage threshold sits below the 10%-free storage-autoscaling trigger so it only fires when autoscaling can't keep up or the `maxAllocatedStorage` cap is hit.

## Why

Fixes the alerting gap tracked in DefangLabs/defang-mvp#3101: fabric's MemoryDB lost its 80% memory/CPU alarms when the cluster moved into the provider-owned Redis component, because external alarms need a handle on the provider-managed child. Per Lio's direction, the provider now owns the alerts, gated by the recipe, with no alerts in affordable mode and per-project notification wiring via the input.

## Notes

- Schema/SDK changes: `alarmTopicArn` added to `defang-aws:index:AWSConfig` and `defang-aws:aws:SharedInfra` (regenerated schema + Go SDK committed).
- GCP/Azure parity deliberately deferred, consistent with the repo's parity posture.
- Unit tests cover the affordable default (no alarms), enabled inputs, and topic-ARN wiring; `golangci-lint` clean.
- defang-mvp follow-up: enable `defang-aws:alarms` in the stack YAML, pass `alarmTopicArn: slackbotAlarmTopic.arn`, and drop the TODO in `alarms.ts` — tested against a fork preview build per DefangLabs/defang-mvp#3101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw7j9FYnbChZJbYArxbhuo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional CloudWatch monitoring alarms for RDS, ElastiCache, and MemoryDB.
  * Added configuration to enable alarms and optionally wire SNS notification actions via an alarm topic ARN.
  * When enabled, provider-created database alarms are created for CPU and relevant capacity/memory/storage signals; notifications are sent on alarm/OK only if the topic ARN is set.
* **Tests**
  * Added Pulumi-mock test coverage for alarm creation behavior (disabled by default, enabled creates expected alarms, topic ARN adds alarm/OK actions).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->