### PR TITLE
feat(compose): interpolate config variables in service command

### DIFF
--- a/provider/compose/helpers.go
+++ b/provider/compose/helpers.go
@@ -200,6 +200,28 @@ func ToPulumiStringArray(ss []string) pulumi.StringArray {
 	return arr
 }
 
+// InterpolateCommand resolves $VAR / ${VAR} config references in each element
+// of a command (or entrypoint) list, mirroring environment-value
+// interpolation. Elements without references pass through unchanged. Unlike
+// bare ${VAR} environment values, command elements are always interpolated
+// inline: container runtimes exec the argv without a shell, so a native
+// secret reference is not an option here.
+func InterpolateCommand(
+	ctx *pulumi.Context,
+	configProvider ConfigProvider,
+	command []string,
+	opts ...pulumi.InvokeOption,
+) pulumi.StringArray {
+	if len(command) == 0 {
+		return nil
+	}
+	arr := make(pulumi.StringArray, len(command))
+	for i, s := range command {
+		arr[i] = InterpolateEnvironmentVariable(ctx, configProvider, s, opts...)
+	}
+	return arr
+}
+
 func InterpolateEnvironmentVariable(
 	ctx *pulumi.Context,
 	configProvider ConfigProvider,

--- a/provider/compose/helpers_test.go
+++ b/provider/compose/helpers_test.go
@@ -238,6 +238,81 @@ func TestInterpolateEnvironmentVariable(t *testing.T) {
 	})
 }
 
+func TestInterpolateCommand(t *testing.T) {
+	t.Run("nil command returns nil", func(t *testing.T) {
+		assert.Nil(t, InterpolateCommand(nil, &mockConfigProvider{}, nil))
+	})
+	t.Run("empty command returns nil", func(t *testing.T) {
+		assert.Nil(t, InterpolateCommand(nil, &mockConfigProvider{}, []string{}))
+	})
+
+	tests := []struct {
+		name     string
+		command  []string
+		configs  map[string]string
+		expected []string
+	}{
+		{
+			name:     "literals pass through unchanged",
+			command:  []string{"litellm", "--port", "4000"},
+			expected: []string{"litellm", "--port", "4000"},
+		},
+		{
+			name:     "braced variable element",
+			command:  []string{"litellm", "--model", "${MODEL}"},
+			configs:  map[string]string{"MODEL": "gpt-4o"},
+			expected: []string{"litellm", "--model", "gpt-4o"},
+		},
+		{
+			name:     "unbraced variable element",
+			command:  []string{"litellm", "--model", "$MODEL"},
+			configs:  map[string]string{"MODEL": "gpt-4o"},
+			expected: []string{"litellm", "--model", "gpt-4o"},
+		},
+		{
+			name:     "variable embedded in text",
+			command:  []string{"sh", "-c", "serve --model=${MODEL} --host=0.0.0.0"},
+			configs:  map[string]string{"MODEL": "llama3"},
+			expected: []string{"sh", "-c", "serve --model=llama3 --host=0.0.0.0"},
+		},
+		{
+			name:     "escaped dollar stays literal",
+			command:  []string{"echo", "$${NOT_A_VAR}"},
+			expected: []string{"echo", "${NOT_A_VAR}"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+				provider := &mockConfigProvider{values: tt.configs}
+				out := InterpolateCommand(ctx, provider, tt.command)
+
+				require.Len(t, out, len(tt.expected))
+				out.ToStringArrayOutput().ApplyT(func(got []string) []string {
+					assert.Equal(t, tt.expected, got)
+					return got
+				})
+				return nil
+			}, pulumi.WithMocks("proj", "stack", testMocks{}))
+			require.NoError(t, err)
+		})
+	}
+
+	t.Run("nil config provider passes command through", func(t *testing.T) {
+		err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+			out := InterpolateCommand(ctx, nil, []string{"litellm", "--model", "${MODEL}"})
+
+			out.ToStringArrayOutput().ApplyT(func(got []string) []string {
+				assert.Equal(t, []string{"litellm", "--model", "${MODEL}"}, got)
+				return got
+			})
+			return nil
+		}, pulumi.WithMocks("proj", "stack", testMocks{}))
+		require.NoError(t, err)
+	})
+}
+
 // healthCheckPathPortCases mirrors the TS suite at
 // defang-mvp/pulumi/test/healthcheck.test.ts (#convertHealthcheck) so behavior
 // parity with the legacy pipeline is explicit. Additional cases beyond the TS

--- a/provider/defangaws/aws/ecs.go
+++ b/provider/defangaws/aws/ecs.go
@@ -624,6 +624,20 @@ func CreateECSService(
 		return nil, err
 	}
 
+	// Resolve ${VAR} config references in the container command, mirroring
+	// env-value interpolation: the argv is exec'd without a shell, so
+	// references must be inlined at deploy time. Returns the index into
+	// allInputs, or -1 for an empty command.
+	resolveCommand := func(cmd []string) int {
+		if len(cmd) == 0 {
+			return -1
+		}
+		idx := len(allInputs)
+		allInputs = append(allInputs, compose.InterpolateCommand(ctx, configProvider, cmd, parentOpt))
+		return idx
+	}
+	commandIdx := resolveCommand(svc.Command)
+
 	// Resolve sidecar container env vars the same way as the main container.
 	type sidecarData struct {
 		name       string
@@ -631,6 +645,7 @@ func CreateECSService(
 		envEntries []envEntry
 		secrets    []Secret
 		imageIdx   int // index into allInputs where the resolved image URI will be
+		commandIdx int // index into allInputs where the resolved command will be, or -1
 	}
 	sidecarDatas := make([]sidecarData, 0, len(args.Sidecars))
 	for scName, sc := range common.Sorted(args.Sidecars) {
@@ -647,7 +662,8 @@ func CreateECSService(
 		imageIdx := len(allInputs)
 		allInputs = append(allInputs, sc.Image)
 		sidecarDatas = append(sidecarDatas, sidecarData{
-			name: scName, cfg: sc, envEntries: scEnvEntries, secrets: scSecrets, imageIdx: imageIdx,
+			name: scName, cfg: sc, envEntries: scEnvEntries, secrets: scSecrets,
+			imageIdx: imageIdx, commandIdx: resolveCommand(sc.Command),
 		})
 	}
 
@@ -703,6 +719,13 @@ func CreateECSService(
 		}
 		logConfiguration := logConfigurationFor(containerName)
 
+		commandAt := func(idx int) []string {
+			if idx < 0 {
+				return nil
+			}
+			return all[idx].([]string)
+		}
+
 		// NOTE: dnsSearchDomains is NOT supported on Fargate with awsvpc network mode.
 		// Instead, we rewrite environment variables to use FQDNs at the provider level.
 
@@ -712,7 +735,7 @@ func CreateECSService(
 			PortMappings:     portMappings,
 			Environment:      envVars,
 			Secrets:          mainSecrets,
-			Command:          svc.Command,
+			Command:          commandAt(commandIdx),
 			EntryPoint:       svc.Entrypoint,
 			DependsOn:        buildDependsOn(svc.DependsOn, args.Sidecars),
 			HealthCheck:      healthCheck,
@@ -741,7 +764,7 @@ func CreateECSService(
 				PortMappings:     []PortMapping{},
 				Environment:      scEnvVars,
 				Secrets:          sd.secrets,
-				Command:          sd.cfg.Command,
+				Command:          commandAt(sd.commandIdx),
 				EntryPoint:       sd.cfg.Entrypoint,
 				DependsOn:        buildDependsOn(sd.cfg.DependsOn, args.Sidecars),
 				HealthCheck:      buildHealthCheck(sd.cfg.HealthCheck),

--- a/provider/defangazure/azure/containerapp.go
+++ b/provider/defangazure/azure/containerapp.go
@@ -304,9 +304,10 @@ func CreateContainerApp(
 				Name:    pulumi.String(serviceName),
 				Image:   imageURI,
 				Command: compose.ToPulumiStringArray(svc.Entrypoint),
-				Args:    compose.ToPulumiStringArray(svc.Command),
-				Env:     result.Envs,
-				Probes:  probes,
+				// Resolve ${VAR} config references like env values
+				Args:   compose.InterpolateCommand(ctx, infra.ConfigProvider, svc.Command),
+				Env:    result.Envs,
+				Probes: probes,
 				Resources: &app.ContainerResourcesArgs{
 					Cpu:    pulumi.Float64(cpu),
 					Memory: pulumi.String(mem),

--- a/provider/defanggcp/gcp/cloudrun.go
+++ b/provider/defanggcp/gcp/cloudrun.go
@@ -205,9 +205,9 @@ func buildTemplate(
 		}
 	}
 
-	// Build command/args
+	// Build command/args, resolving ${VAR} config references like env values
 	commands := compose.ToPulumiStringArray(svc.Entrypoint)
-	cmdArgs := compose.ToPulumiStringArray(svc.Command)
+	cmdArgs := compose.InterpolateCommand(ctx, configProvider, svc.Command, opts...)
 
 	// Cloud Run config from recipe
 	maxInstances := svc.GetReplicas()


### PR DESCRIPTION
Fixes DefangLabs/pulumi-defang#355

A compose service can override the image CMD via `command`, but variable references in it (e.g. `--model $MODEL`) were passed to the container verbatim. The CLI deliberately leaves unresolved variables as `${VAR}` for the CD to resolve, and the CD only did so for `environment` values — and since the argv is exec'd without a shell, the literal `${MODEL}` was never expanded anywhere.

## Changes

- New `compose.InterpolateCommand` helper: resolves `$VAR`/`${VAR}` config references per command element using the same compose-go substitution as environment values (escaped `$$` stays literal). Nil/empty commands pass through as nil.
- **AWS ECS**: main and sidecar container commands are resolved through the existing `allInputs` output-gathering before the container-definitions JSON is built.
- **GCP Cloud Run**: `Args` now interpolated.
- **Azure Container Apps**: `Args` now interpolated.
- Unit tests for the helper (literals, braced/unbraced refs, embedded refs, escaped `$$`, nil provider passthrough).

## Notes

- Command elements can't use native secret references (SSM / Key Vault) the way bare `${VAR}` env values do — the resolved value is inlined into the container definition, same as env values with surrounding text today.
- **GCP Compute Engine deploys are left as-is**: they have no config-provider resolution at all yet (issue #164), and interpolating there would embed config values in plain-text instance metadata; defer to that work.
- `entrypoint` has the same limitation; left untouched to keep this minimal. Happy to extend `InterpolateCommand` to it here or in a follow-up.
- Companion PR for the legacy TS CD: DefangLabs/defang-mvp (linked from the issue).

## Testing

- `go test ./provider/...` — all pass (includes new `TestInterpolateCommand`)
- `cd tests && go test -short ./...` — aws/azure/gcp all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw7j9FYnbChZJbYArxbhuo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `${VAR}` and `$VAR` interpolation in container commands and arguments.
  * Resolved command variables during deployment across ECS, Azure Container Apps, and Google Cloud Run.
  * Preserved escaped variable references and supported embedded variables within command arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->