### PR TITLE
ci: bump pulumi/actions to v7 in build-sdk, scan composite actions with Dependabot

### DIFF
--- a/.github/actions/build-sdk/action.yml
+++ b/.github/actions/build-sdk/action.yml
@@ -16,7 +16,7 @@ runs:
       uses: ./.github/actions/setup-go
 
     - name: Install Pulumi CLI
-      uses: pulumi/actions@8582a9e8cc630786854029b4e09281acd6794b58 # v6
+      uses: pulumi/actions@8e5e406f4007fca908480587cb9893c07090f58d # v7
 
     - if: ${{ inputs.language == 'nodejs' }}
       name: Setup Node

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,13 @@
 version: 2
 updates:
+  # "/" only covers .github/workflows/** plus a root-level action.yml, so each
+  # composite action under .github/actions/ needs its own entry — without one
+  # its pinned actions are never bumped and drift behind the workflows'.
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/build-sdk"
+      - "/.github/actions/setup-go"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 3


### PR DESCRIPTION
Follow-up to PR 306, found while checking the version comments in that diff.

## Problem

The `github-actions` Dependabot entry uses `directory: "/"`. For that ecosystem `/` covers `.github/workflows/**` plus an `action.yml` at the repo root — it does **not** reach composite actions under `.github/actions/*/`.

So `.github/actions/build-sdk/action.yml` has been invisible to Dependabot. It still pins `pulumi/actions@8582a9e` (v6.6.1) while PR 306 moves `test.yml` and `release.yml` to `8e5e406` (v7.0.0). Both `test.yml` and `release.yml` call `./.github/actions/build-sdk`, so merging 306 alone leaves one CI run installing the Pulumi CLI through two different majors of the same action.

## Changes

- Pin `build-sdk` to the same `pulumi/actions` v7.0.0 commit the workflows are moving to.
- Replace `directory: "/"` with a `directories:` list that names each composite action, so they no longer drift. Matches the style already used by the `gomod` entry.

This touches different files than PR 306, so the two do not conflict and can merge in either order.

## Verified

- `actionlint` passes clean on the whole tree.
- `8e5e406f4007fca908480587cb9893c07090f58d` resolves to `pulumi/actions` tags `v7` and `v7.0.0`.
- Every other SHA-pinned action in `.github/` was checked against its real tags. All comments match the pinned commit except `actions/checkout` in PR 306 itself, which I left a review comment about there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3WmpdY3zc555sNdkY9dzQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Pulumi CLI setup used by automated build workflows.
  * Expanded automated monitoring to cover additional GitHub Actions configuration directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->