### PR TITLE
feat: serviceIds Project output — physical IDs of every service's backing resource

### DIFF
--- a/provider/cmd/pulumi-resource-defang-aws/schema.json
+++ b/provider/cmd/pulumi-resource-defang-aws/schema.json
@@ -511,13 +511,6 @@
         "clusterName": {
           "type": "string"
         },
-        "datastoreIds": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string",
-            "plain": true
-          }
-        },
         "endpoints": {
           "type": "object",
           "additionalProperties": {
@@ -533,6 +526,13 @@
         },
         "logGroupName": {
           "type": "string"
+        },
+        "serviceIds": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "plain": true
+          }
         },
         "serviceNames": {
           "type": "object",
@@ -555,7 +555,7 @@
         "logGroupName",
         "serviceNames",
         "taskRoleArns",
-        "datastoreIds"
+        "serviceIds"
       ],
       "inputProperties": {
         "aws": {

--- a/provider/cmd/pulumi-resource-defang-aws/schema.json
+++ b/provider/cmd/pulumi-resource-defang-aws/schema.json
@@ -511,6 +511,13 @@
         "clusterName": {
           "type": "string"
         },
+        "datastoreIds": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "plain": true
+          }
+        },
         "endpoints": {
           "type": "object",
           "additionalProperties": {
@@ -547,7 +554,8 @@
         "clusterName",
         "logGroupName",
         "serviceNames",
-        "taskRoleArns"
+        "taskRoleArns",
+        "datastoreIds"
       ],
       "inputProperties": {
         "aws": {

--- a/provider/cmd/pulumi-resource-defang-azure/schema.json
+++ b/provider/cmd/pulumi-resource-defang-azure/schema.json
@@ -482,6 +482,13 @@
     },
     "defang-azure:index:Project": {
       "properties": {
+        "datastoreIds": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "plain": true
+          }
+        },
         "endpoints": {
           "type": "object",
           "additionalProperties": {
@@ -494,7 +501,8 @@
         }
       },
       "required": [
-        "endpoints"
+        "endpoints",
+        "datastoreIds"
       ],
       "inputProperties": {
         "domain": {

--- a/provider/cmd/pulumi-resource-defang-azure/schema.json
+++ b/provider/cmd/pulumi-resource-defang-azure/schema.json
@@ -482,13 +482,6 @@
     },
     "defang-azure:index:Project": {
       "properties": {
-        "datastoreIds": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string",
-            "plain": true
-          }
-        },
         "endpoints": {
           "type": "object",
           "additionalProperties": {
@@ -498,11 +491,18 @@
         },
         "loadBalancerDns": {
           "type": "string"
+        },
+        "serviceIds": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "plain": true
+          }
         }
       },
       "required": [
         "endpoints",
-        "datastoreIds"
+        "serviceIds"
       ],
       "inputProperties": {
         "domain": {

--- a/provider/cmd/pulumi-resource-defang-gcp/schema.json
+++ b/provider/cmd/pulumi-resource-defang-gcp/schema.json
@@ -510,13 +510,6 @@
     },
     "defang-gcp:index:Project": {
       "properties": {
-        "datastoreIds": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string",
-            "plain": true
-          }
-        },
         "endpoints": {
           "type": "object",
           "additionalProperties": {
@@ -526,11 +519,18 @@
         },
         "loadBalancerDns": {
           "type": "string"
+        },
+        "serviceIds": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "plain": true
+          }
         }
       },
       "required": [
         "endpoints",
-        "datastoreIds"
+        "serviceIds"
       ],
       "inputProperties": {
         "domain": {

--- a/provider/cmd/pulumi-resource-defang-gcp/schema.json
+++ b/provider/cmd/pulumi-resource-defang-gcp/schema.json
@@ -510,6 +510,13 @@
     },
     "defang-gcp:index:Project": {
       "properties": {
+        "datastoreIds": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "plain": true
+          }
+        },
         "endpoints": {
           "type": "object",
           "additionalProperties": {
@@ -522,7 +529,8 @@
         }
       },
       "required": [
-        "endpoints"
+        "endpoints",
+        "datastoreIds"
       ],
       "inputProperties": {
         "domain": {

--- a/provider/defangaws/project.go
+++ b/provider/defangaws/project.go
@@ -247,6 +247,10 @@ func buildProject(
 			taskRoleArns[svcName] = svcComp.TaskRoleArn.Untyped().(pulumi.StringOutput)
 			serviceIds[svcName] = svcComp.ServiceName.Untyped().(pulumi.StringOutput)
 		}
+		// For datastore services, deliberately overwrite the ECS service name set
+		// above with the backing resource's physical ID (RDS instance, MemoryDB/
+		// ElastiCache cluster). newService returns a non-nil datastoreID only for
+		// those, so container services keep their ECS service name.
 		if datastoreID != nil {
 			serviceIds[svcName] = datastoreID
 		}

--- a/provider/defangaws/project.go
+++ b/provider/defangaws/project.go
@@ -101,13 +101,14 @@ type ProjectOutputs struct {
 	// resource-based policies (e.g. KMS key policies) that must name the role.
 	TaskRoleArns pulumix.Output[map[string]string] `pulumi:"taskRoleArns"`
 
-	// DatastoreIds maps managed database service names to their physical
-	// identifiers — the MemoryDB cluster name or ElastiCache replication
-	// group ID for Redis, the RDS DBInstanceIdentifier for Postgres — so
-	// consumers can attach externally managed alarms and dashboards. Mirrors
-	// the standalone components' clusterId/instanceIdentifier outputs, which
-	// are unreachable on Project children.
-	DatastoreIds pulumix.Output[map[string]string] `pulumi:"datastoreIds"`
+	// ServiceIds maps every service name to the physical identifier of its
+	// primary backing resource — the ECS service name for container services
+	// (same value as serviceNames), the MemoryDB cluster name or ElastiCache
+	// replication group ID for Redis, the RDS DBInstanceIdentifier for
+	// Postgres — so consumers can attach externally managed alarms and
+	// dashboards. Child components' own outputs are unreachable on Project
+	// children.
+	ServiceIds pulumix.Output[map[string]string] `pulumi:"serviceIds"`
 }
 
 // Construct implements the ComponentResource interface for Project.
@@ -132,7 +133,7 @@ func (*Project) Construct(
 	comp.LogGroupName = pulumix.Output[string](result.LogGroupName)
 	comp.ServiceNames = pulumix.Output[map[string]string](result.ServiceNames)
 	comp.TaskRoleArns = pulumix.Output[map[string]string](result.TaskRoleArns)
-	comp.DatastoreIds = pulumix.Output[map[string]string](result.DatastoreIds)
+	comp.ServiceIds = pulumix.Output[map[string]string](result.ServiceIds)
 
 	if err := ctx.RegisterResourceOutputs(comp, pulumi.Map{
 		"endpoints":       result.Endpoints,
@@ -142,7 +143,7 @@ func (*Project) Construct(
 		"logGroupName":    result.LogGroupName,
 		"serviceNames":    result.ServiceNames,
 		"taskRoleArns":    result.TaskRoleArns,
-		"datastoreIds":    result.DatastoreIds,
+		"serviceIds":      result.ServiceIds,
 	}); err != nil {
 		return nil, err
 	}
@@ -159,7 +160,7 @@ type projectResult struct {
 	LogGroupName    pulumi.StringOutput
 	ServiceNames    pulumi.StringMapOutput
 	TaskRoleArns    pulumi.StringMapOutput
-	DatastoreIds    pulumi.StringMapOutput
+	ServiceIds      pulumi.StringMapOutput
 }
 
 // buildProject creates all AWS resources for the project.
@@ -188,7 +189,7 @@ func buildProject(
 	endpoints := pulumi.StringMap{}
 	serviceNames := pulumi.StringMap{}
 	taskRoleArns := pulumi.StringMap{}
-	datastoreIds := pulumi.StringMap{}
+	serviceIds := pulumi.StringMap{}
 	dependencies := map[string]pulumi.Resource{} // service name → dependency resource for dependees
 
 	var configProvider compose.ConfigProvider
@@ -244,9 +245,10 @@ func buildProject(
 		if svcComp != nil {
 			serviceNames[svcName] = svcComp.ServiceName.Untyped().(pulumi.StringOutput)
 			taskRoleArns[svcName] = svcComp.TaskRoleArn.Untyped().(pulumi.StringOutput)
+			serviceIds[svcName] = svcComp.ServiceName.Untyped().(pulumi.StringOutput)
 		}
 		if datastoreID != nil {
-			datastoreIds[svcName] = datastoreID
+			serviceIds[svcName] = datastoreID
 		}
 		if dependency != nil {
 			dependencies[svcName] = dependency
@@ -263,7 +265,7 @@ func buildProject(
 		LogGroupName:    infra.LogGroup.Name,
 		ServiceNames:    serviceNames.ToStringMapOutput(),
 		TaskRoleArns:    taskRoleArns.ToStringMapOutput(),
-		DatastoreIds:    datastoreIds.ToStringMapOutput(),
+		ServiceIds:      serviceIds.ToStringMapOutput(),
 	}, nil
 }
 
@@ -283,7 +285,8 @@ func newService(
 	var dependency pulumi.Resource
 	var svcComp *ServiceOutputs
 	// datastoreID is the managed database's physical identifier (nil for
-	// container services), surfaced through the Project's datastoreIds output.
+	// container services, whose ECS service name is used instead), surfaced
+	// through the Project's serviceIds output.
 	var datastoreID pulumi.StringInput
 	var err error
 	switch {

--- a/provider/defangaws/project.go
+++ b/provider/defangaws/project.go
@@ -100,6 +100,14 @@ type ProjectOutputs struct {
 	// Task role ARNs by compose service name (container services only), for
 	// resource-based policies (e.g. KMS key policies) that must name the role.
 	TaskRoleArns pulumix.Output[map[string]string] `pulumi:"taskRoleArns"`
+
+	// DatastoreIds maps managed database service names to their physical
+	// identifiers — the MemoryDB cluster name or ElastiCache replication
+	// group ID for Redis, the RDS DBInstanceIdentifier for Postgres — so
+	// consumers can attach externally managed alarms and dashboards. Mirrors
+	// the standalone components' clusterId/instanceIdentifier outputs, which
+	// are unreachable on Project children.
+	DatastoreIds pulumix.Output[map[string]string] `pulumi:"datastoreIds"`
 }
 
 // Construct implements the ComponentResource interface for Project.
@@ -124,6 +132,7 @@ func (*Project) Construct(
 	comp.LogGroupName = pulumix.Output[string](result.LogGroupName)
 	comp.ServiceNames = pulumix.Output[map[string]string](result.ServiceNames)
 	comp.TaskRoleArns = pulumix.Output[map[string]string](result.TaskRoleArns)
+	comp.DatastoreIds = pulumix.Output[map[string]string](result.DatastoreIds)
 
 	if err := ctx.RegisterResourceOutputs(comp, pulumi.Map{
 		"endpoints":       result.Endpoints,
@@ -133,6 +142,7 @@ func (*Project) Construct(
 		"logGroupName":    result.LogGroupName,
 		"serviceNames":    result.ServiceNames,
 		"taskRoleArns":    result.TaskRoleArns,
+		"datastoreIds":    result.DatastoreIds,
 	}); err != nil {
 		return nil, err
 	}
@@ -149,6 +159,7 @@ type projectResult struct {
 	LogGroupName    pulumi.StringOutput
 	ServiceNames    pulumi.StringMapOutput
 	TaskRoleArns    pulumi.StringMapOutput
+	DatastoreIds    pulumi.StringMapOutput
 }
 
 // buildProject creates all AWS resources for the project.
@@ -177,6 +188,7 @@ func buildProject(
 	endpoints := pulumi.StringMap{}
 	serviceNames := pulumi.StringMap{}
 	taskRoleArns := pulumi.StringMap{}
+	datastoreIds := pulumi.StringMap{}
 	dependencies := map[string]pulumi.Resource{} // service name → dependency resource for dependees
 
 	var configProvider compose.ConfigProvider
@@ -222,7 +234,7 @@ func buildProject(
 		}
 
 		waitForHealthy := waitForSteady[svcName] || args.WaitForSteadyState
-		endpoint, dependency, svcComp, err := newService(
+		endpoint, dependency, svcComp, datastoreID, err := newService(
 			ctx, configProvider, svcName, svc, args.Networks, infra, sidecars[svcName], waitForHealthy, deps, parentOpt)
 		if err != nil {
 			return nil, fmt.Errorf("building service %s: %w", svcName, err)
@@ -232,6 +244,9 @@ func buildProject(
 		if svcComp != nil {
 			serviceNames[svcName] = svcComp.ServiceName.Untyped().(pulumi.StringOutput)
 			taskRoleArns[svcName] = svcComp.TaskRoleArn.Untyped().(pulumi.StringOutput)
+		}
+		if datastoreID != nil {
+			datastoreIds[svcName] = datastoreID
 		}
 		if dependency != nil {
 			dependencies[svcName] = dependency
@@ -248,6 +263,7 @@ func buildProject(
 		LogGroupName:    infra.LogGroup.Name,
 		ServiceNames:    serviceNames.ToStringMapOutput(),
 		TaskRoleArns:    taskRoleArns.ToStringMapOutput(),
+		DatastoreIds:    datastoreIds.ToStringMapOutput(),
 	}, nil
 }
 
@@ -262,41 +278,46 @@ func newService(
 	waitForSteadyState bool,
 	deps []pulumi.Resource,
 	parentOpt pulumi.ResourceOrInvokeOption,
-) (pulumi.StringOutput, pulumi.Resource, *ServiceOutputs, error) {
+) (pulumi.StringOutput, pulumi.Resource, *ServiceOutputs, pulumi.StringInput, error) {
 	var endpoint pulumi.StringOutput
 	var dependency pulumi.Resource
 	var svcComp *ServiceOutputs
+	// datastoreID is the managed database's physical identifier (nil for
+	// container services), surfaced through the Project's datastoreIds output.
+	var datastoreID pulumi.StringInput
 	var err error
 	switch {
 	case svc.Postgres != nil:
 		// Managed Postgres → RDS
 		pgComp := &PostgresOutputs{}
 		if regErr := ctx.RegisterComponentResource(PostgresComponentType, svcName, pgComp, parentOpt); regErr != nil {
-			return pulumi.StringOutput{}, nil, nil, fmt.Errorf("registering postgres component %s: %w", svcName, regErr)
+			return pulumi.StringOutput{}, nil, nil, nil, fmt.Errorf("registering postgres component %s: %w", svcName, regErr)
 		}
 		if err = createPostgres(ctx, pgComp, configProvider, svcName, svc, infra, deps); err == nil {
 			endpoint = pgComp.Endpoint
 			dependency = pgComp.Dependency
+			datastoreID = pgComp.InstanceIdentifier
 		}
 	case svc.Redis != nil:
 		// Managed Redis → ElastiCache
 		redisComp := &RedisOutputs{}
 		if regErr := ctx.RegisterComponentResource(RedisComponentType, svcName, redisComp, parentOpt); regErr != nil {
-			return pulumi.StringOutput{}, nil, nil, fmt.Errorf("registering redis component %s: %w", svcName, regErr)
+			return pulumi.StringOutput{}, nil, nil, nil, fmt.Errorf("registering redis component %s: %w", svcName, regErr)
 		}
 		if err = createRedis(ctx, redisComp, svcName, svc, infra, deps); err == nil {
 			endpoint = redisComp.Endpoint
 			dependency = redisComp.Dependency
+			datastoreID = redisComp.ClusterId
 		}
 	default:
 		// Container service → ECS
 		svcComp = &ServiceOutputs{}
 		if regErr := ctx.RegisterComponentResource(ServiceComponentType, svcName, svcComp, parentOpt); regErr != nil {
-			return pulumi.StringOutput{}, nil, nil, fmt.Errorf("registering service component %s: %w", svcName, regErr)
+			return pulumi.StringOutput{}, nil, nil, nil, fmt.Errorf("registering service component %s: %w", svcName, regErr)
 		}
 		imageURI, imgErr := provideraws.GetServiceImage(ctx, svcName, svc, infra.BuildInfra, pulumi.Parent(svcComp))
 		if imgErr != nil {
-			return pulumi.StringOutput{}, nil, nil, fmt.Errorf("resolving image for %s: %w", svcName, imgErr)
+			return pulumi.StringOutput{}, nil, nil, nil, fmt.Errorf("resolving image for %s: %w", svcName, imgErr)
 		}
 		args := &provideraws.ECSServiceArgs{
 			Infra:              infra,
@@ -311,7 +332,7 @@ func newService(
 		}
 	}
 	if err != nil {
-		return pulumi.StringOutput{}, nil, nil, err
+		return pulumi.StringOutput{}, nil, nil, nil, err
 	}
-	return endpoint, dependency, svcComp, nil
+	return endpoint, dependency, svcComp, datastoreID, nil
 }

--- a/provider/defangazure/project.go
+++ b/provider/defangazure/project.go
@@ -51,6 +51,12 @@ type ProjectOutputs struct {
 
 	// Load balancer DNS name (unused for Azure, kept for interface compat)
 	LoadBalancerDNS pulumi.StringPtrOutput `pulumi:"loadBalancerDns,optional"`
+
+	// DatastoreIds maps managed database service names to their ARM resource
+	// IDs — the PostgreSQL Flexible Server for Postgres, the Redis Enterprise
+	// cluster for Redis — the scope Azure Monitor alert rules target. The
+	// components' typed resource handles are unreachable on Project children.
+	DatastoreIds pulumi.StringMapOutput `pulumi:"datastoreIds"`
 }
 
 // serviceTypes summarises which kinds of services are present in a project.
@@ -126,6 +132,7 @@ func createPostgresResources(
 	infra *providerazure.SharedInfra,
 	managedEndpoints map[string]pulumi.StringOutput,
 	serviceHosts map[string]pulumi.StringOutput,
+	datastoreIds pulumi.StringMap,
 	comp *serviceComponent,
 	childOpts []pulumi.ResourceOption,
 ) (pulumi.StringOutput, error) {
@@ -150,6 +157,7 @@ func createPostgresResources(
 	endpoint := pulumi.Sprintf("%s:5432", fqdn)
 	managedEndpoints[svcName] = endpoint
 	serviceHosts[svcName] = fqdn
+	datastoreIds[svcName] = pgResult.Server.ID().ToStringOutput()
 	return endpoint, nil
 }
 
@@ -160,6 +168,7 @@ func createRedisResources(
 	infra *providerazure.SharedInfra,
 	managedEndpoints map[string]pulumi.StringOutput,
 	serviceHosts map[string]pulumi.StringOutput,
+	datastoreIds pulumi.StringMap,
 	comp *serviceComponent,
 	childOpts []pulumi.ResourceOption,
 ) (pulumi.StringOutput, error) {
@@ -182,6 +191,7 @@ func createRedisResources(
 	host := withResourceDeps(redisResult.Cluster.HostName, redisResult.Readiness)
 	managedEndpoints[svcName] = connURL
 	serviceHosts[svcName] = host
+	datastoreIds[svcName] = redisResult.Cluster.ID().ToStringOutput()
 	return pulumi.Sprintf("%s:10000", host), nil
 }
 
@@ -195,6 +205,7 @@ func createServiceResources(
 	infra *providerazure.SharedInfra,
 	managedEndpoints map[string]pulumi.StringOutput,
 	serviceHosts map[string]pulumi.StringOutput,
+	datastoreIds pulumi.StringMap,
 	llmModels map[string]string,
 	childOpts []pulumi.ResourceOption,
 ) (pulumi.StringOutput, error) {
@@ -204,14 +215,16 @@ func createServiceResources(
 	switch {
 	case svc.Postgres != nil:
 		var err error
-		endpoint, err = createPostgresResources(ctx, svcName, svc, infra, managedEndpoints, serviceHosts, comp, childOpts)
+		endpoint, err = createPostgresResources(
+			ctx, svcName, svc, infra, managedEndpoints, serviceHosts, datastoreIds, comp, childOpts)
 		if err != nil {
 			return pulumi.StringOutput{}, err
 		}
 
 	case svc.Redis != nil:
 		var err error
-		endpoint, err = createRedisResources(ctx, svcName, svc, infra, managedEndpoints, serviceHosts, comp, childOpts)
+		endpoint, err = createRedisResources(
+			ctx, svcName, svc, infra, managedEndpoints, serviceHosts, datastoreIds, comp, childOpts)
 		if err != nil {
 			return pulumi.StringOutput{}, err
 		}
@@ -490,6 +503,7 @@ func (*Project) Construct(
 	}
 
 	endpoints := pulumi.StringMap{}
+	datastoreIds := pulumi.StringMap{}
 
 	// managedEndpoints accumulates connection URLs for managed services (Postgres, Redis, LLM).
 	managedEndpoints := make(map[string]pulumi.StringOutput, len(inputs.Services))
@@ -508,7 +522,7 @@ func (*Project) Construct(
 			continue
 		}
 		endpoint, err := createServiceResources(
-			ctx, svcName, svc, infra, managedEndpoints, serviceHosts, llmModels, childOpts,
+			ctx, svcName, svc, infra, managedEndpoints, serviceHosts, datastoreIds, llmModels, childOpts,
 		)
 		if err != nil {
 			return nil, err
@@ -520,7 +534,7 @@ func (*Project) Construct(
 			continue
 		}
 		endpoint, err := createServiceResources(
-			ctx, svcName, svc, infra, managedEndpoints, serviceHosts, llmModels, childOpts,
+			ctx, svcName, svc, infra, managedEndpoints, serviceHosts, datastoreIds, llmModels, childOpts,
 		)
 		if err != nil {
 			return nil, err
@@ -532,10 +546,12 @@ func (*Project) Construct(
 
 	comp.Endpoints = endpoints.ToStringMapOutput()
 	comp.LoadBalancerDNS = loadBalancerDNS
+	comp.DatastoreIds = datastoreIds.ToStringMapOutput()
 
 	if err := ctx.RegisterResourceOutputs(comp, pulumi.Map{
 		"endpoints":       endpoints.ToStringMapOutput(),
 		"loadBalancerDns": loadBalancerDNS,
+		"datastoreIds":    datastoreIds.ToStringMapOutput(),
 	}); err != nil {
 		return nil, err
 	}

--- a/provider/defangazure/project.go
+++ b/provider/defangazure/project.go
@@ -52,11 +52,14 @@ type ProjectOutputs struct {
 	// Load balancer DNS name (unused for Azure, kept for interface compat)
 	LoadBalancerDNS pulumi.StringPtrOutput `pulumi:"loadBalancerDns,optional"`
 
-	// DatastoreIds maps managed database service names to their ARM resource
-	// IDs — the PostgreSQL Flexible Server for Postgres, the Redis Enterprise
-	// cluster for Redis — the scope Azure Monitor alert rules target. The
-	// components' typed resource handles are unreachable on Project children.
-	DatastoreIds pulumi.StringMapOutput `pulumi:"datastoreIds"`
+	// ServiceIds maps service names to the ARM resource ID of their primary
+	// backing resource — the Container App for container services, the
+	// PostgreSQL Flexible Server for Postgres, the Redis Enterprise cluster
+	// for Redis — the scope Azure Monitor alert rules target. LLM services
+	// are omitted (they share the project's Cognitive Services deployment).
+	// The components' typed resource handles are unreachable on Project
+	// children.
+	ServiceIds pulumi.StringMapOutput `pulumi:"serviceIds"`
 }
 
 // serviceTypes summarises which kinds of services are present in a project.
@@ -132,7 +135,7 @@ func createPostgresResources(
 	infra *providerazure.SharedInfra,
 	managedEndpoints map[string]pulumi.StringOutput,
 	serviceHosts map[string]pulumi.StringOutput,
-	datastoreIds pulumi.StringMap,
+	serviceIds pulumi.StringMap,
 	comp *serviceComponent,
 	childOpts []pulumi.ResourceOption,
 ) (pulumi.StringOutput, error) {
@@ -157,7 +160,7 @@ func createPostgresResources(
 	endpoint := pulumi.Sprintf("%s:5432", fqdn)
 	managedEndpoints[svcName] = endpoint
 	serviceHosts[svcName] = fqdn
-	datastoreIds[svcName] = pgResult.Server.ID().ToStringOutput()
+	serviceIds[svcName] = pgResult.Server.ID().ToStringOutput()
 	return endpoint, nil
 }
 
@@ -168,7 +171,7 @@ func createRedisResources(
 	infra *providerazure.SharedInfra,
 	managedEndpoints map[string]pulumi.StringOutput,
 	serviceHosts map[string]pulumi.StringOutput,
-	datastoreIds pulumi.StringMap,
+	serviceIds pulumi.StringMap,
 	comp *serviceComponent,
 	childOpts []pulumi.ResourceOption,
 ) (pulumi.StringOutput, error) {
@@ -191,7 +194,7 @@ func createRedisResources(
 	host := withResourceDeps(redisResult.Cluster.HostName, redisResult.Readiness)
 	managedEndpoints[svcName] = connURL
 	serviceHosts[svcName] = host
-	datastoreIds[svcName] = redisResult.Cluster.ID().ToStringOutput()
+	serviceIds[svcName] = redisResult.Cluster.ID().ToStringOutput()
 	return pulumi.Sprintf("%s:10000", host), nil
 }
 
@@ -205,7 +208,7 @@ func createServiceResources(
 	infra *providerazure.SharedInfra,
 	managedEndpoints map[string]pulumi.StringOutput,
 	serviceHosts map[string]pulumi.StringOutput,
-	datastoreIds pulumi.StringMap,
+	serviceIds pulumi.StringMap,
 	llmModels map[string]string,
 	childOpts []pulumi.ResourceOption,
 ) (pulumi.StringOutput, error) {
@@ -216,7 +219,7 @@ func createServiceResources(
 	case svc.Postgres != nil:
 		var err error
 		endpoint, err = createPostgresResources(
-			ctx, svcName, svc, infra, managedEndpoints, serviceHosts, datastoreIds, comp, childOpts)
+			ctx, svcName, svc, infra, managedEndpoints, serviceHosts, serviceIds, comp, childOpts)
 		if err != nil {
 			return pulumi.StringOutput{}, err
 		}
@@ -224,7 +227,7 @@ func createServiceResources(
 	case svc.Redis != nil:
 		var err error
 		endpoint, err = createRedisResources(
-			ctx, svcName, svc, infra, managedEndpoints, serviceHosts, datastoreIds, comp, childOpts)
+			ctx, svcName, svc, infra, managedEndpoints, serviceHosts, serviceIds, comp, childOpts)
 		if err != nil {
 			return pulumi.StringOutput{}, err
 		}
@@ -264,6 +267,7 @@ func createServiceResources(
 		if err != nil {
 			return pulumi.StringOutput{}, err
 		}
+		serviceIds[svcName] = svcComp.AppID
 		return svcComp.Endpoint, nil
 	}
 
@@ -503,7 +507,7 @@ func (*Project) Construct(
 	}
 
 	endpoints := pulumi.StringMap{}
-	datastoreIds := pulumi.StringMap{}
+	serviceIds := pulumi.StringMap{}
 
 	// managedEndpoints accumulates connection URLs for managed services (Postgres, Redis, LLM).
 	managedEndpoints := make(map[string]pulumi.StringOutput, len(inputs.Services))
@@ -522,7 +526,7 @@ func (*Project) Construct(
 			continue
 		}
 		endpoint, err := createServiceResources(
-			ctx, svcName, svc, infra, managedEndpoints, serviceHosts, datastoreIds, llmModels, childOpts,
+			ctx, svcName, svc, infra, managedEndpoints, serviceHosts, serviceIds, llmModels, childOpts,
 		)
 		if err != nil {
 			return nil, err
@@ -534,7 +538,7 @@ func (*Project) Construct(
 			continue
 		}
 		endpoint, err := createServiceResources(
-			ctx, svcName, svc, infra, managedEndpoints, serviceHosts, datastoreIds, llmModels, childOpts,
+			ctx, svcName, svc, infra, managedEndpoints, serviceHosts, serviceIds, llmModels, childOpts,
 		)
 		if err != nil {
 			return nil, err
@@ -546,12 +550,12 @@ func (*Project) Construct(
 
 	comp.Endpoints = endpoints.ToStringMapOutput()
 	comp.LoadBalancerDNS = loadBalancerDNS
-	comp.DatastoreIds = datastoreIds.ToStringMapOutput()
+	comp.ServiceIds = serviceIds.ToStringMapOutput()
 
 	if err := ctx.RegisterResourceOutputs(comp, pulumi.Map{
 		"endpoints":       endpoints.ToStringMapOutput(),
 		"loadBalancerDns": loadBalancerDNS,
-		"datastoreIds":    datastoreIds.ToStringMapOutput(),
+		"serviceIds":      serviceIds.ToStringMapOutput(),
 	}); err != nil {
 		return nil, err
 	}

--- a/provider/defangazure/service.go
+++ b/provider/defangazure/service.go
@@ -52,6 +52,9 @@ type ServiceInputs struct {
 type ServiceOutputs struct {
 	pulumi.ResourceState
 	Endpoint pulumi.StringOutput `pulumi:"endpoint"`
+	// AppID is the Container App's ARM resource ID, surfaced through the
+	// Project's serviceIds output. Untagged — not part of the SDK schema.
+	AppID pulumi.StringOutput
 }
 
 // ServiceComponentType is the Pulumi resource type token for the Service component.
@@ -143,6 +146,7 @@ func createContainerApp(
 		return fmt.Errorf("creating Container App %s: %w", serviceName, err)
 	}
 	comp.Endpoint = caResult.App.LatestRevisionFqdn.ApplyT(fqdnToHTTPS).(pulumi.StringOutput)
+	comp.AppID = caResult.App.ID().ToStringOutput()
 	if err := ctx.RegisterResourceOutputs(comp, pulumi.Map{
 		"endpoint": comp.Endpoint,
 	}); err != nil {

--- a/provider/defanggcp/project.go
+++ b/provider/defanggcp/project.go
@@ -38,19 +38,20 @@ type ProjectOutputs struct {
 	// Load balancer DNS name (unused for GCP, kept for interface compat)
 	LoadBalancerDNS pulumi.StringPtrOutput `pulumi:"loadBalancerDns,optional"`
 
-	// DatastoreIds maps managed database service names to their physical
-	// identifiers — the Cloud SQL instance name for Postgres, the Memorystore
-	// instance ID for Redis — so consumers can attach externally managed
-	// alerting and dashboards. The components' typed instance handles are
-	// unreachable on Project children.
-	DatastoreIds pulumi.StringMapOutput `pulumi:"datastoreIds"`
+	// ServiceIds maps every service name to the physical identifier of its
+	// primary backing resource — the Cloud Run service name or Compute Engine
+	// regional MIG name for container services, the Cloud SQL instance name
+	// for Postgres, the Memorystore instance ID for Redis — so consumers can
+	// attach externally managed alerting and dashboards. Child components'
+	// handles are unreachable on Project children.
+	ServiceIds pulumi.StringMapOutput `pulumi:"serviceIds"`
 }
 
 // projectResult extends the cross-provider BuildResult with GCP-specific
 // handles surfaced as Project outputs.
 type projectResult struct {
 	common.BuildResult
-	DatastoreIds pulumi.StringMapOutput
+	ServiceIds pulumi.StringMapOutput
 }
 
 // Construct implements the ComponentResource interface for Project.
@@ -71,12 +72,12 @@ func (*Project) Construct(
 
 	comp.Endpoints = result.Endpoints
 	comp.LoadBalancerDNS = result.LoadBalancerDNS
-	comp.DatastoreIds = result.DatastoreIds
+	comp.ServiceIds = result.ServiceIds
 
 	if err := ctx.RegisterResourceOutputs(comp, pulumi.Map{
 		"endpoints":       result.Endpoints,
 		"loadBalancerDns": result.LoadBalancerDNS,
-		"datastoreIds":    result.DatastoreIds,
+		"serviceIds":      result.ServiceIds,
 	}); err != nil {
 		return nil, err
 	}
@@ -106,7 +107,7 @@ func buildProject(
 
 	// Deploy each service, wrapped in a component resource for tree organization
 	endpoints := pulumi.StringMap{}
-	datastoreIds := pulumi.StringMap{}
+	serviceIds := pulumi.StringMap{}
 	dependencies := map[string]pulumi.Resource{} // service name → component resource for dependees
 	var configProvider compose.ConfigProvider
 	if ctx.DryRun() {
@@ -145,7 +146,7 @@ func buildProject(
 		}
 		endpoints[svcName] = endpoint
 		if datastoreID != nil {
-			datastoreIds[svcName] = datastoreID
+			serviceIds[svcName] = datastoreID
 		}
 		dependencies[svcName] = svcComp
 		if lbEntry != nil {
@@ -175,7 +176,7 @@ func buildProject(
 			Endpoints:       endpoints.ToStringMapOutput(),
 			LoadBalancerDNS: pulumi.StringPtr("").ToStringPtrOutput(),
 		},
-		DatastoreIds: datastoreIds.ToStringMapOutput(),
+		ServiceIds: serviceIds.ToStringMapOutput(),
 	}, nil
 }
 
@@ -192,8 +193,8 @@ func buildService(
 	var endpoint pulumi.StringOutput
 	var lbEntry *providergcp.LBServiceEntry
 	var svcComp pulumi.Resource
-	// datastoreID is the managed database's physical identifier (nil for
-	// container services), surfaced through the Project's datastoreIds output.
+	// datastoreID is the physical identifier of the service's primary backing
+	// resource, surfaced through the Project's serviceIds output.
 	var datastoreID pulumi.StringInput
 
 	svcChildOpts := childOpts
@@ -242,6 +243,7 @@ func buildService(
 		}
 		endpoint = svcCompTyped.Endpoint
 		lbEntry = svcCompTyped.LBEntry
+		datastoreID = svcCompTyped.ResourceName
 		svcComp = svcCompTyped
 	}
 	// Managed Postgres/Redis still need the PrivateFqdn wired here because their

--- a/provider/defanggcp/project.go
+++ b/provider/defanggcp/project.go
@@ -37,6 +37,20 @@ type ProjectOutputs struct {
 
 	// Load balancer DNS name (unused for GCP, kept for interface compat)
 	LoadBalancerDNS pulumi.StringPtrOutput `pulumi:"loadBalancerDns,optional"`
+
+	// DatastoreIds maps managed database service names to their physical
+	// identifiers — the Cloud SQL instance name for Postgres, the Memorystore
+	// instance ID for Redis — so consumers can attach externally managed
+	// alerting and dashboards. The components' typed instance handles are
+	// unreachable on Project children.
+	DatastoreIds pulumi.StringMapOutput `pulumi:"datastoreIds"`
+}
+
+// projectResult extends the cross-provider BuildResult with GCP-specific
+// handles surfaced as Project outputs.
+type projectResult struct {
+	common.BuildResult
+	DatastoreIds pulumi.StringMapOutput
 }
 
 // Construct implements the ComponentResource interface for Project.
@@ -57,10 +71,12 @@ func (*Project) Construct(
 
 	comp.Endpoints = result.Endpoints
 	comp.LoadBalancerDNS = result.LoadBalancerDNS
+	comp.DatastoreIds = result.DatastoreIds
 
 	if err := ctx.RegisterResourceOutputs(comp, pulumi.Map{
 		"endpoints":       result.Endpoints,
 		"loadBalancerDns": result.LoadBalancerDNS,
+		"datastoreIds":    result.DatastoreIds,
 	}); err != nil {
 		return nil, err
 	}
@@ -75,7 +91,7 @@ func buildProject(
 	projectName string,
 	args ProjectInputs,
 	parentOpt pulumi.ResourceOption,
-) (*common.BuildResult, error) {
+) (*projectResult, error) {
 	childOpts := []pulumi.ResourceOption{parentOpt}
 
 	config, err := providergcp.BuildGlobalConfig(ctx, projectName, args.Domain, args.Services, childOpts...)
@@ -90,6 +106,7 @@ func buildProject(
 
 	// Deploy each service, wrapped in a component resource for tree organization
 	endpoints := pulumi.StringMap{}
+	datastoreIds := pulumi.StringMap{}
 	dependencies := map[string]pulumi.Resource{} // service name → component resource for dependees
 	var configProvider compose.ConfigProvider
 	if ctx.DryRun() {
@@ -121,12 +138,15 @@ func buildProject(
 			}
 		}
 
-		endpoint, svcComp, lbEntry, err := buildService(
+		endpoint, svcComp, lbEntry, datastoreID, err := buildService(
 			ctx, projectName, configProvider, svcName, svc, config, deps, childOpts)
 		if err != nil {
 			return nil, err
 		}
 		endpoints[svcName] = endpoint
+		if datastoreID != nil {
+			datastoreIds[svcName] = datastoreID
+		}
 		dependencies[svcName] = svcComp
 		if lbEntry != nil {
 			lbEntries = append(lbEntries, *lbEntry)
@@ -150,9 +170,12 @@ func buildProject(
 		return nil, err
 	}
 
-	return &common.BuildResult{
-		Endpoints:       endpoints.ToStringMapOutput(),
-		LoadBalancerDNS: pulumi.StringPtr("").ToStringPtrOutput(),
+	return &projectResult{
+		BuildResult: common.BuildResult{
+			Endpoints:       endpoints.ToStringMapOutput(),
+			LoadBalancerDNS: pulumi.StringPtr("").ToStringPtrOutput(),
+		},
+		DatastoreIds: datastoreIds.ToStringMapOutput(),
 	}, nil
 }
 
@@ -165,10 +188,13 @@ func buildService(
 	infra *providergcp.SharedInfra,
 	deps []pulumi.Resource,
 	childOpts []pulumi.ResourceOption,
-) (pulumi.StringOutput, pulumi.Resource, *providergcp.LBServiceEntry, error) {
+) (pulumi.StringOutput, pulumi.Resource, *providergcp.LBServiceEntry, pulumi.StringInput, error) {
 	var endpoint pulumi.StringOutput
 	var lbEntry *providergcp.LBServiceEntry
 	var svcComp pulumi.Resource
+	// datastoreID is the managed database's physical identifier (nil for
+	// container services), surfaced through the Project's datastoreIds output.
+	var datastoreID pulumi.StringInput
 
 	svcChildOpts := childOpts
 	if len(deps) > 0 {
@@ -180,37 +206,39 @@ func buildService(
 		// Managed Postgres → Cloud SQL
 		pgComp := &PostgresOutputs{}
 		if err := ctx.RegisterComponentResource(PostgresComponentType, svcName, pgComp, svcChildOpts...); err != nil {
-			return pulumi.StringOutput{}, nil, nil, fmt.Errorf("registering Cloud SQL component %s: %w", svcName, err)
+			return pulumi.StringOutput{}, nil, nil, nil, fmt.Errorf("registering Cloud SQL component %s: %w", svcName, err)
 		}
 		if err := createPostgres(ctx, pgComp, configProvider, svcName, svc, infra); err != nil {
-			return pulumi.StringOutput{}, nil, nil, err
+			return pulumi.StringOutput{}, nil, nil, nil, err
 		}
 		endpoint = pgComp.Endpoint
 		lbEntry = &providergcp.LBServiceEntry{Name: svcName, PostgresInstance: pgComp.Instance, Config: svc}
+		datastoreID = pgComp.Instance.Name
 		svcComp = pgComp
 	case svc.Redis != nil:
 		// Managed Redis → Memorystore
 		redisComp := &RedisOutputs{}
 		if err := ctx.RegisterComponentResource(RedisComponentType, svcName, redisComp, svcChildOpts...); err != nil {
-			return pulumi.StringOutput{}, nil, nil, fmt.Errorf("registering Memorystore component %s: %w", svcName, err)
+			return pulumi.StringOutput{}, nil, nil, nil, fmt.Errorf("registering Memorystore component %s: %w", svcName, err)
 		}
 		if err := createRedis(ctx, redisComp, svcName, svc, infra); err != nil {
-			return pulumi.StringOutput{}, nil, nil, err
+			return pulumi.StringOutput{}, nil, nil, nil, err
 		}
 		endpoint = redisComp.Endpoint
 		lbEntry = &providergcp.LBServiceEntry{Name: svcName, RedisInstance: redisComp.Instance, Config: svc}
+		datastoreID = redisComp.Instance.Name
 		svcComp = redisComp
 	default:
 		svcCompTyped := &ServiceOutputs{}
 		if err := ctx.RegisterComponentResource(ServiceComponentType, svcName, svcCompTyped, svcChildOpts...); err != nil {
-			return pulumi.StringOutput{}, nil, nil, fmt.Errorf("registering Service component %s: %w", svcName, err)
+			return pulumi.StringOutput{}, nil, nil, nil, fmt.Errorf("registering Service component %s: %w", svcName, err)
 		}
 		image, err := providergcp.GetServiceImage(ctx, svcName, svc, infra.Repos, infra.BuildInfra, svcChildOpts...)
 		if err != nil {
-			return pulumi.StringOutput{}, nil, nil, fmt.Errorf("resolving image for %s: %w", svcName, err)
+			return pulumi.StringOutput{}, nil, nil, nil, fmt.Errorf("resolving image for %s: %w", svcName, err)
 		}
 		if err := createService(ctx, svcCompTyped, projectName, configProvider, svcName, image, svc, infra, nil); err != nil {
-			return pulumi.StringOutput{}, nil, nil, err
+			return pulumi.StringOutput{}, nil, nil, nil, err
 		}
 		endpoint = svcCompTyped.Endpoint
 		lbEntry = svcCompTyped.LBEntry
@@ -223,7 +251,7 @@ func buildService(
 		lbEntry.PrivateFqdn = fmt.Sprintf("%s.%s", common.ServiceLabel(svcName), "google.internal")
 	}
 
-	return endpoint, svcComp, lbEntry, nil
+	return endpoint, svcComp, lbEntry, datastoreID, nil
 }
 
 func createServiceAccount(

--- a/provider/defanggcp/service.go
+++ b/provider/defanggcp/service.go
@@ -77,6 +77,10 @@ type ServiceOutputs struct {
 	// LBEntry is an internal-only handle used by the project dispatcher to wire
 	// services into the external load balancer. Untagged — not part of the SDK schema.
 	LBEntry *providergcp.LBServiceEntry
+	// ResourceName is the physical name of the primary backing resource (Cloud
+	// Run service or Compute Engine regional MIG), surfaced through the
+	// Project's serviceIds output. Untagged — not part of the SDK schema.
+	ResourceName pulumi.StringOutput
 }
 
 // ServiceComponentType is the Pulumi resource type token for the Service component.
@@ -236,6 +240,7 @@ func createService(
 		}
 		endpoint = crResult.Service.Uri
 		lbEntry = &providergcp.LBServiceEntry{Name: serviceName, CloudRunService: crResult.Service, Config: svc}
+		comp.ResourceName = crResult.Service.Name
 	} else {
 		ceArgs := &providergcp.ComputeEngineArgs{
 			SA:       identity,
@@ -257,6 +262,7 @@ func createService(
 		if svc.HasIngressPorts() || svc.HasHostPorts() {
 			lbEntry = &providergcp.LBServiceEntry{Name: serviceName, InstanceGroup: ceResult.InstanceGroup, Config: svc}
 		}
+		comp.ResourceName = ceResult.InstanceGroup.Name
 	}
 
 	if lbEntry != nil && svc.HasHostPorts() {

--- a/sdk/v2/go/defang-aws/project.go
+++ b/sdk/v2/go/defang-aws/project.go
@@ -17,11 +17,11 @@ type Project struct {
 	pulumi.ResourceState
 
 	ClusterName     pulumi.StringOutput    `pulumi:"clusterName"`
-	DatastoreIds    pulumi.StringMapOutput `pulumi:"datastoreIds"`
 	Endpoints       pulumi.StringMapOutput `pulumi:"endpoints"`
 	LoadBalancerArn pulumi.StringPtrOutput `pulumi:"loadBalancerArn"`
 	LoadBalancerDns pulumi.StringPtrOutput `pulumi:"loadBalancerDns"`
 	LogGroupName    pulumi.StringOutput    `pulumi:"logGroupName"`
+	ServiceIds      pulumi.StringMapOutput `pulumi:"serviceIds"`
 	ServiceNames    pulumi.StringMapOutput `pulumi:"serviceNames"`
 	TaskRoleArns    pulumi.StringMapOutput `pulumi:"taskRoleArns"`
 }
@@ -103,10 +103,6 @@ func (o ProjectOutput) ClusterName() pulumi.StringOutput {
 	return o.ApplyT(func(v *Project) pulumi.StringOutput { return v.ClusterName }).(pulumi.StringOutput)
 }
 
-func (o ProjectOutput) DatastoreIds() pulumi.StringMapOutput {
-	return o.ApplyT(func(v *Project) pulumi.StringMapOutput { return v.DatastoreIds }).(pulumi.StringMapOutput)
-}
-
 func (o ProjectOutput) Endpoints() pulumi.StringMapOutput {
 	return o.ApplyT(func(v *Project) pulumi.StringMapOutput { return v.Endpoints }).(pulumi.StringMapOutput)
 }
@@ -121,6 +117,10 @@ func (o ProjectOutput) LoadBalancerDns() pulumi.StringPtrOutput {
 
 func (o ProjectOutput) LogGroupName() pulumi.StringOutput {
 	return o.ApplyT(func(v *Project) pulumi.StringOutput { return v.LogGroupName }).(pulumi.StringOutput)
+}
+
+func (o ProjectOutput) ServiceIds() pulumi.StringMapOutput {
+	return o.ApplyT(func(v *Project) pulumi.StringMapOutput { return v.ServiceIds }).(pulumi.StringMapOutput)
 }
 
 func (o ProjectOutput) ServiceNames() pulumi.StringMapOutput {

--- a/sdk/v2/go/defang-aws/project.go
+++ b/sdk/v2/go/defang-aws/project.go
@@ -17,6 +17,7 @@ type Project struct {
 	pulumi.ResourceState
 
 	ClusterName     pulumi.StringOutput    `pulumi:"clusterName"`
+	DatastoreIds    pulumi.StringMapOutput `pulumi:"datastoreIds"`
 	Endpoints       pulumi.StringMapOutput `pulumi:"endpoints"`
 	LoadBalancerArn pulumi.StringPtrOutput `pulumi:"loadBalancerArn"`
 	LoadBalancerDns pulumi.StringPtrOutput `pulumi:"loadBalancerDns"`
@@ -100,6 +101,10 @@ func (o ProjectOutput) ToProjectOutputWithContext(ctx context.Context) ProjectOu
 
 func (o ProjectOutput) ClusterName() pulumi.StringOutput {
 	return o.ApplyT(func(v *Project) pulumi.StringOutput { return v.ClusterName }).(pulumi.StringOutput)
+}
+
+func (o ProjectOutput) DatastoreIds() pulumi.StringMapOutput {
+	return o.ApplyT(func(v *Project) pulumi.StringMapOutput { return v.DatastoreIds }).(pulumi.StringMapOutput)
 }
 
 func (o ProjectOutput) Endpoints() pulumi.StringMapOutput {

--- a/sdk/v2/go/defang-azure/project.go
+++ b/sdk/v2/go/defang-azure/project.go
@@ -16,9 +16,9 @@ import (
 type Project struct {
 	pulumi.ResourceState
 
-	DatastoreIds    pulumi.StringMapOutput `pulumi:"datastoreIds"`
 	Endpoints       pulumi.StringMapOutput `pulumi:"endpoints"`
 	LoadBalancerDns pulumi.StringPtrOutput `pulumi:"loadBalancerDns"`
+	ServiceIds      pulumi.StringMapOutput `pulumi:"serviceIds"`
 }
 
 // NewProject registers a new resource with the given unique name, arguments, and options.
@@ -92,16 +92,16 @@ func (o ProjectOutput) ToProjectOutputWithContext(ctx context.Context) ProjectOu
 	return o
 }
 
-func (o ProjectOutput) DatastoreIds() pulumi.StringMapOutput {
-	return o.ApplyT(func(v *Project) pulumi.StringMapOutput { return v.DatastoreIds }).(pulumi.StringMapOutput)
-}
-
 func (o ProjectOutput) Endpoints() pulumi.StringMapOutput {
 	return o.ApplyT(func(v *Project) pulumi.StringMapOutput { return v.Endpoints }).(pulumi.StringMapOutput)
 }
 
 func (o ProjectOutput) LoadBalancerDns() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Project) pulumi.StringPtrOutput { return v.LoadBalancerDns }).(pulumi.StringPtrOutput)
+}
+
+func (o ProjectOutput) ServiceIds() pulumi.StringMapOutput {
+	return o.ApplyT(func(v *Project) pulumi.StringMapOutput { return v.ServiceIds }).(pulumi.StringMapOutput)
 }
 
 func init() {

--- a/sdk/v2/go/defang-azure/project.go
+++ b/sdk/v2/go/defang-azure/project.go
@@ -16,6 +16,7 @@ import (
 type Project struct {
 	pulumi.ResourceState
 
+	DatastoreIds    pulumi.StringMapOutput `pulumi:"datastoreIds"`
 	Endpoints       pulumi.StringMapOutput `pulumi:"endpoints"`
 	LoadBalancerDns pulumi.StringPtrOutput `pulumi:"loadBalancerDns"`
 }
@@ -89,6 +90,10 @@ func (o ProjectOutput) ToProjectOutput() ProjectOutput {
 
 func (o ProjectOutput) ToProjectOutputWithContext(ctx context.Context) ProjectOutput {
 	return o
+}
+
+func (o ProjectOutput) DatastoreIds() pulumi.StringMapOutput {
+	return o.ApplyT(func(v *Project) pulumi.StringMapOutput { return v.DatastoreIds }).(pulumi.StringMapOutput)
 }
 
 func (o ProjectOutput) Endpoints() pulumi.StringMapOutput {

--- a/sdk/v2/go/defang-gcp/project.go
+++ b/sdk/v2/go/defang-gcp/project.go
@@ -16,9 +16,9 @@ import (
 type Project struct {
 	pulumi.ResourceState
 
-	DatastoreIds    pulumi.StringMapOutput `pulumi:"datastoreIds"`
 	Endpoints       pulumi.StringMapOutput `pulumi:"endpoints"`
 	LoadBalancerDns pulumi.StringPtrOutput `pulumi:"loadBalancerDns"`
+	ServiceIds      pulumi.StringMapOutput `pulumi:"serviceIds"`
 }
 
 // NewProject registers a new resource with the given unique name, arguments, and options.
@@ -92,16 +92,16 @@ func (o ProjectOutput) ToProjectOutputWithContext(ctx context.Context) ProjectOu
 	return o
 }
 
-func (o ProjectOutput) DatastoreIds() pulumi.StringMapOutput {
-	return o.ApplyT(func(v *Project) pulumi.StringMapOutput { return v.DatastoreIds }).(pulumi.StringMapOutput)
-}
-
 func (o ProjectOutput) Endpoints() pulumi.StringMapOutput {
 	return o.ApplyT(func(v *Project) pulumi.StringMapOutput { return v.Endpoints }).(pulumi.StringMapOutput)
 }
 
 func (o ProjectOutput) LoadBalancerDns() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Project) pulumi.StringPtrOutput { return v.LoadBalancerDns }).(pulumi.StringPtrOutput)
+}
+
+func (o ProjectOutput) ServiceIds() pulumi.StringMapOutput {
+	return o.ApplyT(func(v *Project) pulumi.StringMapOutput { return v.ServiceIds }).(pulumi.StringMapOutput)
 }
 
 func init() {

--- a/sdk/v2/go/defang-gcp/project.go
+++ b/sdk/v2/go/defang-gcp/project.go
@@ -16,6 +16,7 @@ import (
 type Project struct {
 	pulumi.ResourceState
 
+	DatastoreIds    pulumi.StringMapOutput `pulumi:"datastoreIds"`
 	Endpoints       pulumi.StringMapOutput `pulumi:"endpoints"`
 	LoadBalancerDns pulumi.StringPtrOutput `pulumi:"loadBalancerDns"`
 }
@@ -89,6 +90,10 @@ func (o ProjectOutput) ToProjectOutput() ProjectOutput {
 
 func (o ProjectOutput) ToProjectOutputWithContext(ctx context.Context) ProjectOutput {
 	return o
+}
+
+func (o ProjectOutput) DatastoreIds() pulumi.StringMapOutput {
+	return o.ApplyT(func(v *Project) pulumi.StringMapOutput { return v.DatastoreIds }).(pulumi.StringMapOutput)
 }
 
 func (o ProjectOutput) Endpoints() pulumi.StringMapOutput {


### PR DESCRIPTION
Per Lio's direction (DefangLabs/defang-mvp#3101 + review): the Project exposes the physical IDs of its children so consumers can hook up alarms, dashboards, and other externally managed attachments — for **all** services, not just databases, on **all three clouds**.

## What

New `serviceIds` Project output: service name → physical identifier of the service's primary backing resource.

| Cloud | Containers | Redis | Postgres |
|---|---|---|---|
| AWS | ECS service name (same value as `serviceNames`) | MemoryDB cluster name / ElastiCache replication group ID | RDS `DBInstanceIdentifier` |
| GCP | Cloud Run service name / Compute Engine regional MIG name | Memorystore instance ID | Cloud SQL instance name |
| Azure | Container App ARM ID | Redis Enterprise cluster ARM ID | Flexible Server ARM ID |

Azure carries full ARM resource IDs because that's the scope Azure Monitor alert rules target; Azure LLM services are omitted (they share the project's Cognitive Services deployment, no single backing resource).

## Why

The standalone components export `clusterId`/`instanceIdentifier` for exactly this, but remote-component children are unreachable from the consuming program, so a Project-owned resource's identifiers were inaccessible — the original gap in DefangLabs/defang-mvp#3101. Complements the recipe-gated provider alarms in #352: the recipe is the zero-effort default, `serviceIds` is the escape hatch for custom alerting.

Note for ElastiCache consumers: metric alarms are per *member* cache cluster, and member naming differs between cluster modes — resolve members from the replication group (e.g. `aws.elasticache.ReplicationGroup.get(...).memberClusters`) rather than reconstructing names from the RG ID.

Schemas + Go SDKs regenerated and committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw7j9FYnbChZJbYArxbhuo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `serviceIds` project output across AWS, Azure, and GCP.
  * Service IDs now identify the underlying deployed resources for containers, databases, caches, and other supported services.
  * Added SDK accessors so applications can retrieve service IDs programmatically.
  * Updated resource schemas to expose and require the new output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->