### PR TITLE
fix(lint): drop stale funlen suppression on createService (main is red)

### DIFF
--- a/provider/defanggcp/service.go
+++ b/provider/defanggcp/service.go
@@ -247,7 +247,6 @@ func validateSidecarImages(serviceName string, sidecars map[string]compose.Servi
 // the Cloud Run service or Compute Engine MIG under an already-registered Service
 // component, populates its Endpoint/LBEntry, and registers its outputs. Shared
 // between Construct and the project-level dispatcher.
-//nolint:funlen // sequential service setup is clearer as one function
 func createService(
 	ctx *pulumi.Context,
 	comp *ServiceOutputs,


### PR DESCRIPTION
`main` has been failing `test.yml` at the `golangci-lint` step:

```
provider/defanggcp/service.go:250:1: directive `//nolint:funlen // sequential service setup is
clearer as one function` is unused for linter "funlen" (nolintlint)
```

## Cause

`fa08b8e` added that `//nolint:funlen` to unblock `main` after PR 350 merged. Merging PR 351 afterward shrank `createService` back under the 100-line `funlen` limit, which made the suppression redundant — and `nolintlint` is enabled, so it rejects unused directives. The fix for the last lint break became the next one.

## Change

Delete the directive. One line, no behavior change.

## Heads up on the margin

`createService` is now 100 lines against a `funlen.lines: 100` limit — exactly one line of headroom. The next addition to that function will trip `funlen` for real. When that happens the fix is to split the function, not to re-add a suppression, or this loops a third time. Noted in the commit message too.

## Verified

- Reproduced the failure locally, then confirmed the deletion clears it: `golangci-lint run --enable-only funlen,nolintlint ./provider/...` reports `0 issues`.
- `go build ./provider/...` succeeds.
- `go test -short ./provider/defanggcp/...` passes, both `defanggcp` and `defanggcp/gcp`.

Independent of PR 384 and PR 306 — different files, any merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3WmpdY3zc555sNdkY9dzQ