### PR TITLE
AWS: bind apex/project domain only for a single ingress port

### DIFF
--- a/provider/defangaws/aws/ecs.go
+++ b/provider/defangaws/aws/ecs.go
@@ -55,7 +55,13 @@ type SharedInfra struct {
 	PrivateZoneID    pulumi.StringPtrInput   `pulumi:"privateZoneID,optional"`
 	PrivateDomain    string
 	ProjectDomain    string
-	ZoneId           pulumi.StringPtrInput // Route53 zone ID for public DNS records (empty if no public DNS)
+	// ApexServiceName is the service that serves the bare project (apex)
+	// domain. Set only when the whole project has exactly one ingress port
+	// (a single service with a single ingress port); empty otherwise, in
+	// which case the apex is left to the ALB listener's default action.
+	// Resolved in buildProject; not a schema field.
+	ApexServiceName string
+	ZoneId          pulumi.StringPtrInput // Route53 zone ID for public DNS records (empty if no public DNS)
 	// shared "private SG" — attached to all services, no ingress rules
 	PrivateSgID    pulumi.StringPtrInput `pulumi:"privateSgID,optional"`
 	AlbSG          *ec2.SecurityGroup    // nil if no ALB
@@ -854,8 +860,11 @@ func CreateECSService(
 					endpoints = append(endpoints, svc.DomainName)
 				case infra.ProjectDomain != "":
 					endpoints = append(endpoints, fmt.Sprintf("%s.%s", serviceLabel, infra.ProjectDomain))
-					if firstIngress {
-						// FIXME: which service should listen on the project domain?
+					// The apex (bare project) domain is bound to a service only
+					// when the whole project has exactly one ingress port; the
+					// owner is resolved in buildProject. Otherwise the apex is
+					// left to the ALB listener's default action.
+					if serviceName == infra.ApexServiceName {
 						endpoints = append(endpoints, infra.ProjectDomain)
 					}
 				}

--- a/provider/defangaws/project.go
+++ b/provider/defangaws/project.go
@@ -204,6 +204,11 @@ func buildProject(
 		return nil, err
 	}
 
+	// Bind the project (apex) domain to a service only when the whole project
+	// has exactly one ingress port — i.e. a single service with a single
+	// ingress port. Otherwise the apex is left unbound (ALB default action).
+	infra.ApexServiceName = apexServiceName(standalone)
+
 	// Pre-compute which services need waitForSteadyState: true if any other
 	// service depends on them with condition: service_healthy (matches TS tenant_stack.ts)
 	waitForSteady := map[string]bool{}
@@ -271,6 +276,34 @@ func buildProject(
 		TaskRoleArns:    taskRoleArns.ToStringMapOutput(),
 		ServiceIds:      serviceIds.ToStringMapOutput(),
 	}, nil
+}
+
+// apexServiceName returns the service that should serve the bare project
+// (apex) domain: the sole service that has exactly one ingress port, but only
+// when it is the only ingress port in the whole project. Returns "" when the
+// project has zero or multiple ingress ports, leaving the apex unbound. The
+// result is independent of map iteration order (it depends only on the count
+// of ingress ports and, when that count is 1, the single owner).
+func apexServiceName(services compose.Services) string {
+	owner := ""
+	ingressPorts := 0
+	for name, svc := range services {
+		// Managed datastores are dispatched as Postgres/Redis, never as ALB
+		// ingress targets, so they can't own the apex even if a port is set.
+		if svc.Postgres != nil || svc.Redis != nil {
+			continue
+		}
+		for _, port := range svc.Ports {
+			if port.IsIngress() {
+				ingressPorts++
+				owner = name
+			}
+		}
+	}
+	if ingressPorts != 1 {
+		return ""
+	}
+	return owner
 }
 
 func newService(

--- a/provider/defangaws/project_test.go
+++ b/provider/defangaws/project_test.go
@@ -1,0 +1,79 @@
+package defangaws
+
+import (
+	"testing"
+
+	"github.com/DefangLabs/pulumi-defang/provider/compose"
+)
+
+func TestApexServiceName(t *testing.T) {
+	ingress := compose.ServicePortConfig{Target: 80, Mode: compose.PortModeIngress}
+	defaultMode := compose.ServicePortConfig{Target: 80} // empty mode defaults to ingress
+	host := compose.ServicePortConfig{Target: 5432, Mode: compose.PortModeHost}
+
+	tests := []struct {
+		name     string
+		services compose.Services
+		want     string
+	}{
+		{
+			name:     "no services",
+			services: compose.Services{},
+			want:     "",
+		},
+		{
+			name: "single service single ingress port",
+			services: compose.Services{
+				"web": {Ports: []compose.ServicePortConfig{ingress}},
+			},
+			want: "web",
+		},
+		{
+			name: "empty mode counts as ingress",
+			services: compose.Services{
+				"web": {Ports: []compose.ServicePortConfig{defaultMode}},
+			},
+			want: "web",
+		},
+		{
+			name: "one ingress service alongside managed datastore and worker",
+			services: compose.Services{
+				"web":    {Ports: []compose.ServicePortConfig{ingress}},
+				"db":     {Postgres: &compose.PostgresConfig{}, Ports: []compose.ServicePortConfig{defaultMode}},
+				"cache":  {Redis: &compose.RedisConfig{}, Ports: []compose.ServicePortConfig{defaultMode}},
+				"worker": {}, // no ports
+			},
+			want: "web",
+		},
+		{
+			name: "host-only port does not qualify",
+			services: compose.Services{
+				"internal": {Ports: []compose.ServicePortConfig{host}},
+			},
+			want: "",
+		},
+		{
+			name: "two ingress services -> unbound",
+			services: compose.Services{
+				"web": {Ports: []compose.ServicePortConfig{ingress}},
+				"api": {Ports: []compose.ServicePortConfig{ingress}},
+			},
+			want: "",
+		},
+		{
+			name: "single service with two ingress ports -> unbound",
+			services: compose.Services{
+				"web": {Ports: []compose.ServicePortConfig{ingress, {Target: 443, Mode: compose.PortModeIngress}}},
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := apexServiceName(tt.services); got != tt.want {
+				t.Errorf("apexServiceName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Make the auto-assigned (non-BYOD) **project/apex domain** deterministic: bind it to a service **if and only if the whole project has exactly one ingress port** (a single service with a single ingress port). Otherwise the apex is left unbound and served by the ALB listener's default action.

This is the AWS half of the resolution discussed in #373 (apex question). GCP is a separate follow-up because there it's coupled with the per-service host-rule fix (Finding 1 in #373).

> **Breaking change:** projects with 2+ ingress ports previously got the apex bound to a *random* service; after this PR the apex returns the ALB default action — a 404 fixed-response (or 301 to HTTPS on the HTTP listener). Users whose apex happened to resolve usefully will now see a 404 there. This is the deliberate resolution of the apex question in issue 373.

## Why

Today the bare project domain is attached as a host-header alias to whichever ingress service is iterated first, with the code flagging it directly:

```go
if firstIngress {
    // FIXME: which service should listen on the project domain?
    endpoints = append(endpoints, infra.ProjectDomain)
}
```

That "first" is not just arbitrary — it's **non-deterministic**: service dispatch iterates a Go map (`common.TopologicalSort` ranges the services map), so the apex can point at a different service between otherwise-identical deploys.

## How

- New pure helper `apexServiceName(services)` counts ingress ports across the project's deployable services; returns the sole owner when the count is exactly 1, else `""`. Order-independent (depends only on the count and, when 1, the single owner). Managed datastores (Postgres/Redis) are skipped — they never get ALB ingress rules.
- Resolved once in `buildProject`, carried on the internal `SharedInfra.ApexServiceName` (untagged; not a schema field), and consumed in `CreateECSService`. The `FIXME` block becomes `if serviceName == infra.ApexServiceName`.
- Per-service `<service>.<domain>` and per-port `<service>--<port>.<domain>` routing is unchanged.

## Behavior

| Project shape | Apex (`<project>-<stack>.<tenant>.<base>`) |
|---|---|
| 1 service, 1 ingress port | → that service |
| web (1 ingress) + managed db + worker | → web |
| 2+ ingress services, or 1 service with 2 ingress ports | unbound (ALB default action) |
| host-port-only / datastore only | unbound |

Known exception: if the sole ingress service has a BYOD custom domain (`domainname:`), the custom-domain branch takes precedence and the apex stays unbound — same as before this PR.

## Test

`TestApexServiceName` (table-driven) covers: none, single, empty-mode-defaults-to-ingress, one-ingress-alongside-datastore+worker, host-only, two-ingress-services, and single-service-two-ingress-ports.

```
CGO_ENABLED=0 go build ./... && CGO_ENABLED=0 go test ./provider/...   # ok
```

No schema surface changed; `ApexServiceName` is an untagged internal field, confirmed by the schema-regen CI job.
