### PR TITLE
fix(aws): give ECR repos a lifecycle policy so they stop growing forever

### DIFF
--- a/provider/defangaws/aws/ecr.go
+++ b/provider/defangaws/aws/ecr.go
@@ -29,6 +29,19 @@ func createECRRepo(
 		return nil, fmt.Errorf("creating ECR repository: %w", err)
 	}
 
+	// Without this the repository keeps every image ever pushed: the raw ECR
+	// resource has no default lifecycle policy of any kind.
+	policy, err := buildLifecyclePolicy(keepBuildImages)
+	if err != nil {
+		return nil, fmt.Errorf("building ECR lifecycle policy: %w", err)
+	}
+	if _, err := ecr.NewLifecyclePolicy(ctx, name+"-lifecycle", &ecr.LifecyclePolicyArgs{
+		Repository: repo.Name,
+		Policy:     pulumi.String(policy),
+	}, common.MergeOptions(opts, pulumi.Parent(repo))...); err != nil {
+		return nil, fmt.Errorf("creating ECR lifecycle policy: %w", err)
+	}
+
 	return &ecrResult{
 		repository: repo,
 		repoURL:    pulumix.Output[string](repo.RepositoryUrl),
@@ -69,6 +82,23 @@ func createEcrPullThroughCache(
 	)...)
 	if err != nil {
 		return nil, fmt.Errorf("creating ECR pull-through cache rule %q: %w", name, err)
+	}
+
+	// ECR creates the cache repositories itself on the first pull, so there is no
+	// repository resource here to attach a lifecycle policy to and the repos it
+	// creates have none. A creation template is the only mechanism that reaches
+	// them (DefangLabs/defang-mvp#1056).
+	cachePolicy, err := cacheLifecyclePolicy(keepCacheImages)
+	if err != nil {
+		return nil, fmt.Errorf("building ECR cache lifecycle policy: %w", err)
+	}
+	if _, err := ecr.NewRepositoryCreationTemplate(ctx, name+"-cache-template", &ecr.RepositoryCreationTemplateArgs{
+		Prefix:          rule.EcrRepositoryPrefix,
+		AppliedFors:     pulumi.StringArray{pulumi.String("PULL_THROUGH_CACHE")},
+		Description:     pulumi.Sprintf("Retention for %s pull-through cache repos", name),
+		LifecyclePolicy: pulumi.String(cachePolicy),
+	}, common.MergeOptions(opts, pulumi.Parent(rule))...); err != nil {
+		return nil, fmt.Errorf("creating ECR repository creation template %q: %w", name, err)
 	}
 
 	// Build the full ECR mirror URL prefix: {registryId}.dkr.ecr.{region}.amazonaws.com/{prefix}

--- a/provider/defangaws/aws/ecr_policy.go
+++ b/provider/defangaws/aws/ecr_policy.go
@@ -1,0 +1,91 @@
+package aws
+
+import "encoding/json"
+
+// ECR retention. Without a lifecycle policy an ECR repository keeps every image
+// forever: unlike awsx, the raw ecr.Repository resource applies no default at
+// all, not even for untagged images. Measured on the Defang org 2026-08-11:
+// 2.13 TB of ECR storage ($216/month) of which 90% was expirable, and one
+// repository (prod1/kaniko-build) held 11,351 images.
+// See DefangLabs/defang-global#112.
+const (
+	// keepBuildImages bounds a per-project build repo. Chosen as a count rather
+	// than an age because a service that has not been rebuilt in a year still
+	// runs its old image and must be able to pull it again on a task restart —
+	// in the Defang org, live tasks reference images up to 742 days old.
+	keepBuildImages = 20
+
+	// keepCacheImages bounds each pull-through cache repo. Mirrored images can
+	// always be fetched again from upstream, so this can be small.
+	keepCacheImages = 10
+
+	// expireUntaggedDays clears superseded build layers quickly. Only applied to
+	// build repos: see cacheLifecyclePolicy for why caches must not have it.
+	expireUntaggedDays = 1
+)
+
+type lifecycleSelection struct {
+	TagStatus   string `json:"tagStatus"`
+	CountType   string `json:"countType"`
+	CountUnit   string `json:"countUnit,omitempty"`
+	CountNumber int    `json:"countNumber"`
+}
+
+type lifecycleRule struct {
+	RulePriority int                `json:"rulePriority"`
+	Description  string             `json:"description"`
+	Selection    lifecycleSelection `json:"selection"`
+	Action       struct {
+		Type string `json:"type"`
+	} `json:"action"`
+}
+
+type lifecyclePolicy struct {
+	Rules []lifecycleRule `json:"rules"`
+}
+
+func expireRule(priority int, description string, selection lifecycleSelection) lifecycleRule {
+	rule := lifecycleRule{
+		RulePriority: priority,
+		Description:  description,
+		Selection:    selection,
+	}
+	rule.Action.Type = "expire"
+	return rule
+}
+
+// buildLifecyclePolicy is the policy for a repository that holds images we build.
+func buildLifecyclePolicy(keepImages int) (string, error) {
+	policy := lifecyclePolicy{Rules: []lifecycleRule{
+		expireRule(1, "expire untagged images", lifecycleSelection{
+			TagStatus:   "untagged",
+			CountType:   "sinceImagePushed",
+			CountUnit:   "days",
+			CountNumber: expireUntaggedDays,
+		}),
+		expireRule(2, "keep the newest images", lifecycleSelection{
+			TagStatus:   "any",
+			CountType:   "imageCountMoreThan",
+			CountNumber: keepImages,
+		}),
+	}}
+	out, err := json.Marshal(policy)
+	return string(out), err
+}
+
+// cacheLifecyclePolicy is the policy for repositories that ECR creates for a
+// pull-through cache. It has exactly one rule and no untagged rule on purpose:
+// images pulled by digest arrive untagged, so an untagged rule empties the whole
+// cache. An empty cache still works, but it puts every deploy back on the
+// upstream registry and its rate limits (DefangLabs/defang-mvp#2487).
+func cacheLifecyclePolicy(keepImages int) (string, error) {
+	policy := lifecyclePolicy{Rules: []lifecycleRule{
+		expireRule(1, "keep the newest mirrored images", lifecycleSelection{
+			TagStatus:   "any",
+			CountType:   "imageCountMoreThan",
+			CountNumber: keepImages,
+		}),
+	}}
+	out, err := json.Marshal(policy)
+	return string(out), err
+}

--- a/provider/defangaws/aws/ecr_policy.go
+++ b/provider/defangaws/aws/ecr_policy.go
@@ -9,10 +9,14 @@ import "encoding/json"
 // repository (prod1/kaniko-build) held 11,351 images.
 // See DefangLabs/defang-global#112.
 const (
-	// keepBuildImages bounds a per-project build repo. Chosen as a count rather
-	// than an age because a service that has not been rebuilt in a year still
-	// runs its old image and must be able to pull it again on a task restart —
-	// in the Defang org, live tasks reference images up to 742 days old.
+	// keepBuildImages bounds a per-project build repo. In this provider the
+	// repo holds a single mutable :latest tag (codebuild.go pushes every
+	// service's build there; nothing is deployed by digest), so the live image
+	// is always the newest and a count rule can never expire it — the count is
+	// a cap on sub-24h untagged churn, not an in-use-image guard. A count is
+	// still preferred over an age rule so a rarely-rebuilt project keeps its
+	// tagged image indefinitely (elsewhere in the Defang org, live tasks
+	// reference images up to 742 days old).
 	keepBuildImages = 20
 
 	// keepCacheImages bounds each pull-through cache repo. Mirrored images can

--- a/provider/defangaws/aws/ecr_policy_test.go
+++ b/provider/defangaws/aws/ecr_policy_test.go
@@ -1,0 +1,83 @@
+package aws
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func parsePolicy(t *testing.T, doc string) lifecyclePolicy {
+	t.Helper()
+	var parsed lifecyclePolicy
+	require.NoError(t, json.Unmarshal([]byte(doc), &parsed))
+	return parsed
+}
+
+func buildPolicy(t *testing.T, keep int) string {
+	t.Helper()
+	doc, err := buildLifecyclePolicy(keep)
+	require.NoError(t, err)
+	return doc
+}
+
+func cachePolicy(t *testing.T, keep int) string {
+	t.Helper()
+	doc, err := cacheLifecyclePolicy(keep)
+	require.NoError(t, err)
+	return doc
+}
+
+func TestBuildLifecyclePolicy(t *testing.T) {
+	policy := parsePolicy(t, buildPolicy(t, keepBuildImages))
+	require.Len(t, policy.Rules, 2)
+
+	untagged := policy.Rules[0]
+	assert.Equal(t, 1, untagged.RulePriority)
+	assert.Equal(t, "untagged", untagged.Selection.TagStatus)
+	assert.Equal(t, "sinceImagePushed", untagged.Selection.CountType)
+	assert.Equal(t, "days", untagged.Selection.CountUnit)
+	assert.Equal(t, "expire", untagged.Action.Type)
+
+	// Bounding the count is the whole point: without it the repo grows forever.
+	keep := policy.Rules[1]
+	assert.Equal(t, 2, keep.RulePriority)
+	assert.Equal(t, "any", keep.Selection.TagStatus)
+	assert.Equal(t, "imageCountMoreThan", keep.Selection.CountType)
+	assert.Equal(t, keepBuildImages, keep.Selection.CountNumber)
+	// Age would delete images that live-but-not-recently-rebuilt services need.
+	assert.Empty(t, keep.Selection.CountUnit)
+}
+
+func TestCacheLifecyclePolicyHasNoUntaggedRule(t *testing.T) {
+	policy := parsePolicy(t, cachePolicy(t, keepCacheImages))
+	require.Len(t, policy.Rules, 1, "a cache needs exactly one count rule")
+
+	rule := policy.Rules[0]
+	assert.Equal(t, "any", rule.Selection.TagStatus)
+	assert.Equal(t, keepCacheImages, rule.Selection.CountNumber)
+
+	// Images pulled by digest arrive untagged, so an untagged rule would empty
+	// the cache and push every deploy onto the upstream registry's rate limits.
+	for _, r := range policy.Rules {
+		assert.NotEqual(t, "untagged", r.Selection.TagStatus)
+	}
+}
+
+func TestLifecyclePoliciesAreValidJSON(t *testing.T) {
+	for name, doc := range map[string]string{
+		"build": buildPolicy(t, 5),
+		"cache": cachePolicy(t, 5),
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.True(t, json.Valid([]byte(doc)))
+			// ECR rejects a policy with an unknown or empty action type.
+			for _, r := range parsePolicy(t, doc).Rules {
+				assert.Equal(t, "expire", r.Action.Type)
+				assert.NotEmpty(t, r.Description)
+				assert.Positive(t, r.Selection.CountNumber)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Companion to DefangLabs/defang-mvp#3171, which fixes the same class of bug in the legacy Pulumi code. Both come out of the measurement in DefangLabs/defang-global#112 item 1.

## What was wrong

`createECRRepo` creates the repository and stops there. **The raw `ecr.Repository` resource applies no default lifecycle policy of any kind** — not even for untagged images — so `grep -rn LifecyclePolicy` over this repo returned nothing and every image a project ever builds is retained. Each new BYOC project starts another unbounded repository. This is strictly worse than the legacy path, where awsx at least applies an untagged-only default.

Pull-through caches are worse again: ECR creates those repositories itself on the first pull, so there is no Pulumi resource to attach a policy to and they end up with none at all.

Measured across the Defang org on 2026-08-11 (272 repos, 9 accounts):

| | |
|---|---|
| ECR storage | 2.13 TB, **$216/month**, flat at $7.11/day |
| Repos with no lifecycle policy | 252 of 272 |
| Expirable | **90%** |
| Largest single repo | 11,351 images, 2,411 GB apparent |

## What this changes

**Build repos** (`ecr.NewLifecyclePolicy` on the repository) — expire untagged after 1 day, then keep the newest 20 images.

Count, not age, and deliberately: live ECS tasks in that org reference images **up to 742 days old** (`library/grafana/loki`), plus `loki-conf` at 578 days and two project `kaniko-build` repos at 270 days with no rebuild since 2025-11-14. An age rule deletes those — the running task survives, but the next restart or scale-out cannot pull. A count rule is safe here because this provider's build repo is per-project, so one project's builds cannot push another's image out of the window.

**Pull-through cache repos** (`ecr.NewRepositoryCreationTemplate` with `appliedFors: ["PULL_THROUGH_CACHE"]`) — keep the newest 10, and **no untagged rule**. That omission is the important detail: in a cache almost every image is untagged, because it arrives by digest. I verified one — `defang-cd-ecr-public/defang-io/cd` holds 25 images, all 25 untagged (5 OCI indexes plus their 20 children). An untagged rule would empty the cache and put every deploy back on `public.ecr.aws` and its rate limits, i.e. DefangLabs/defang-mvp#2487 again.

The policy documents live in a new `ecr_policy.go` as pure functions so the rule shapes are unit-testable without standing up a stack.

## Follow-up worth filing separately

`createEcrPullThroughCache` derives its prefix from `AutonamingPrefix`, i.e. one cache namespace **per project**. The same upstream image therefore gets cached once per project inside a single account. Measured in the `lab` account: **55 distinct prefixes each holding their own copy of `aws-observability/aws-for-fluent-bit`**, and 37 each caching `defang-io/route53-sidecar` — about 1 TB apparent org-wide in duplicate copies. This PR bounds each copy; sharing the prefix per account would remove them, but that needs adopt-or-create semantics because the namespace is account-global, which is exactly why the current code scopes it per project (as its own comment explains). Happy to do that as a second PR if you want it.

## Testing

`CGO_ENABLED=0 go test ./provider/...` passes; 3 new test functions cover the rule shapes, including a regression guard that the cache policy never grows an untagged rule. `go vet` clean, `gofmt` clean. `golangci-lint` reports 40 pre-existing `goconst` findings elsewhere in `provider/defangaws/aws` and none in these files; `recipe.go` was already unformatted on `main` and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3WmpdY3zc555sNdkY9dzQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic lifecycle policies for container image repositories.
  * Build repositories now retain the configured number of recent images and remove older untagged images.
  * Pull-through cache repositories retain the configured number of recent images.
  * Added lifecycle policies to repositories created through pull-through caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->