### PR TITLE
GCP Compute Engine: native secrets for env via boot-fetch (#164)

### DIFF
--- a/provider/defanggcp/gcp/compute.go
+++ b/provider/defanggcp/gcp/compute.go
@@ -9,6 +9,7 @@ import (
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/compute"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/projects"
+	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/secretmanager"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -35,6 +36,7 @@ type ComputeEngineArgs struct {
 // run on Cloud Run (e.g. background workers with no listening port).
 func CreateComputeEngine(
 	ctx *pulumi.Context,
+	configProvider compose.ConfigProvider,
 	serviceName string,
 	image pulumi.StringInput,
 	svc compose.ServiceConfig,
@@ -52,6 +54,20 @@ func CreateComputeEngine(
 			"roles/monitoring.metricWriter",
 			"roles/cloudtrace.agent",
 		}, gcpConfig, parentOpt)
+	}
+
+	// Classify each container's env into inline values and native secret refs,
+	// then grant the instance SA access to every referenced secret. Bare ${VAR}
+	// / null "KEY:" values are boot-fetched (see secretFetchScript) rather than
+	// embedded in instance metadata.
+	mainPlan := classifyComputeSecretEnv(ctx, configProvider, svc.Environment)
+	sidecarPlans := make(map[string]containerSecretPlan, len(args.Sidecars))
+	for name, sc := range args.Sidecars {
+		sidecarPlans[name] = classifyComputeSecretEnv(ctx, configProvider, sc.Environment)
+	}
+	secretMembers, err := grantSecretAccess(ctx, serviceName, args.SA, mainPlan, sidecarPlans, parentOpt)
+	if err != nil {
+		return nil, err
 	}
 
 	namedPorts := make(compute.RegionInstanceGroupManagerNamedPortArray, len(svc.Ports))
@@ -79,11 +95,17 @@ func CreateComputeEngine(
 	fqdn := common.ServiceFQDN(serviceName, svc, gcpConfig.Domain, "google.internal")
 	cloudInit := getCloudInitConfig(
 		serviceName, image, svc, gcpConfig.Region, gcpConfig.Etag, gcpConfig.ProjectName, gcpConfig.Stack, fqdn,
-		addHealthCheckSidecar, args.Sidecars)
+		gcpConfig.GcpProject, addHealthCheckSidecar, args.Sidecars, mainPlan, sidecarPlans)
 
+	// The instance template must depend on the secret IAM bindings so instances
+	// don't boot (and run the fetch script) before they can read the secrets.
+	templateOpts := []pulumi.ResourceOption{parentOpt}
+	if len(secretMembers) > 0 {
+		templateOpts = append(templateOpts, pulumi.DependsOn(secretMembers))
+	}
 	instanceTemplate, err := createInstanceTemplate(
 		ctx, serviceName, serviceName, machineType, getComputeBootImage(svc), cloudInit,
-		args.SA, args.Triggers, gcpConfig, iamDeps, parentOpt)
+		args.SA, args.Triggers, gcpConfig, iamDeps, templateOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -332,6 +354,52 @@ func buildMIGUpdatePolicy(numZones, targetSize int) *compute.RegionInstanceGroup
 	return policy
 }
 
+// grantSecretAccess grants the instance service account
+// roles/secretmanager.secretAccessor on every Secret Manager secret referenced
+// (as a bare ${VAR} or null "KEY:") by the main container or any sidecar, so the
+// boot-time fetch script can read them. Secret IDs are deduped across
+// containers. Returns the created members for use as instance-template
+// dependencies.
+func grantSecretAccess(
+	ctx *pulumi.Context,
+	serviceName string,
+	sa *ServiceIdentity,
+	mainPlan containerSecretPlan,
+	sidecarPlans map[string]containerSecretPlan,
+	parentOpt pulumi.ResourceOrInvokeOption,
+) ([]pulumi.Resource, error) {
+	seen := make(map[string]struct{})
+	var ids []string
+	collect := func(plan containerSecretPlan) {
+		for _, r := range plan.secretRefs {
+			if _, ok := seen[r.secretID]; !ok {
+				seen[r.secretID] = struct{}{}
+				ids = append(ids, r.secretID)
+			}
+		}
+	}
+	collect(mainPlan)
+	for _, plan := range common.Sorted(sidecarPlans) {
+		collect(plan)
+	}
+
+	var members []pulumi.Resource
+	for _, sid := range ids {
+		opts := append([]pulumi.ResourceOption{parentOpt}, sa.deleteOpts()...)
+		member, err := secretmanager.NewSecretIamMember(ctx, serviceName+"-secret-"+sid,
+			&secretmanager.SecretIamMemberArgs{
+				SecretId: pulumi.String(sid),
+				Role:     pulumi.String("roles/secretmanager.secretAccessor"),
+				Member:   pulumi.Sprintf("serviceAccount:%v", sa.Email),
+			}, opts...)
+		if err != nil {
+			return nil, fmt.Errorf("granting secret access for %s: %w", sid, err)
+		}
+		members = append(members, member)
+	}
+	return members, nil
+}
+
 // addRolesToServiceAccount grants IAM roles to a service account at the project level.
 // Returns a resource array output that can be used as a dependency.
 func addRolesToServiceAccount(
@@ -484,6 +552,100 @@ func dockerRunFlags(
 	return params, command
 }
 
+// computeSecretEnv maps a container env var to the Secret Manager secret ID
+// whose latest version supplies its value. The value is fetched at container
+// start (see secretFetchScript) instead of being embedded in instance metadata,
+// which is readable unauthenticated from the instance.
+type computeSecretEnv struct {
+	envKey   string
+	secretID string
+}
+
+// containerSecretPlan is the per-container result of classifyComputeSecretEnv:
+// the env values inlined into `docker run -e` and the ones boot-fetched from
+// Secret Manager.
+type containerSecretPlan struct {
+	inline     compose.Environment
+	secretRefs []computeSecretEnv
+}
+
+// classifyComputeSecretEnv splits a container's environment into values inlined
+// into the `docker run` command (static literals and dynamic Outputs) and
+// native secret references (bare ${VAR} or null "KEY:") that are boot-fetched
+// from Secret Manager. Interpolated values (mixed literal + ${VAR}) stay on the
+// inline path for now; resolving them without leaking plaintext into instance
+// metadata needs deploy-time derived configs — see issue 293. With no config
+// provider (e.g. standalone with no secrets), everything is inlined.
+func classifyComputeSecretEnv(
+	ctx *pulumi.Context, cp compose.ConfigProvider, env compose.Environment,
+) containerSecretPlan {
+	if cp == nil {
+		return containerSecretPlan{inline: env}
+	}
+	plan := containerSecretPlan{inline: make(compose.Environment, len(env))}
+	// Iterate sorted so the generated fetch script and IAM bindings are stable.
+	for k, v := range common.Sorted(env) {
+		if configKey := compose.GetConfigName2(k, v); configKey != "" {
+			if secretID, err := cp.GetSecretRef(ctx, configKey); err == nil && secretID != "" {
+				plan.secretRefs = append(plan.secretRefs, computeSecretEnv{envKey: k, secretID: secretID})
+				continue
+			}
+			// Couldn't resolve a ref: fall through and inline (matches the
+			// pre-secrets behavior rather than dropping the variable).
+		}
+		plan.inline[k] = v
+	}
+	return plan
+}
+
+// secretFetchScript returns the cloud-init write_files block for the boot-time
+// secret fetch script, the systemd ExecStartPre line that runs it, and the
+// `docker run --env-file` flag that injects the fetched values. All three are
+// empty when there are no secret refs.
+//
+// The script reads the instance service account's OAuth token from the metadata
+// server and fetches each secret's latest version from the Secret Manager REST
+// API — no gcloud (absent on Container-Optimized OS) required. Values land in a
+// tmpfs file (0600, /run) that never touches disk or instance metadata.
+//
+// NOTE: docker --env-file is line-oriented, so a secret whose value contains a
+// newline (e.g. a PEM key) cannot be injected this way. Such values need a
+// per-secret file mount; tracked as a follow-up.
+func secretFetchScript(gcpProject, unit string, refs []computeSecretEnv) (writeFile, execStartPre, envFileFlag string) {
+	if len(refs) == 0 {
+		return "", "", ""
+	}
+	scriptPath := "/opt/defang/" + unit + "-secrets.sh"
+	envFile := "/run/defang/" + unit + ".env"
+
+	var s strings.Builder
+	s.WriteString("#!/bin/bash\n")
+	s.WriteString("set -uo pipefail\n")
+	s.WriteString("umask 077\n")
+	s.WriteString("mkdir -p /run/defang\n")
+	s.WriteString(`tok=$(curl -s -H "Metadata-Flavor: Google" ` +
+		`http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token ` +
+		`| grep -o '"access_token":"[^"]*"' | cut -d'"' -f4)` + "\n")
+	fmt.Fprintf(&s, `sm() { curl -s -H "Authorization: Bearer $tok" `+
+		`"https://secretmanager.googleapis.com/v1/projects/%s/secrets/$1/versions/latest:access" `+
+		`| grep -o '"data":"[^"]*"' | cut -d'"' -f4 | base64 -d; }`+"\n", gcpProject)
+	s.WriteString("{\n")
+	for _, r := range refs {
+		fmt.Fprintf(&s, "printf '%%s=%%s\\n' '%s' \"$(sm '%s')\"\n", r.envKey, r.secretID)
+	}
+	fmt.Fprintf(&s, "} > %s\n", envFile)
+
+	// Indent the script body under the write_files `content: |` block (6 spaces).
+	var wf strings.Builder
+	fmt.Fprintf(&wf, "\n  - path: %s\n    permissions: \"0700\"\n    owner: root\n    content: |\n", scriptPath)
+	for _, line := range strings.Split(strings.TrimRight(s.String(), "\n"), "\n") {
+		wf.WriteString("      ")
+		wf.WriteString(line)
+		wf.WriteString("\n")
+	}
+	return wf.String(), "ExecStartPre=" + scriptPath, "--env-file " + envFile
+}
+
 // flattenEnvFlags renders `-e "K=V"` docker flags for the given static env
 // pairs followed by the service's compose environment. Dynamic (Output)
 // values are threaded through a Sprintf so they resolve at apply time.
@@ -533,14 +695,26 @@ func getCloudInitConfig(
 	image pulumi.StringInput,
 	svc compose.ServiceConfig,
 	region, etag, projectName, stack, fqdn string,
+	gcpProject string,
 	addHealthCheckSidecar bool,
 	sidecars map[string]compose.ServiceConfig,
+	mainPlan containerSecretPlan,
+	sidecarPlans map[string]containerSecretPlan,
 ) pulumi.StringOutput {
 	var buf strings.Builder
 	buf.WriteString("#cloud-config\n\nwrite_files:")
 
 	containerName := svc.GetContainerName(serviceName)
 	params, command := dockerRunFlags(svc, sidecars)
+
+	// Secret env vars are boot-fetched into a tmpfs env-file rather than embedded
+	// in instance metadata. The fetch script is written first so it precedes the
+	// service unit in write_files.
+	secretWriteFile, secretExecPre, secretEnvFileFlag := secretFetchScript(gcpProject, serviceName, mainPlan.secretRefs)
+	if secretEnvFileFlag != "" {
+		params = append(params, secretEnvFileFlag)
+	}
+	buf.WriteString(escapePercent(secretWriteFile))
 
 	// Defang-injected runtime vars, mirroring the Cloud Run path (buildEnvVars).
 	staticEnv := [][2]string{{"DEFANG_SERVICE", serviceName}}
@@ -550,7 +724,7 @@ func getCloudInitConfig(
 	if fqdn != "" {
 		staticEnv = append(staticEnv, [2]string{"DEFANG_FQDN", fqdn})
 	}
-	envFlags := flattenEnvFlags(staticEnv, svc.Environment)
+	envFlags := flattenEnvFlags(staticEnv, mainPlan.inline)
 
 	var dependencies strings.Builder
 	dependencies.WriteString("Wants=gcr-online.target docker.socket\n      After=gcr-online.target docker.socket")
@@ -581,7 +755,7 @@ func getCloudInitConfig(
 	}
 	for name, sc := range common.Sorted(sidecars) {
 		var unitText pulumi.StringInput
-		unitText, runcmds = buildSidecarUnit(serviceName, name, region, sc, sidecars, runcmds)
+		unitText, runcmds = buildSidecarUnit(serviceName, name, region, gcpProject, sc, sidecars, sidecarPlans[name], runcmds)
 		extraUnitsFmt.WriteString("%s")
 		extraUnitsArgs = append(extraUnitsArgs, unitText)
 	}
@@ -605,6 +779,7 @@ func getCloudInitConfig(
       Restart=always
       RestartSec=30
       Environment="HOME=/home/container-user"
+      %[9]s
       ExecStartPre=/usr/bin/docker-credential-gcr configure-docker --registries %[5]s-docker.pkg.dev
       ExecStart=/usr/bin/docker run --pull=always --rm --name=%[7]s %[3]s %%s%%s %[4]s
       ExecStop=/usr/bin/docker stop -t %[6]d %[7]s
@@ -624,7 +799,8 @@ runcmd:
 		region,
 		stopGraceSeconds(svc),
 		containerName,
-		escapePercent(strings.Join(runcmds, "\n  - ")))
+		escapePercent(strings.Join(runcmds, "\n  - ")),
+		escapePercent(secretExecPre))
 
 	// buf now contains exactly three %s placeholders (env flags, image, and
 	// extra units — the Inputs that may resolve at apply time); all other
@@ -669,15 +845,22 @@ func sidecarUnitName(serviceName, sidecarName string) string {
 // --volumes-from keeps working across restarts; a run-once sidecar (restart: "no")
 // becomes a oneshot unit the main service can order After=.
 func buildSidecarUnit(
-	serviceName, sidecarName, region string,
+	serviceName, sidecarName, region, gcpProject string,
 	sc compose.ServiceConfig,
 	sidecars map[string]compose.ServiceConfig,
+	plan containerSecretPlan,
 	runcmds []string,
 ) (pulumi.StringInput, []string) {
 	unit := sidecarUnitName(serviceName, sidecarName)
 	containerName := sc.GetContainerName(sidecarName)
 	params, command := dockerRunFlags(sc, sidecars)
-	envFlags := flattenEnvFlags(nil, sc.Environment)
+
+	// Boot-fetch this sidecar's secret env into its own tmpfs env-file.
+	secretWriteFile, secretExecPre, secretEnvFileFlag := secretFetchScript(gcpProject, unit, plan.secretRefs)
+	if secretEnvFileFlag != "" {
+		params = append(params, secretEnvFileFlag)
+	}
+	envFlags := flattenEnvFlags(nil, plan.inline)
 
 	var serviceSection string
 	if sc.Restart == "no" {
@@ -687,7 +870,10 @@ func buildSidecarUnit(
 			stopGraceSeconds(sc), containerName)
 	}
 
-	units := pulumi.Sprintf(`
+	// %[11]s (secret fetch script write_files entry) and %[12]s (its
+	// ExecStartPre) are passed as Sprintf argument values, so any '%' in the
+	// script survives literally without escaping.
+	units := pulumi.Sprintf(`%[11]s
   - path: /etc/systemd/system/%[1]s.service
     permissions: "0644"
     owner: root
@@ -701,6 +887,7 @@ func buildSidecarUnit(
       [Service]
       %[4]s
       Environment="HOME=/home/container-user"
+      %[12]s
       ExecStartPre=/usr/bin/docker-credential-gcr configure-docker --registries %[5]s-docker.pkg.dev
       ExecStartPre=-/usr/bin/docker rm -f %[6]s
       ExecStart=/usr/bin/docker run --pull=always --name=%[6]s %[7]s %[8]s%[9]s %[10]s
@@ -719,7 +906,9 @@ func buildSidecarUnit(
 		strings.Join(params, " "),
 		envFlags,
 		sc.Image, // validated non-nil in createService; may resolve at apply time
-		strings.Join(command, " "))
+		strings.Join(command, " "),
+		secretWriteFile,
+		secretExecPre)
 
 	runcmds = append(runcmds,
 		fmt.Sprintf("systemctl enable %s.service", unit),

--- a/provider/defanggcp/gcp/compute.go
+++ b/provider/defanggcp/gcp/compute.go
@@ -70,24 +70,7 @@ func CreateComputeEngine(
 		return nil, err
 	}
 
-	namedPorts := make(compute.RegionInstanceGroupManagerNamedPortArray, len(svc.Ports))
-	var healthCheckPort *int
-	for i, port := range svc.Ports {
-		proto := port.GetProtocol()
-		namedPorts[i] = &compute.RegionInstanceGroupManagerNamedPortArgs{
-			Name: pulumi.String(fmt.Sprintf("port-%s-%d", proto, port.Target)),
-			Port: pulumi.Int(port.Target),
-		}
-		if proto == "tcp" {
-			p := int(port.Target)
-			healthCheckPort = &p
-		}
-	}
-	addHealthCheckSidecar := healthCheckPort == nil
-	if addHealthCheckSidecar {
-		p := 8080
-		healthCheckPort = &p
-	}
+	namedPorts, healthCheckPort, addHealthCheckSidecar := computeNamedPorts(svc)
 
 	// DEFANG_FQDN: custom domain, else public FQDN (ingress), else the private
 	// FQDN (<label>.google.internal) for internal services — the private zone is
@@ -156,6 +139,33 @@ func CreateComputeEngine(
 	}
 
 	return &ComputeEngineResult{InstanceGroup: instanceGroup}, nil
+}
+
+// computeNamedPorts builds the MIG named-port array from the service's ports and
+// determines the health-check port. Services with no TCP port get a dedicated
+// HTTP health-check sidecar on 8080 so the MIG auto-healer can probe liveness.
+func computeNamedPorts(svc compose.ServiceConfig) (
+	compute.RegionInstanceGroupManagerNamedPortArray, *int, bool,
+) {
+	namedPorts := make(compute.RegionInstanceGroupManagerNamedPortArray, len(svc.Ports))
+	var healthCheckPort *int
+	for i, port := range svc.Ports {
+		proto := port.GetProtocol()
+		namedPorts[i] = &compute.RegionInstanceGroupManagerNamedPortArgs{
+			Name: pulumi.String(fmt.Sprintf("port-%s-%d", proto, port.Target)),
+			Port: pulumi.Int(port.Target),
+		}
+		if proto == "tcp" {
+			p := int(port.Target)
+			healthCheckPort = &p
+		}
+	}
+	addHealthCheckSidecar := healthCheckPort == nil
+	if addHealthCheckSidecar {
+		p := 8080
+		healthCheckPort = &p
+	}
+	return namedPorts, healthCheckPort, addHealthCheckSidecar
 }
 
 // networkID returns the network to attach instances and firewalls to: the
@@ -611,7 +621,8 @@ func classifyComputeSecretEnv(
 // NOTE: docker --env-file is line-oriented, so a secret whose value contains a
 // newline (e.g. a PEM key) cannot be injected this way. Such values need a
 // per-secret file mount; tracked as a follow-up.
-func secretFetchScript(gcpProject, unit string, refs []computeSecretEnv) (writeFile, execStartPre, envFileFlag string) {
+// Returns (write_files block, ExecStartPre line, docker --env-file flag).
+func secretFetchScript(gcpProject, unit string, refs []computeSecretEnv) (string, string, string) {
 	if len(refs) == 0 {
 		return "", "", ""
 	}
@@ -685,6 +696,25 @@ func stopGraceSeconds(svc compose.ServiceConfig) int {
 	return 30
 }
 
+// buildUnitDependencies renders the [Unit] ordering directives for the main
+// service: it always waits on gcr-online + docker, and additionally requires and
+// orders After each same-instance sidecar named in depends_on (cross-instance
+// dependencies aren't enforceable from a single unit).
+func buildUnitDependencies(
+	serviceName string, svc compose.ServiceConfig, sidecars map[string]compose.ServiceConfig,
+) string {
+	var dependencies strings.Builder
+	dependencies.WriteString("Wants=gcr-online.target docker.socket\n      After=gcr-online.target docker.socket")
+	for name := range common.Sorted(svc.DependsOn) {
+		if _, ok := sidecars[name]; !ok {
+			continue // only same-instance sidecar dependencies are enforceable here
+		}
+		unit := sidecarUnitName(serviceName, name)
+		fmt.Fprintf(&dependencies, "\n      Requires=%s.service\n      After=%s.service", unit, unit)
+	}
+	return dependencies.String()
+}
+
 // getCloudInitConfig generates a cloud-init YAML string for running a container on
 // Container-Optimized OS using systemd. For portless services it adds an HTTP health
 // check sidecar so the MIG auto-healer can probe container liveness. User-defined
@@ -726,15 +756,7 @@ func getCloudInitConfig(
 	}
 	envFlags := flattenEnvFlags(staticEnv, mainPlan.inline)
 
-	var dependencies strings.Builder
-	dependencies.WriteString("Wants=gcr-online.target docker.socket\n      After=gcr-online.target docker.socket")
-	for name := range common.Sorted(svc.DependsOn) {
-		if _, ok := sidecars[name]; !ok {
-			continue // only same-instance sidecar dependencies are enforceable here
-		}
-		unit := sidecarUnitName(serviceName, name)
-		fmt.Fprintf(&dependencies, "\n      Requires=%s.service\n      After=%s.service", unit, unit)
-	}
+	dependencies := buildUnitDependencies(serviceName, svc, sidecars)
 
 	runcmds := make([]string, 0, 5+4+2*len(sidecars)+2)
 	runcmds = append(runcmds,
@@ -793,7 +815,7 @@ runcmd:
   - %[8]s
 `,
 		serviceName,
-		escapePercent(dependencies.String()),
+		escapePercent(dependencies),
 		escapePercent(strings.Join(params, " ")),
 		escapePercent(strings.Join(command, " ")),
 		region,

--- a/provider/defanggcp/gcp/compute.go
+++ b/provider/defanggcp/gcp/compute.go
@@ -9,6 +9,7 @@ import (
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/compute"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/projects"
+	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/secretmanager"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -39,6 +40,7 @@ type ComputeEngineArgs struct {
 // run on Cloud Run (e.g. background workers with no listening port).
 func CreateComputeEngine(
 	ctx *pulumi.Context,
+	configProvider compose.ConfigProvider,
 	serviceName string,
 	image pulumi.StringInput,
 	svc compose.ServiceConfig,
@@ -56,6 +58,20 @@ func CreateComputeEngine(
 			"roles/monitoring.metricWriter",
 			"roles/cloudtrace.agent",
 		}, gcpConfig, parentOpt)
+	}
+
+	// Classify each container's env into inline values and native secret refs,
+	// then grant the instance SA access to every referenced secret. Bare ${VAR}
+	// / null "KEY:" values are boot-fetched (see secretFetchScript) rather than
+	// embedded in instance metadata.
+	mainPlan := classifyComputeSecretEnv(ctx, configProvider, svc.Environment)
+	sidecarPlans := make(map[string]containerSecretPlan, len(args.Sidecars))
+	for name, sc := range args.Sidecars {
+		sidecarPlans[name] = classifyComputeSecretEnv(ctx, configProvider, sc.Environment)
+	}
+	secretMembers, err := grantSecretAccess(ctx, serviceName, args.SA, mainPlan, sidecarPlans, parentOpt)
+	if err != nil {
+		return nil, err
 	}
 
 	namedPorts := make(compute.RegionInstanceGroupManagerNamedPortArray, len(svc.Ports))
@@ -83,11 +99,16 @@ func CreateComputeEngine(
 	fqdn := common.ServiceFQDN(serviceName, svc, gcpConfig.Domain, "google.internal")
 	cloudInit := getCloudInitConfig(
 		serviceName, image, svc, gcpConfig.Region, gcpConfig.Etag, gcpConfig.ProjectName, gcpConfig.Stack, fqdn,
-		addHealthCheckSidecar, args.Sidecars)
+		gcpConfig.GcpProject, addHealthCheckSidecar, args.Sidecars, mainPlan, sidecarPlans)
 
+	// The instance template must depend on the secret IAM bindings so instances
+	// don't boot (and run the fetch script) before they can read the secrets.
 	templateOpts := []pulumi.ResourceOption{parentOpt}
-	if len(args.PolicyDeps) > 0 {
-		templateOpts = append(templateOpts, pulumi.DependsOn(args.PolicyDeps))
+	templateDeps := make([]pulumi.Resource, 0, len(args.PolicyDeps)+len(secretMembers))
+	templateDeps = append(templateDeps, args.PolicyDeps...)
+	templateDeps = append(templateDeps, secretMembers...)
+	if len(templateDeps) > 0 {
+		templateOpts = append(templateOpts, pulumi.DependsOn(templateDeps))
 	}
 	instanceTemplate, err := createInstanceTemplate(
 		ctx, serviceName, serviceName, machineType, getComputeBootImage(svc), cloudInit,
@@ -340,6 +361,52 @@ func buildMIGUpdatePolicy(numZones, targetSize int) *compute.RegionInstanceGroup
 	return policy
 }
 
+// grantSecretAccess grants the instance service account
+// roles/secretmanager.secretAccessor on every Secret Manager secret referenced
+// (as a bare ${VAR} or null "KEY:") by the main container or any sidecar, so the
+// boot-time fetch script can read them. Secret IDs are deduped across
+// containers. Returns the created members for use as instance-template
+// dependencies.
+func grantSecretAccess(
+	ctx *pulumi.Context,
+	serviceName string,
+	sa *ServiceIdentity,
+	mainPlan containerSecretPlan,
+	sidecarPlans map[string]containerSecretPlan,
+	parentOpt pulumi.ResourceOrInvokeOption,
+) ([]pulumi.Resource, error) {
+	seen := make(map[string]struct{})
+	var ids []string
+	collect := func(plan containerSecretPlan) {
+		for _, r := range plan.secretRefs {
+			if _, ok := seen[r.secretID]; !ok {
+				seen[r.secretID] = struct{}{}
+				ids = append(ids, r.secretID)
+			}
+		}
+	}
+	collect(mainPlan)
+	for _, plan := range common.Sorted(sidecarPlans) {
+		collect(plan)
+	}
+
+	var members []pulumi.Resource
+	for _, sid := range ids {
+		opts := append([]pulumi.ResourceOption{parentOpt}, sa.deleteOpts()...)
+		member, err := secretmanager.NewSecretIamMember(ctx, serviceName+"-secret-"+sid,
+			&secretmanager.SecretIamMemberArgs{
+				SecretId: pulumi.String(sid),
+				Role:     pulumi.String("roles/secretmanager.secretAccessor"),
+				Member:   pulumi.Sprintf("serviceAccount:%v", sa.Email),
+			}, opts...)
+		if err != nil {
+			return nil, fmt.Errorf("granting secret access for %s: %w", sid, err)
+		}
+		members = append(members, member)
+	}
+	return members, nil
+}
+
 // AddRolesToServiceAccount grants IAM roles to a service account at the project level.
 // Returns a resource array output that can be used as a dependency.
 func AddRolesToServiceAccount(
@@ -492,6 +559,100 @@ func dockerRunFlags(
 	return params, command
 }
 
+// computeSecretEnv maps a container env var to the Secret Manager secret ID
+// whose latest version supplies its value. The value is fetched at container
+// start (see secretFetchScript) instead of being embedded in instance metadata,
+// which is readable unauthenticated from the instance.
+type computeSecretEnv struct {
+	envKey   string
+	secretID string
+}
+
+// containerSecretPlan is the per-container result of classifyComputeSecretEnv:
+// the env values inlined into `docker run -e` and the ones boot-fetched from
+// Secret Manager.
+type containerSecretPlan struct {
+	inline     compose.Environment
+	secretRefs []computeSecretEnv
+}
+
+// classifyComputeSecretEnv splits a container's environment into values inlined
+// into the `docker run` command (static literals and dynamic Outputs) and
+// native secret references (bare ${VAR} or null "KEY:") that are boot-fetched
+// from Secret Manager. Interpolated values (mixed literal + ${VAR}) stay on the
+// inline path for now; resolving them without leaking plaintext into instance
+// metadata needs deploy-time derived configs — see issue 293. With no config
+// provider (e.g. standalone with no secrets), everything is inlined.
+func classifyComputeSecretEnv(
+	ctx *pulumi.Context, cp compose.ConfigProvider, env compose.Environment,
+) containerSecretPlan {
+	if cp == nil {
+		return containerSecretPlan{inline: env}
+	}
+	plan := containerSecretPlan{inline: make(compose.Environment, len(env))}
+	// Iterate sorted so the generated fetch script and IAM bindings are stable.
+	for k, v := range common.Sorted(env) {
+		if configKey := compose.GetConfigName2(k, v); configKey != "" {
+			if secretID, err := cp.GetSecretRef(ctx, configKey); err == nil && secretID != "" {
+				plan.secretRefs = append(plan.secretRefs, computeSecretEnv{envKey: k, secretID: secretID})
+				continue
+			}
+			// Couldn't resolve a ref: fall through and inline (matches the
+			// pre-secrets behavior rather than dropping the variable).
+		}
+		plan.inline[k] = v
+	}
+	return plan
+}
+
+// secretFetchScript returns the cloud-init write_files block for the boot-time
+// secret fetch script, the systemd ExecStartPre line that runs it, and the
+// `docker run --env-file` flag that injects the fetched values. All three are
+// empty when there are no secret refs.
+//
+// The script reads the instance service account's OAuth token from the metadata
+// server and fetches each secret's latest version from the Secret Manager REST
+// API — no gcloud (absent on Container-Optimized OS) required. Values land in a
+// tmpfs file (0600, /run) that never touches disk or instance metadata.
+//
+// NOTE: docker --env-file is line-oriented, so a secret whose value contains a
+// newline (e.g. a PEM key) cannot be injected this way. Such values need a
+// per-secret file mount; tracked as a follow-up.
+func secretFetchScript(gcpProject, unit string, refs []computeSecretEnv) (writeFile, execStartPre, envFileFlag string) {
+	if len(refs) == 0 {
+		return "", "", ""
+	}
+	scriptPath := "/opt/defang/" + unit + "-secrets.sh"
+	envFile := "/run/defang/" + unit + ".env"
+
+	var s strings.Builder
+	s.WriteString("#!/bin/bash\n")
+	s.WriteString("set -uo pipefail\n")
+	s.WriteString("umask 077\n")
+	s.WriteString("mkdir -p /run/defang\n")
+	s.WriteString(`tok=$(curl -s -H "Metadata-Flavor: Google" ` +
+		`http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token ` +
+		`| grep -o '"access_token":"[^"]*"' | cut -d'"' -f4)` + "\n")
+	fmt.Fprintf(&s, `sm() { curl -s -H "Authorization: Bearer $tok" `+
+		`"https://secretmanager.googleapis.com/v1/projects/%s/secrets/$1/versions/latest:access" `+
+		`| grep -o '"data":"[^"]*"' | cut -d'"' -f4 | base64 -d; }`+"\n", gcpProject)
+	s.WriteString("{\n")
+	for _, r := range refs {
+		fmt.Fprintf(&s, "printf '%%s=%%s\\n' '%s' \"$(sm '%s')\"\n", r.envKey, r.secretID)
+	}
+	fmt.Fprintf(&s, "} > %s\n", envFile)
+
+	// Indent the script body under the write_files `content: |` block (6 spaces).
+	var wf strings.Builder
+	fmt.Fprintf(&wf, "\n  - path: %s\n    permissions: \"0700\"\n    owner: root\n    content: |\n", scriptPath)
+	for _, line := range strings.Split(strings.TrimRight(s.String(), "\n"), "\n") {
+		wf.WriteString("      ")
+		wf.WriteString(line)
+		wf.WriteString("\n")
+	}
+	return wf.String(), "ExecStartPre=" + scriptPath, "--env-file " + envFile
+}
+
 // flattenEnvFlags renders `-e "K=V"` docker flags for the given static env
 // pairs followed by the service's compose environment. Dynamic (Output)
 // values are threaded through a Sprintf so they resolve at apply time.
@@ -541,14 +702,26 @@ func getCloudInitConfig(
 	image pulumi.StringInput,
 	svc compose.ServiceConfig,
 	region, etag, projectName, stack, fqdn string,
+	gcpProject string,
 	addHealthCheckSidecar bool,
 	sidecars map[string]compose.ServiceConfig,
+	mainPlan containerSecretPlan,
+	sidecarPlans map[string]containerSecretPlan,
 ) pulumi.StringOutput {
 	var buf strings.Builder
 	buf.WriteString("#cloud-config\n\nwrite_files:")
 
 	containerName := svc.GetContainerName(serviceName)
 	params, command := dockerRunFlags(svc, sidecars)
+
+	// Secret env vars are boot-fetched into a tmpfs env-file rather than embedded
+	// in instance metadata. The fetch script is written first so it precedes the
+	// service unit in write_files.
+	secretWriteFile, secretExecPre, secretEnvFileFlag := secretFetchScript(gcpProject, serviceName, mainPlan.secretRefs)
+	if secretEnvFileFlag != "" {
+		params = append(params, secretEnvFileFlag)
+	}
+	buf.WriteString(escapePercent(secretWriteFile))
 
 	// Defang-injected runtime vars, mirroring the Cloud Run path (buildEnvVars).
 	staticEnv := [][2]string{{"DEFANG_SERVICE", serviceName}}
@@ -558,7 +731,7 @@ func getCloudInitConfig(
 	if fqdn != "" {
 		staticEnv = append(staticEnv, [2]string{"DEFANG_FQDN", fqdn})
 	}
-	envFlags := flattenEnvFlags(staticEnv, svc.Environment)
+	envFlags := flattenEnvFlags(staticEnv, mainPlan.inline)
 
 	var dependencies strings.Builder
 	dependencies.WriteString("Wants=gcr-online.target docker.socket\n      After=gcr-online.target docker.socket")
@@ -589,7 +762,7 @@ func getCloudInitConfig(
 	}
 	for name, sc := range common.Sorted(sidecars) {
 		var unitText pulumi.StringInput
-		unitText, runcmds = buildSidecarUnit(serviceName, name, region, sc, sidecars, runcmds)
+		unitText, runcmds = buildSidecarUnit(serviceName, name, region, gcpProject, sc, sidecars, sidecarPlans[name], runcmds)
 		extraUnitsFmt.WriteString("%s")
 		extraUnitsArgs = append(extraUnitsArgs, unitText)
 	}
@@ -613,6 +786,7 @@ func getCloudInitConfig(
       Restart=always
       RestartSec=30
       Environment="HOME=/home/container-user"
+      %[9]s
       ExecStartPre=/usr/bin/docker-credential-gcr configure-docker --registries %[5]s-docker.pkg.dev
       ExecStart=/usr/bin/docker run --pull=always --rm --name=%[7]s %[3]s %%s%%s %[4]s
       ExecStop=/usr/bin/docker stop -t %[6]d %[7]s
@@ -632,7 +806,8 @@ runcmd:
 		region,
 		stopGraceSeconds(svc),
 		containerName,
-		escapePercent(strings.Join(runcmds, "\n  - ")))
+		escapePercent(strings.Join(runcmds, "\n  - ")),
+		escapePercent(secretExecPre))
 
 	// buf now contains exactly three %s placeholders (env flags, image, and
 	// extra units — the Inputs that may resolve at apply time); all other
@@ -677,15 +852,22 @@ func sidecarUnitName(serviceName, sidecarName string) string {
 // --volumes-from keeps working across restarts; a run-once sidecar (restart: "no")
 // becomes a oneshot unit the main service can order After=.
 func buildSidecarUnit(
-	serviceName, sidecarName, region string,
+	serviceName, sidecarName, region, gcpProject string,
 	sc compose.ServiceConfig,
 	sidecars map[string]compose.ServiceConfig,
+	plan containerSecretPlan,
 	runcmds []string,
 ) (pulumi.StringInput, []string) {
 	unit := sidecarUnitName(serviceName, sidecarName)
 	containerName := sc.GetContainerName(sidecarName)
 	params, command := dockerRunFlags(sc, sidecars)
-	envFlags := flattenEnvFlags(nil, sc.Environment)
+
+	// Boot-fetch this sidecar's secret env into its own tmpfs env-file.
+	secretWriteFile, secretExecPre, secretEnvFileFlag := secretFetchScript(gcpProject, unit, plan.secretRefs)
+	if secretEnvFileFlag != "" {
+		params = append(params, secretEnvFileFlag)
+	}
+	envFlags := flattenEnvFlags(nil, plan.inline)
 
 	var serviceSection string
 	if sc.Restart == "no" {
@@ -695,7 +877,10 @@ func buildSidecarUnit(
 			stopGraceSeconds(sc), containerName)
 	}
 
-	units := pulumi.Sprintf(`
+	// %[11]s (secret fetch script write_files entry) and %[12]s (its
+	// ExecStartPre) are passed as Sprintf argument values, so any '%' in the
+	// script survives literally without escaping.
+	units := pulumi.Sprintf(`%[11]s
   - path: /etc/systemd/system/%[1]s.service
     permissions: "0644"
     owner: root
@@ -709,6 +894,7 @@ func buildSidecarUnit(
       [Service]
       %[4]s
       Environment="HOME=/home/container-user"
+      %[12]s
       ExecStartPre=/usr/bin/docker-credential-gcr configure-docker --registries %[5]s-docker.pkg.dev
       ExecStartPre=-/usr/bin/docker rm -f %[6]s
       ExecStart=/usr/bin/docker run --pull=always --name=%[6]s %[7]s %[8]s%[9]s %[10]s
@@ -727,7 +913,9 @@ func buildSidecarUnit(
 		strings.Join(params, " "),
 		envFlags,
 		sc.Image, // validated non-nil in createService; may resolve at apply time
-		strings.Join(command, " "))
+		strings.Join(command, " "),
+		secretWriteFile,
+		secretExecPre)
 
 	runcmds = append(runcmds,
 		fmt.Sprintf("systemctl enable %s.service", unit),

--- a/provider/defanggcp/gcp/compute.go
+++ b/provider/defanggcp/gcp/compute.go
@@ -656,7 +656,8 @@ func secretFetchScript(gcpProject, unit string, refs []computeSecretEnv) (string
 		`| grep -o '"data":"[^"]*"' | cut -d'"' -f4 | base64 -d; }`+"\n", gcpProject)
 	s.WriteString("{\n")
 	for _, r := range refs {
-		fmt.Fprintf(&s, `v=$(sm '%s') || { echo "defang: failed to fetch secret %s" >&2; exit 1; }`+"\n", r.secretID, r.secretID)
+		fmt.Fprintf(&s, `v=$(sm '%s') || { echo "defang: failed to fetch secret %s" >&2; exit 1; }`+"\n",
+			r.secretID, r.secretID)
 		fmt.Fprintf(&s, "printf '%%s=%%s\\n' '%s' \"$v\"\n", r.envKey)
 	}
 	fmt.Fprintf(&s, "} > %s\n", envFile)

--- a/provider/defanggcp/gcp/compute.go
+++ b/provider/defanggcp/gcp/compute.go
@@ -636,20 +636,28 @@ func secretFetchScript(gcpProject, unit string, refs []computeSecretEnv) (string
 	scriptPath := "/opt/defang/" + unit + "-secrets.sh"
 	envFile := "/run/defang/" + unit + ".env"
 
+	// Fail fast: a fetch that errors out (or yields an empty token) must fail
+	// ExecStartPre so the unit does not start the container with an empty
+	// secret value — a silent empty credential is far harder to diagnose than
+	// a unit that refuses to start. `curl -f` turns HTTP errors into non-zero
+	// exits and `grep` exits 1 when the expected field is absent (e.g. an
+	// error payload), so with pipefail every failure mode is caught.
 	var s strings.Builder
 	s.WriteString("#!/bin/bash\n")
-	s.WriteString("set -uo pipefail\n")
+	s.WriteString("set -euo pipefail\n")
 	s.WriteString("umask 077\n")
 	s.WriteString("mkdir -p /run/defang\n")
-	s.WriteString(`tok=$(curl -s -H "Metadata-Flavor: Google" ` +
+	s.WriteString(`tok=$(curl -fsS -H "Metadata-Flavor: Google" ` +
 		`http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token ` +
 		`| grep -o '"access_token":"[^"]*"' | cut -d'"' -f4)` + "\n")
-	fmt.Fprintf(&s, `sm() { curl -s -H "Authorization: Bearer $tok" `+
+	s.WriteString(`[ -n "$tok" ] || { echo "defang: empty metadata token" >&2; exit 1; }` + "\n")
+	fmt.Fprintf(&s, `sm() { curl -fsS -H "Authorization: Bearer $tok" `+
 		`"https://secretmanager.googleapis.com/v1/projects/%s/secrets/$1/versions/latest:access" `+
 		`| grep -o '"data":"[^"]*"' | cut -d'"' -f4 | base64 -d; }`+"\n", gcpProject)
 	s.WriteString("{\n")
 	for _, r := range refs {
-		fmt.Fprintf(&s, "printf '%%s=%%s\\n' '%s' \"$(sm '%s')\"\n", r.envKey, r.secretID)
+		fmt.Fprintf(&s, `v=$(sm '%s') || { echo "defang: failed to fetch secret %s" >&2; exit 1; }`+"\n", r.secretID, r.secretID)
+		fmt.Fprintf(&s, "printf '%%s=%%s\\n' '%s' \"$v\"\n", r.envKey)
 	}
 	fmt.Fprintf(&s, "} > %s\n", envFile)
 

--- a/provider/defanggcp/gcp/compute.go
+++ b/provider/defanggcp/gcp/compute.go
@@ -74,24 +74,7 @@ func CreateComputeEngine(
 		return nil, err
 	}
 
-	namedPorts := make(compute.RegionInstanceGroupManagerNamedPortArray, len(svc.Ports))
-	var healthCheckPort *int
-	for i, port := range svc.Ports {
-		proto := port.GetProtocol()
-		namedPorts[i] = &compute.RegionInstanceGroupManagerNamedPortArgs{
-			Name: pulumi.String(fmt.Sprintf("port-%s-%d", proto, port.Target)),
-			Port: pulumi.Int(port.Target),
-		}
-		if proto == "tcp" {
-			p := int(port.Target)
-			healthCheckPort = &p
-		}
-	}
-	addHealthCheckSidecar := healthCheckPort == nil
-	if addHealthCheckSidecar {
-		p := 8080
-		healthCheckPort = &p
-	}
+	namedPorts, healthCheckPort, addHealthCheckSidecar := computeNamedPorts(svc)
 
 	// DEFANG_FQDN: custom domain, else public FQDN (ingress), else the private
 	// FQDN (<label>.google.internal) for internal services — the private zone is
@@ -163,6 +146,33 @@ func CreateComputeEngine(
 	}
 
 	return &ComputeEngineResult{InstanceGroup: instanceGroup}, nil
+}
+
+// computeNamedPorts builds the MIG named-port array from the service's ports and
+// determines the health-check port. Services with no TCP port get a dedicated
+// HTTP health-check sidecar on 8080 so the MIG auto-healer can probe liveness.
+func computeNamedPorts(svc compose.ServiceConfig) (
+	compute.RegionInstanceGroupManagerNamedPortArray, *int, bool,
+) {
+	namedPorts := make(compute.RegionInstanceGroupManagerNamedPortArray, len(svc.Ports))
+	var healthCheckPort *int
+	for i, port := range svc.Ports {
+		proto := port.GetProtocol()
+		namedPorts[i] = &compute.RegionInstanceGroupManagerNamedPortArgs{
+			Name: pulumi.String(fmt.Sprintf("port-%s-%d", proto, port.Target)),
+			Port: pulumi.Int(port.Target),
+		}
+		if proto == "tcp" {
+			p := int(port.Target)
+			healthCheckPort = &p
+		}
+	}
+	addHealthCheckSidecar := healthCheckPort == nil
+	if addHealthCheckSidecar {
+		p := 8080
+		healthCheckPort = &p
+	}
+	return namedPorts, healthCheckPort, addHealthCheckSidecar
 }
 
 // networkID returns the network to attach instances and firewalls to: the
@@ -618,7 +628,8 @@ func classifyComputeSecretEnv(
 // NOTE: docker --env-file is line-oriented, so a secret whose value contains a
 // newline (e.g. a PEM key) cannot be injected this way. Such values need a
 // per-secret file mount; tracked as a follow-up.
-func secretFetchScript(gcpProject, unit string, refs []computeSecretEnv) (writeFile, execStartPre, envFileFlag string) {
+// Returns (write_files block, ExecStartPre line, docker --env-file flag).
+func secretFetchScript(gcpProject, unit string, refs []computeSecretEnv) (string, string, string) {
 	if len(refs) == 0 {
 		return "", "", ""
 	}
@@ -692,6 +703,25 @@ func stopGraceSeconds(svc compose.ServiceConfig) int {
 	return 30
 }
 
+// buildUnitDependencies renders the [Unit] ordering directives for the main
+// service: it always waits on gcr-online + docker, and additionally requires and
+// orders After each same-instance sidecar named in depends_on (cross-instance
+// dependencies aren't enforceable from a single unit).
+func buildUnitDependencies(
+	serviceName string, svc compose.ServiceConfig, sidecars map[string]compose.ServiceConfig,
+) string {
+	var dependencies strings.Builder
+	dependencies.WriteString("Wants=gcr-online.target docker.socket\n      After=gcr-online.target docker.socket")
+	for name := range common.Sorted(svc.DependsOn) {
+		if _, ok := sidecars[name]; !ok {
+			continue // only same-instance sidecar dependencies are enforceable here
+		}
+		unit := sidecarUnitName(serviceName, name)
+		fmt.Fprintf(&dependencies, "\n      Requires=%s.service\n      After=%s.service", unit, unit)
+	}
+	return dependencies.String()
+}
+
 // getCloudInitConfig generates a cloud-init YAML string for running a container on
 // Container-Optimized OS using systemd. For portless services it adds an HTTP health
 // check sidecar so the MIG auto-healer can probe container liveness. User-defined
@@ -733,15 +763,7 @@ func getCloudInitConfig(
 	}
 	envFlags := flattenEnvFlags(staticEnv, mainPlan.inline)
 
-	var dependencies strings.Builder
-	dependencies.WriteString("Wants=gcr-online.target docker.socket\n      After=gcr-online.target docker.socket")
-	for name := range common.Sorted(svc.DependsOn) {
-		if _, ok := sidecars[name]; !ok {
-			continue // only same-instance sidecar dependencies are enforceable here
-		}
-		unit := sidecarUnitName(serviceName, name)
-		fmt.Fprintf(&dependencies, "\n      Requires=%s.service\n      After=%s.service", unit, unit)
-	}
+	dependencies := buildUnitDependencies(serviceName, svc, sidecars)
 
 	runcmds := make([]string, 0, 5+4+2*len(sidecars)+2)
 	runcmds = append(runcmds,
@@ -800,7 +822,7 @@ runcmd:
   - %[8]s
 `,
 		serviceName,
-		escapePercent(dependencies.String()),
+		escapePercent(dependencies),
 		escapePercent(strings.Join(params, " ")),
 		escapePercent(strings.Join(command, " ")),
 		region,

--- a/provider/defanggcp/gcp/compute_test.go
+++ b/provider/defanggcp/gcp/compute_test.go
@@ -218,7 +218,9 @@ func TestClassifyComputeSecretEnv(t *testing.T) {
 
 	// secret refs are sorted by env key: BARE, NULLED
 	require.Len(t, plan.secretRefs, 2)
+	//nolint:gosec // G101: secret resource names (IDs), not credential values.
 	assert.Equal(t, computeSecretEnv{envKey: "BARE", secretID: "Defang_proj_stack_SECRET_ONE"}, plan.secretRefs[0])
+	//nolint:gosec // G101: secret resource names (IDs), not credential values.
 	assert.Equal(t, computeSecretEnv{envKey: "NULLED", secretID: "Defang_proj_stack_NULLED"}, plan.secretRefs[1])
 	// literals and mixed interpolation stay inline
 	assert.Contains(t, plan.inline, "PLAIN")
@@ -237,8 +239,8 @@ func TestClassifyComputeSecretEnv(t *testing.T) {
 // flag that consume it.
 func TestSecretFetchScript(t *testing.T) {
 	refs := []computeSecretEnv{
-		{envKey: "DB", secretID: "Defang_p_s_DBPASS"},
-		{envKey: "API", secretID: "Defang_p_s_APIKEY"},
+		{envKey: "DB", secretID: "Defang_p_s_DBPASS"},  //nolint:gosec // G101 false positive
+		{envKey: "API", secretID: "Defang_p_s_APIKEY"}, //nolint:gosec // G101 false positive
 	}
 	wf, pre, flag := secretFetchScript("my-proj", "svc", refs)
 
@@ -268,7 +270,7 @@ func TestGetCloudInitConfigSecrets(t *testing.T) {
 	plan := containerSecretPlan{
 		inline: compose.Environment{"PLAIN": pulumi.String("x")},
 		secretRefs: []computeSecretEnv{
-			{envKey: "SECRET_ENV", secretID: "Defang_proj_stack_SECRET_ENV"},
+			{envKey: "SECRET_ENV", secretID: "Defang_proj_stack_SECRET_ENV"}, //nolint:gosec // G101 false positive
 		},
 	}
 

--- a/provider/defanggcp/gcp/compute_test.go
+++ b/provider/defanggcp/gcp/compute_test.go
@@ -45,7 +45,8 @@ func TestGetCloudInitConfigDefangEnv(t *testing.T) {
 			wg.Add(1)
 			err := pulumi.RunErr(func(ctx *pulumi.Context) error {
 				out := getCloudInitConfig(
-					"api", pulumi.String("img:latest"), svc, "us-central1", tt.etag, "", "", tt.fqdn, false, nil)
+					"api", pulumi.String("img:latest"), svc, "us-central1", tt.etag, "", "", tt.fqdn, "",
+					false, nil, containerSecretPlan{inline: svc.Environment}, nil)
 				out.ApplyT(func(s string) string {
 					defer wg.Done()
 					cloudInit = s
@@ -100,7 +101,8 @@ func TestGetCloudInitConfigLogLabels(t *testing.T) {
 			wg.Add(1)
 			err := pulumi.RunErr(func(ctx *pulumi.Context) error {
 				out := getCloudInitConfig(
-					"api", pulumi.String("img:latest"), svc, "us-central1", tt.etag, tt.projectName, tt.stack, "", false, nil)
+					"api", pulumi.String("img:latest"), svc, "us-central1", tt.etag, tt.projectName, tt.stack, "", "",
+					false, nil, containerSecretPlan{inline: svc.Environment}, nil)
 				out.ApplyT(func(s string) string {
 					defer wg.Done()
 					cloudInit = s
@@ -148,7 +150,9 @@ func TestGetCloudInitConfigSidecars(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
-		out := getCloudInitConfig("cd", pulumi.String("img:latest"), svc, "us-central1", "", "", "", "", true, sidecars)
+		out := getCloudInitConfig("cd", pulumi.String("img:latest"), svc, "us-central1", "", "", "", "", "",
+			true, sidecars, containerSecretPlan{inline: svc.Environment},
+			map[string]containerSecretPlan{"handler": {inline: sidecars["handler"].Environment}})
 		out.ApplyT(func(s string) string {
 			defer wg.Done()
 			cloudInit = s
@@ -179,5 +183,119 @@ func TestGetCloudInitConfigSidecars(t *testing.T) {
 	// '%' escaping: env value intact, image substituted
 	assert.Contains(t, cloudInit, `-e "RATIO=100%"`)
 	assert.Contains(t, cloudInit, "img:latest")
+	assert.NotContains(t, cloudInit, "%!")
+}
+
+// mockSecretConfigProvider resolves bare ${VAR} / null env refs to a
+// deterministic Secret Manager ID so the classify/cloud-init paths can be
+// tested without a live backend.
+type mockSecretConfigProvider struct{ prefix string }
+
+func (m *mockSecretConfigProvider) GetConfigValue(
+	_ *pulumi.Context, key string, _ ...pulumi.InvokeOption,
+) pulumi.StringOutput {
+	return pulumi.String("val-" + key).ToStringOutput()
+}
+
+func (m *mockSecretConfigProvider) GetSecretRef(
+	_ *pulumi.Context, key string, _ ...pulumi.InvokeOption,
+) (string, error) {
+	return m.prefix + key, nil
+}
+
+// classifyComputeSecretEnv routes bare ${VAR} and null "KEY:" values to native
+// secret refs, and leaves literals and interpolated (mixed) values inline.
+func TestClassifyComputeSecretEnv(t *testing.T) {
+	env := compose.Environment{
+		"PLAIN":  pulumi.String("literal"),
+		"BARE":   pulumi.String("${SECRET_ONE}"),
+		"NULLED": nil,
+		"MIXED":  pulumi.String("pre-${SECRET_TWO}-post"),
+	}
+	cp := &mockSecretConfigProvider{prefix: "Defang_proj_stack_"}
+
+	plan := classifyComputeSecretEnv(nil, cp, env)
+
+	// secret refs are sorted by env key: BARE, NULLED
+	require.Len(t, plan.secretRefs, 2)
+	assert.Equal(t, computeSecretEnv{envKey: "BARE", secretID: "Defang_proj_stack_SECRET_ONE"}, plan.secretRefs[0])
+	assert.Equal(t, computeSecretEnv{envKey: "NULLED", secretID: "Defang_proj_stack_NULLED"}, plan.secretRefs[1])
+	// literals and mixed interpolation stay inline
+	assert.Contains(t, plan.inline, "PLAIN")
+	assert.Contains(t, plan.inline, "MIXED")
+	assert.NotContains(t, plan.inline, "BARE")
+	assert.NotContains(t, plan.inline, "NULLED")
+
+	// with no config provider, everything is inlined
+	nilPlan := classifyComputeSecretEnv(nil, nil, env)
+	assert.Nil(t, nilPlan.secretRefs)
+	assert.Equal(t, env, nilPlan.inline)
+}
+
+// secretFetchScript emits a COS-compatible boot fetch (metadata token + Secret
+// Manager REST API) writing a tmpfs env-file, plus the ExecStartPre + env-file
+// flag that consume it.
+func TestSecretFetchScript(t *testing.T) {
+	refs := []computeSecretEnv{
+		{envKey: "DB", secretID: "Defang_p_s_DBPASS"},
+		{envKey: "API", secretID: "Defang_p_s_APIKEY"},
+	}
+	wf, pre, flag := secretFetchScript("my-proj", "svc", refs)
+
+	assert.Equal(t, "ExecStartPre=/opt/defang/svc-secrets.sh", pre)
+	assert.Equal(t, "--env-file /run/defang/svc.env", flag)
+	assert.Contains(t, wf, "path: /opt/defang/svc-secrets.sh")
+	assert.Contains(t, wf, `permissions: "0700"`)
+	assert.Contains(t, wf, "metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")
+	assert.Contains(t, wf, "https://secretmanager.googleapis.com/v1/projects/my-proj/secrets/")
+	assert.Contains(t, wf, `printf '%s=%s\n' 'DB' "$(sm 'Defang_p_s_DBPASS')"`)
+	assert.Contains(t, wf, `printf '%s=%s\n' 'API' "$(sm 'Defang_p_s_APIKEY')"`)
+	assert.Contains(t, wf, "} > /run/defang/svc.env")
+
+	// no refs -> no output
+	wf2, pre2, flag2 := secretFetchScript("p", "svc", nil)
+	assert.Empty(t, wf2)
+	assert.Empty(t, pre2)
+	assert.Empty(t, flag2)
+}
+
+// getCloudInitConfig must boot-fetch secret env (not inline it) while still
+// inlining plain values, and wire up the ExecStartPre + --env-file.
+func TestGetCloudInitConfigSecrets(t *testing.T) {
+	svc := compose.ServiceConfig{
+		Ports: []compose.ServicePortConfig{{Target: 8080, Mode: compose.PortModeHost}},
+	}
+	plan := containerSecretPlan{
+		inline: compose.Environment{"PLAIN": pulumi.String("x")},
+		secretRefs: []computeSecretEnv{
+			{envKey: "SECRET_ENV", secretID: "Defang_proj_stack_SECRET_ENV"},
+		},
+	}
+
+	var cloudInit string
+	var wg sync.WaitGroup
+	wg.Add(1)
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		out := getCloudInitConfig(
+			"api", pulumi.String("img:latest"), svc, "us-central1", "", "", "", "", "gcp-proj",
+			false, nil, plan, nil)
+		out.ApplyT(func(s string) string {
+			defer wg.Done()
+			cloudInit = s
+			return s
+		})
+		return nil
+	}, pulumi.WithMocks("proj", "stack", testMocks{}))
+	require.NoError(t, err)
+	wg.Wait()
+
+	assert.Contains(t, cloudInit, "ExecStartPre=/opt/defang/api-secrets.sh")
+	assert.Contains(t, cloudInit, "--env-file /run/defang/api.env")
+	assert.Contains(t, cloudInit, "https://secretmanager.googleapis.com/v1/projects/gcp-proj/secrets/")
+	assert.Contains(t, cloudInit, `printf '%s=%s\n' 'SECRET_ENV' "$(sm 'Defang_proj_stack_SECRET_ENV')"`)
+	// plain value inlined, secret value NOT inlined
+	assert.Contains(t, cloudInit, `-e "PLAIN=x"`)
+	assert.NotContains(t, cloudInit, `-e "SECRET_ENV`)
+	// no leftover format artifacts
 	assert.NotContains(t, cloudInit, "%!")
 }

--- a/provider/defanggcp/gcp/compute_test.go
+++ b/provider/defanggcp/gcp/compute_test.go
@@ -250,9 +250,15 @@ func TestSecretFetchScript(t *testing.T) {
 	assert.Contains(t, wf, `permissions: "0700"`)
 	assert.Contains(t, wf, "metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")
 	assert.Contains(t, wf, "https://secretmanager.googleapis.com/v1/projects/my-proj/secrets/")
-	assert.Contains(t, wf, `printf '%s=%s\n' 'DB' "$(sm 'Defang_p_s_DBPASS')"`)
-	assert.Contains(t, wf, `printf '%s=%s\n' 'API' "$(sm 'Defang_p_s_APIKEY')"`)
+	assert.Contains(t, wf, `v=$(sm 'Defang_p_s_DBPASS') || { echo "defang: failed to fetch secret Defang_p_s_DBPASS" >&2; exit 1; }`)
+	assert.Contains(t, wf, `printf '%s=%s\n' 'DB' "$v"`)
+	assert.Contains(t, wf, `v=$(sm 'Defang_p_s_APIKEY') || { echo "defang: failed to fetch secret Defang_p_s_APIKEY" >&2; exit 1; }`)
+	assert.Contains(t, wf, `printf '%s=%s\n' 'API' "$v"`)
 	assert.Contains(t, wf, "} > /run/defang/svc.env")
+	// fetch failures must fail ExecStartPre, never write an empty value
+	assert.Contains(t, wf, "set -euo pipefail")
+	assert.Contains(t, wf, `[ -n "$tok" ]`)
+	assert.Contains(t, wf, "curl -fsS")
 
 	// no refs -> no output
 	wf2, pre2, flag2 := secretFetchScript("p", "svc", nil)
@@ -294,7 +300,8 @@ func TestGetCloudInitConfigSecrets(t *testing.T) {
 	assert.Contains(t, cloudInit, "ExecStartPre=/opt/defang/api-secrets.sh")
 	assert.Contains(t, cloudInit, "--env-file /run/defang/api.env")
 	assert.Contains(t, cloudInit, "https://secretmanager.googleapis.com/v1/projects/gcp-proj/secrets/")
-	assert.Contains(t, cloudInit, `printf '%s=%s\n' 'SECRET_ENV' "$(sm 'Defang_proj_stack_SECRET_ENV')"`)
+	assert.Contains(t, cloudInit, `v=$(sm 'Defang_proj_stack_SECRET_ENV')`)
+	assert.Contains(t, cloudInit, `printf '%s=%s\n' 'SECRET_ENV' "$v"`)
 	// plain value inlined, secret value NOT inlined
 	assert.Contains(t, cloudInit, `-e "PLAIN=x"`)
 	assert.NotContains(t, cloudInit, `-e "SECRET_ENV`)

--- a/provider/defanggcp/gcp/compute_test.go
+++ b/provider/defanggcp/gcp/compute_test.go
@@ -250,9 +250,11 @@ func TestSecretFetchScript(t *testing.T) {
 	assert.Contains(t, wf, `permissions: "0700"`)
 	assert.Contains(t, wf, "metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")
 	assert.Contains(t, wf, "https://secretmanager.googleapis.com/v1/projects/my-proj/secrets/")
-	assert.Contains(t, wf, `v=$(sm 'Defang_p_s_DBPASS') || { echo "defang: failed to fetch secret Defang_p_s_DBPASS" >&2; exit 1; }`)
+	assert.Contains(t, wf,
+		`v=$(sm 'Defang_p_s_DBPASS') || { echo "defang: failed to fetch secret Defang_p_s_DBPASS" >&2; exit 1; }`)
 	assert.Contains(t, wf, `printf '%s=%s\n' 'DB' "$v"`)
-	assert.Contains(t, wf, `v=$(sm 'Defang_p_s_APIKEY') || { echo "defang: failed to fetch secret Defang_p_s_APIKEY" >&2; exit 1; }`)
+	assert.Contains(t, wf,
+		`v=$(sm 'Defang_p_s_APIKEY') || { echo "defang: failed to fetch secret Defang_p_s_APIKEY" >&2; exit 1; }`)
 	assert.Contains(t, wf, `printf '%s=%s\n' 'API' "$v"`)
 	assert.Contains(t, wf, "} > /run/defang/svc.env")
 	// fetch failures must fail ExecStartPre, never write an empty value

--- a/provider/defanggcp/service.go
+++ b/provider/defanggcp/service.go
@@ -248,7 +248,7 @@ func createService(
 			Triggers: extras.Triggers,
 		}
 		ceResult, ceErr := providergcp.CreateComputeEngine(
-			ctx, serviceName, image, svc, ceArgs, infra, parentOpt,
+			ctx, configProvider, serviceName, image, svc, ceArgs, infra, parentOpt,
 		)
 		if ceErr != nil {
 			return fmt.Errorf("creating Compute Engine service %s: %w", serviceName, ceErr)

--- a/provider/defanggcp/service.go
+++ b/provider/defanggcp/service.go
@@ -314,7 +314,7 @@ func createService(
 			PolicyDeps: policyDeps,
 		}
 		ceResult, ceErr := providergcp.CreateComputeEngine(
-			ctx, serviceName, image, svc, ceArgs, infra, parentOpt,
+			ctx, configProvider, serviceName, image, svc, ceArgs, infra, parentOpt,
 		)
 		if ceErr != nil {
 			return fmt.Errorf("creating Compute Engine service %s: %w", serviceName, ceErr)


### PR DESCRIPTION
Closes half of #164 (the "secrets for compute services" half). See caveats below (⚠️ not yet validated on a live GCP deploy).

## Problem

GCP Compute Engine services get **no** config-provider resolution today:
- a bare `${VAR}` env value reaches the container as the literal string `${VAR}` (silent breakage);
- there is no way to inject a secret without inlining its plaintext into the `docker run` command embedded in **instance metadata**, which is readable **unauthenticated** from the instance (the worst sink discussed in #293).

## Approach (validates @edwardrf's hint in #164, adjusted for COS)

COS ships no `gcloud`, so instead of a native Secret Manager ↔ Compute Engine integration, cloud-init writes a small fetch script that:
1. reads the instance service account's OAuth token from the metadata server,
2. calls the Secret Manager REST API (`.../versions/latest:access`) for each secret (`curl` + `grep`/`cut` + `base64 -d`, all present on COS),
3. writes `KEY=value` lines to a tmpfs env-file (`/run/defang/<unit>.env`, `umask 077`).

The systemd unit runs it as `ExecStartPre=` and the container consumes it via `docker run --env-file`. The value never touches disk or instance metadata. Per-secret `roles/secretmanager.secretAccessor` is granted to the instance SA, and the instance template depends on those bindings so instances don't boot before they can read.

Env classification mirrors Cloud Run's `buildEnvVars`:
- **bare `${VAR}` / null `KEY:`** → native secret ref (boot-fetched);
- **static literal / dynamic Output** → inlined as `-e K=V` (unchanged);
- **interpolated (mixed literal + `${VAR}`)** → left inline for now (see below).

Covers the main container and sidecars.

## Scope / follow-ups

- **Interpolated env is deferred to #293.** Resolving `postgres://...${PW}...` leak-free means writing the result to a deploy-time derived config, which #293 is standardizing cross-cloud (@lionello). CE will consume whatever #293 lands rather than forking the naming here. (No regression: interpolated env on CE is not resolved today either.)
- **Multiline secrets:** `docker --env-file` is line-oriented, so a secret value containing a newline (e.g. a PEM key) can't be injected this way yet. Flagged with a `NOTE` in `secretFetchScript`; needs a per-secret file mount as a follow-up.

## Tests

Unit tests on the generated cloud-init: env classification (`TestClassifyComputeSecretEnv`), fetch-script generation (`TestSecretFetchScript`), and end-to-end cloud-init (`TestGetCloudInitConfigSecrets`) asserting the secret is boot-fetched and **not** inlined while plain values still are. Existing compute/sidecar tests updated for the new signature.

⚠️ **Not yet exercised against a live GCP deploy** — the fetch script's behavior on real COS (token parse, `:access` response shape, `--env-file` consumption) should be validated on a stack before this leaves draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secure Secret Manager integration for Compute Engine deployments.
  * Secrets are fetched at startup and provided to main and sidecar containers through temporary environment files.
  * Referenced secrets now automatically receive the required instance access permissions.
  * Improved deployment handling for environment variables, named ports, and health checks.

* **Tests**
  * Added coverage for secret classification, retrieval scripts, and cloud-init configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->