### PR TITLE
fix(lint): suppress funlen on createService — main test job red since 2026-07-20

### DIFF
--- a/provider/defanggcp/service.go
+++ b/provider/defanggcp/service.go
@@ -201,6 +201,7 @@ func validateSidecarImages(serviceName string, sidecars map[string]compose.Servi
 // the Cloud Run service or Compute Engine MIG under an already-registered Service
 // component, populates its Endpoint/LBEntry, and registers its outputs. Shared
 // between Construct and the project-level dispatcher.
+//nolint:funlen // sequential service setup is clearer as one function
 func createService(
 	ctx *pulumi.Context,
 	comp *ServiceOutputs,


### PR DESCRIPTION
## What

One line: add `//nolint:funlen` to `createService` in `provider/defanggcp/service.go`, using the same convention already applied in `provider/defangaws` (alb.go, ecs.go, rds.go, memorydb.go, lb.go).

## Why

The feat/gcp-policies merge (PR 350, 2026-07-20) pushed `createService` to 101 lines, one over golangci-lint's `funlen` limit of 100. Since then **main's own `test` job is red** (run 29728942161) and every open PR inherits the failure — it is currently masking real CI signal on PR 376, PR 379, and the dependabot queue.

Verified locally: `golangci-lint run provider/defanggcp/...` no longer reports funlen, and `go build ./provider/...` is clean.

Extracting the Cloud-Run-vs-Compute-Engine branch into a helper would be the nicer long-term fix, but the suppress matches how the AWS provider handles the same linter and unblocks CI today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LaK7gzpvfPMHL2hkBPFeHH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code-quality configuration to accommodate an existing service implementation.
  * No changes to runtime behavior or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->