### PR TITLE
fix(aws): TG health-check timeout and pull-through-cache prefix deploy blockers

### DIFF
--- a/provider/defangaws/aws/ecr.go
+++ b/provider/defangaws/aws/ecr.go
@@ -43,16 +43,20 @@ type PullThroughCache struct {
 }
 
 // createEcrPullThroughCache creates an ECR pull-through cache rule for the given upstream registry.
-// Matches TS createEcrPullThroughCache in shared/aws/repos.ts.
+// Matches TS createEcrPullThroughCache in shared/aws/repos.ts. prefixSeed
+// seeds the repository prefix — an ACCOUNT-global namespace, so it must be
+// scoped (e.g. by project) to avoid colliding with rules owned by other
+// stacks/programs in the same account; name stays the (stable) resource name.
 func createEcrPullThroughCache(
 	ctx *pulumi.Context,
 	name string,
+	prefixSeed string,
 	upstreamRegistryURL pulumi.StringInput,
 	opts ...pulumi.ResourceOption,
 ) (*PullThroughCache, error) {
 	const maxCacheRepoLength = 30 // was 20 https://github.com/hashicorp/terraform-provider-aws/pull/34716
 	// PullThroughCacheRule does not support autonaming, so we need to generate a unique and compliant prefix ourselves.
-	prefix := strings.ToLower(common.AutonamingPrefix(ctx, name))
+	prefix := strings.ToLower(common.AutonamingPrefix(ctx, prefixSeed))
 	if len(prefix) > maxCacheRepoLength {
 		// 	TODO: hashTrim/truncate prefix smartly
 		prefix = prefix[:maxCacheRepoLength]

--- a/provider/defangaws/aws/infra.go
+++ b/provider/defangaws/aws/infra.go
@@ -79,8 +79,13 @@ func CreateProjectInfra(
 		}
 	}
 
-	// Create public ECR pull-through cache for faster image pulls (matches TS initializeStack)
-	publicEcrCache, err := createEcrPullThroughCache(ctx, "ecr-public", pulumi.String("public.ecr.aws"), opt)
+	// Create public ECR pull-through cache for faster image pulls (matches TS
+	// initializeStack). The prefix is project-scoped: it's an account-global
+	// namespace, and a bare "ecr-public" collides with rules owned by other
+	// programs (or a second Project) in the same account. Pre-existing rules
+	// keep their prefix via IgnoreChanges(ecrRepositoryPrefix).
+	publicEcrCache, err := createEcrPullThroughCache(
+		ctx, "ecr-public", projectName+"-ecr-public", pulumi.String("public.ecr.aws"), opt)
 	if err != nil {
 		return nil, fmt.Errorf("creating ECR pull-through cache: %w", err)
 	}

--- a/provider/defangaws/aws/lb.go
+++ b/provider/defangaws/aws/lb.go
@@ -114,6 +114,29 @@ func createLbLogsBucket(
 	return bucket, nil
 }
 
+// tgHealthCheckTiming derives the target-group health check interval and
+// timeout from a compose healthcheck (nil = recipe defaults), matching TS
+// createTargetGroup in lb.ts: `clamp(healthCheck?.timeout ?? interval, 2,
+// min(interval-1, 120))`. AWS requires timeout < interval, so the
+// unset-timeout fallback must be the CLAMPED default — clampInt returns its
+// fallback verbatim, and a raw `interval` fallback fails TG creation (e.g. a
+// compose healthcheck with interval 5s and no timeout).
+func tgHealthCheckTiming(defaultInterval int, healthCheck *compose.HealthCheckConfig) (int, int) {
+	interval := defaultInterval
+	if healthCheck != nil {
+		interval = clampInt(int(healthCheck.IntervalSeconds), 5, 300, defaultInterval)
+	}
+	maxTimeout := interval - 1
+	if maxTimeout > 120 {
+		maxTimeout = 120
+	}
+	timeout := min(max(interval, 2), maxTimeout)
+	if healthCheck != nil {
+		timeout = clampInt(int(healthCheck.TimeoutSeconds), 2, maxTimeout, timeout)
+	}
+	return interval, timeout
+}
+
 //nolint:funlen // sequential TG+LR setup is clearer as one function
 func createTgLrPair(
 	ctx *pulumi.Context,
@@ -139,20 +162,7 @@ func createTgLrPair(
 	tgName := targetGroupName(serviceName, int(port.Target), appProto, port.Listener)
 
 	// Target group health check (matches TS createTargetGroup in lb.ts)
-	defaultInterval := HealthCheckInterval.Get(ctx)
-	interval := defaultInterval
-	if healthCheck != nil {
-		interval = clampInt(int(healthCheck.IntervalSeconds), 5, 300, defaultInterval)
-	}
-	maxTimeout := interval - 1
-	if maxTimeout > 120 {
-		maxTimeout = 120
-	}
-	// Default timeout to interval, clamped to [2, maxTimeout] (matches TS: `healthCheck?.timeout ?? interval`)
-	timeout := clampInt(interval, 2, maxTimeout, interval)
-	if healthCheck != nil {
-		timeout = clampInt(int(healthCheck.TimeoutSeconds), 2, maxTimeout, interval)
-	}
+	interval, timeout := tgHealthCheckTiming(HealthCheckInterval.Get(ctx), healthCheck)
 	unhealthyThreshold := (3)
 	if healthCheck != nil {
 		unhealthyThreshold = clampInt(int(healthCheck.Retries), 2, 10, 3)

--- a/provider/defangaws/aws/lb_test.go
+++ b/provider/defangaws/aws/lb_test.go
@@ -1,0 +1,59 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/DefangLabs/pulumi-defang/provider/compose"
+)
+
+func TestTgHealthCheckTiming(t *testing.T) {
+	tests := []struct {
+		name         string
+		healthCheck  *compose.HealthCheckConfig
+		wantInterval int
+		wantTimeout  int
+	}{
+		{
+			name:         "no healthcheck uses defaults",
+			healthCheck:  nil,
+			wantInterval: 5,
+			wantTimeout:  4,
+		},
+		{
+			// Regression: fabric's healthcheck (interval 5, no timeout) must
+			// not fall back to timeout == interval — AWS rejects the TG with
+			// "Health check timeout '5' must be smaller than the interval '5'".
+			name:         "unset timeout stays below interval",
+			healthCheck:  &compose.HealthCheckConfig{IntervalSeconds: 5},
+			wantInterval: 5,
+			wantTimeout:  4,
+		},
+		{
+			name:         "explicit timeout clamped below interval",
+			healthCheck:  &compose.HealthCheckConfig{IntervalSeconds: 10, TimeoutSeconds: 10},
+			wantInterval: 10,
+			wantTimeout:  9,
+		},
+		{
+			name:         "explicit timeout kept when valid",
+			healthCheck:  &compose.HealthCheckConfig{IntervalSeconds: 30, TimeoutSeconds: 5},
+			wantInterval: 30,
+			wantTimeout:  5,
+		},
+		{
+			name:         "large interval caps timeout at 120",
+			healthCheck:  &compose.HealthCheckConfig{IntervalSeconds: 300},
+			wantInterval: 300,
+			wantTimeout:  120,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			interval, timeout := tgHealthCheckTiming(5, tt.healthCheck)
+			if interval != tt.wantInterval || timeout != tt.wantTimeout {
+				t.Errorf("got interval=%d timeout=%d, want interval=%d timeout=%d",
+					interval, timeout, tt.wantInterval, tt.wantTimeout)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The first real deploy of the defang-on-defang migration (DefangLabs/defang-mvp#3102, dev stack, preview build) surfaced two Project deploy blockers that previews can't catch (both are AWS create-time validations):

## 1. Target group: `Health check timeout '5' must be smaller than the interval '5'`

Any compose healthcheck that sets an `interval` but no `timeout` hit this: `clampInt` returns its fallback verbatim, so the `interval` fallback escaped the `maxTimeout = interval - 1` cap. The TS original (`clamp(healthCheck?.timeout ?? interval, 2, toMax)`) clamped the fallback. Extracted `tgHealthCheckTiming` with the clamped default and added regression tests (fabric's `interval: 5s`, no timeout → timeout 4).

## 2. Pull-through cache: `PullThroughCacheRuleAlreadyExistsException`

The project's public-ECR pull-through cache rule used the fixed prefix `ecr-public`. The prefix is an **account-global** namespace, so this collides with any same-prefix rule owned by another program in the account — defang-mvp's playground TS stack owns exactly that rule. The prefix is now project-scoped (`<project>-ecr-public`, still ≤30 chars).

Deployed rules are unaffected: `IgnoreChanges(ecrRepositoryPrefix)` keeps their existing prefix, and both the exec-role policy ARN and the `CachePrefix` URL read the live prefix from the rule, not the seed.

No schema/SDK changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw7j9FYnbChZJbYArxbhuo