### PR TITLE
feat(azure): serve wildcard custom domains through Azure Front Door

### DIFF
--- a/cd/go.mod
+++ b/cd/go.mod
@@ -163,6 +163,7 @@ require (
 	github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 // indirect
 	github.com/pulumi/pulumi-azure-native-sdk/app/v3 v3.17.0 // indirect
 	github.com/pulumi/pulumi-azure-native-sdk/authorization/v3 v3.17.0 // indirect
+	github.com/pulumi/pulumi-azure-native-sdk/cdn/v3 v3.17.0 // indirect
 	github.com/pulumi/pulumi-azure-native-sdk/cognitiveservices/v3 v3.17.0 // indirect
 	github.com/pulumi/pulumi-azure-native-sdk/containerregistry/v3 v3.17.0 // indirect
 	github.com/pulumi/pulumi-azure-native-sdk/dbforpostgresql/v3 v3.17.0 // indirect

--- a/cd/go.sum
+++ b/cd/go.sum
@@ -358,6 +358,8 @@ github.com/pulumi/pulumi-azure-native-sdk/app/v3 v3.17.0 h1:QZksspyGhUliOncXYSun
 github.com/pulumi/pulumi-azure-native-sdk/app/v3 v3.17.0/go.mod h1:A4c9UObJvoBe0GZLalGGCf3x4WJsutLuZTgHGB9Du1A=
 github.com/pulumi/pulumi-azure-native-sdk/authorization/v3 v3.17.0 h1:XQ4akM+v4jT6bUDrbzqty0YpwPJAbS/47QzfuAt6+MM=
 github.com/pulumi/pulumi-azure-native-sdk/authorization/v3 v3.17.0/go.mod h1:eCpJILleDDKZkpjXQU1pRYOIinx/FfbCdNCiolUQRBM=
+github.com/pulumi/pulumi-azure-native-sdk/cdn/v3 v3.17.0 h1:22+mtR+UDed94Wf7MvOOO+hzLyV24lPJxQHSDvn4d2c=
+github.com/pulumi/pulumi-azure-native-sdk/cdn/v3 v3.17.0/go.mod h1:fvrWk/61fMf3EejTRRXShEmluo8Fih40PSloveYt9lI=
 github.com/pulumi/pulumi-azure-native-sdk/cognitiveservices/v3 v3.17.0 h1:VEnTJGvX3JxNpGCFG3Ebu36Dy80Y29CE/MhHdQ+VWiA=
 github.com/pulumi/pulumi-azure-native-sdk/cognitiveservices/v3 v3.17.0/go.mod h1:9dmHyxXmeX8bniNWfP/+QEAcDPpmROxP+yMdZP8jlkE=
 github.com/pulumi/pulumi-azure-native-sdk/containerregistry/v3 v3.17.0 h1:SHj85MVhfFwJDr9Sf86iHlAviRVW0oN8xqp6JVh0PNE=

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/pulumi/pulumi-awsx/sdk/v3 v3.1.0
 	github.com/pulumi/pulumi-azure-native-sdk/app/v3 v3.17.0
 	github.com/pulumi/pulumi-azure-native-sdk/authorization/v3 v3.17.0
+	github.com/pulumi/pulumi-azure-native-sdk/cdn/v3 v3.17.0
 	github.com/pulumi/pulumi-azure-native-sdk/cognitiveservices/v3 v3.17.0
 	github.com/pulumi/pulumi-azure-native-sdk/containerregistry/v3 v3.17.0
 	github.com/pulumi/pulumi-azure-native-sdk/dbforpostgresql/v3 v3.17.0

--- a/go.sum
+++ b/go.sum
@@ -373,6 +373,8 @@ github.com/pulumi/pulumi-azure-native-sdk/app/v3 v3.17.0 h1:QZksspyGhUliOncXYSun
 github.com/pulumi/pulumi-azure-native-sdk/app/v3 v3.17.0/go.mod h1:A4c9UObJvoBe0GZLalGGCf3x4WJsutLuZTgHGB9Du1A=
 github.com/pulumi/pulumi-azure-native-sdk/authorization/v3 v3.17.0 h1:XQ4akM+v4jT6bUDrbzqty0YpwPJAbS/47QzfuAt6+MM=
 github.com/pulumi/pulumi-azure-native-sdk/authorization/v3 v3.17.0/go.mod h1:eCpJILleDDKZkpjXQU1pRYOIinx/FfbCdNCiolUQRBM=
+github.com/pulumi/pulumi-azure-native-sdk/cdn/v3 v3.17.0 h1:22+mtR+UDed94Wf7MvOOO+hzLyV24lPJxQHSDvn4d2c=
+github.com/pulumi/pulumi-azure-native-sdk/cdn/v3 v3.17.0/go.mod h1:fvrWk/61fMf3EejTRRXShEmluo8Fih40PSloveYt9lI=
 github.com/pulumi/pulumi-azure-native-sdk/cognitiveservices/v3 v3.17.0 h1:VEnTJGvX3JxNpGCFG3Ebu36Dy80Y29CE/MhHdQ+VWiA=
 github.com/pulumi/pulumi-azure-native-sdk/cognitiveservices/v3 v3.17.0/go.mod h1:9dmHyxXmeX8bniNWfP/+QEAcDPpmROxP+yMdZP8jlkE=
 github.com/pulumi/pulumi-azure-native-sdk/containerregistry/v3 v3.17.0 h1:SHj85MVhfFwJDr9Sf86iHlAviRVW0oN8xqp6JVh0PNE=

--- a/provider/common/dns.go
+++ b/provider/common/dns.go
@@ -72,9 +72,12 @@ func ServiceFQDN(serviceName string, svc compose.ServiceConfig, publicDomain, pr
 // of the name that follows it, e.g. "*.example.com".
 const WildcardPrefix = "*."
 
-// IsWildcardHost reports whether hostname is a wildcard hostname.
+// IsWildcardHost reports whether hostname is a wildcard hostname. A bare "*."
+// isn't one: it stands for nothing, and passing it on as a domain would have a
+// cloud reject it — or worse, accept it.
 func IsWildcardHost(hostname string) bool {
-	return strings.HasPrefix(hostname, WildcardPrefix)
+	base, found := strings.CutPrefix(hostname, WildcardPrefix)
+	return found && base != ""
 }
 
 // ByodHostnames returns the bring-your-own-domain hostnames a service asks to be

--- a/provider/common/dns.go
+++ b/provider/common/dns.go
@@ -68,6 +68,26 @@ func ServiceFQDN(serviceName string, svc compose.ServiceConfig, publicDomain, pr
 	return ""
 }
 
+// WildcardPrefix marks a hostname that stands for every single-level subdomain
+// of the name that follows it, e.g. "*.example.com".
+const WildcardPrefix = "*."
+
+// IsWildcardHost reports whether hostname is a wildcard hostname.
+func IsWildcardHost(hostname string) bool {
+	return strings.HasPrefix(hostname, WildcardPrefix)
+}
+
+// ByodHostnames returns the bring-your-own-domain hostnames a service asks to be
+// reachable on: its `domainname`, followed by the aliases on its default
+// network. A service with no `domainname` gets nil even when it has aliases —
+// aliases extend a BYOD request, they don't make one.
+func ByodHostnames(svc compose.ServiceConfig) []string {
+	if svc.DomainName == "" {
+		return nil
+	}
+	return append([]string{svc.DomainName}, svc.DefaultNetwork().Aliases...)
+}
+
 // https://www.rfc-editor.org/rfc/rfc6762#appendix-G and https://www.rfc-editor.org/rfc/rfc8375
 var privateZoneRegex = regexp.MustCompile(`(?i)\b(intranet|internal|private|corp|home|home\.arpa|lan|local)\.?$`)
 

--- a/provider/common/dns_test.go
+++ b/provider/common/dns_test.go
@@ -195,3 +195,81 @@ func TestGetZoneName(t *testing.T) {
 		}
 	}
 }
+
+func TestIsWildcardHost(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"*.example.com", true},
+		{"*.a.b.example.com", true},
+		{"example.com", false},
+		{"", false},
+		// A wildcard is only a wildcard as the leftmost label; anywhere else it
+		// is just an invalid hostname, not a pattern.
+		{"a.*.example.com", false},
+		{"*", false},
+	}
+	for _, tt := range tests {
+		if got := IsWildcardHost(tt.input); got != tt.want {
+			t.Errorf("IsWildcardHost(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestByodHostnames(t *testing.T) {
+	withAliases := func(aliases ...string) map[compose.NetworkID]compose.ServiceNetworkConfig {
+		return map[compose.NetworkID]compose.ServiceNetworkConfig{
+			compose.DefaultNetwork: {Aliases: aliases},
+		}
+	}
+
+	tests := []struct {
+		name string
+		svc  compose.ServiceConfig
+		want []string
+	}{
+		{
+			name: "no domainname yields nothing even with aliases",
+			svc:  compose.ServiceConfig{Networks: withAliases("alias.example.com")},
+			want: nil,
+		},
+		{
+			name: "domainname alone",
+			svc:  compose.ServiceConfig{DomainName: "auth.example.com"},
+			want: []string{"auth.example.com"},
+		},
+		{
+			name: "domainname comes first, then aliases in order",
+			svc: compose.ServiceConfig{
+				DomainName: "auth.example.com",
+				Networks:   withAliases("*.auth.example.com", "login.example.com"),
+			},
+			want: []string{"auth.example.com", "*.auth.example.com", "login.example.com"},
+		},
+		{
+			name: "aliases on a non-default network are ignored",
+			svc: compose.ServiceConfig{
+				DomainName: "auth.example.com",
+				Networks: map[compose.NetworkID]compose.ServiceNetworkConfig{
+					"internal": {Aliases: []string{"*.internal.example.com"}},
+				},
+			},
+			want: []string{"auth.example.com"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ByodHostnames(tt.svc)
+			if len(got) != len(tt.want) {
+				t.Fatalf("ByodHostnames() = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("ByodHostnames() = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}

--- a/provider/common/dns_test.go
+++ b/provider/common/dns_test.go
@@ -209,6 +209,8 @@ func TestIsWildcardHost(t *testing.T) {
 		// is just an invalid hostname, not a pattern.
 		{"a.*.example.com", false},
 		{"*", false},
+		// "*." stands for nothing; it is not a wildcard for the empty domain.
+		{"*.", false},
 	}
 	for _, tt := range tests {
 		if got := IsWildcardHost(tt.input); got != tt.want {

--- a/provider/defangaws/aws/cert.go
+++ b/provider/defangaws/aws/cert.go
@@ -184,12 +184,11 @@ func createCertsAndRoute53Dns(
 	if infra == nil || infra.HttpsListener == nil || infra.Alb == nil {
 		return nil
 	}
-	if svc.DomainName == "" {
+	// Collect all BYOD hostnames: domainname + network aliases
+	hostnames := common.ByodHostnames(svc)
+	if len(hostnames) == 0 {
 		return nil
 	}
-
-	// Collect all BYOD hostnames: domainname + network aliases
-	hostnames := append([]string{svc.DomainName}, svc.DefaultNetwork().Aliases...)
 
 	// Group hostnames that share the same validation record onto one cert
 	certGroups := groupHostnamesByCert(hostnames)

--- a/provider/defangazure/azure/azure.go
+++ b/provider/defangazure/azure/azure.go
@@ -39,6 +39,10 @@ type SharedInfra struct {
 	// EnsureDomainZone so that `defang compose down` deletes it (and its records)
 	// instead of orphaning it in the resource group. Nil when Domain is empty.
 	DomainZone *dns.Zone
+	// FrontDoor is the project's Azure Front Door profile and endpoint, which
+	// serve the wildcard hostnames Container Apps can't bind. Nil unless some
+	// service asks for one — see frontdoor.go.
+	FrontDoor *FrontDoorInfra
 }
 
 // BaseTags returns the project-wide tag map: defang-project (Pulumi project),

--- a/provider/defangazure/azure/containerapp.go
+++ b/provider/defangazure/azure/containerapp.go
@@ -88,6 +88,9 @@ type containerAppResult struct {
 	// CustomDomain is nil unless the project sets a delegate Domain *and* the
 	// service exposes a public ingress; see CreateCustomDomain.
 	CustomDomain *CustomDomainResult
+	// WildcardDomain is nil unless the service declares a wildcard hostname and
+	// the project has a Front Door to serve it; see CreateWildcardDomain.
+	WildcardDomain *WildcardDomainResult
 }
 
 // containerAppCpuMemory snaps requested CPU/memory to Azure Container Apps fixed tiers.
@@ -338,16 +341,38 @@ func CreateContainerApp(
 		return nil, fmt.Errorf("creating Container App: %w", err)
 	}
 
-	// Provision per-service DNS records + managed cert under the project
-	// delegate domain (no-op when infra.Domain is empty or the service is
-	// internal-only). Bound to the CA's parent option set so failures here
-	// propagate through the normal component graph.
+	// Attach the service's public hostnames. Bound to the CA's parent option set
+	// so failures here propagate through the normal component graph.
+	return createAppDomains(ctx, serviceName, svc, containerApp, infra, opts...)
+}
+
+// createAppDomains attaches the service's public hostnames to its Container App:
+// the delegate-domain records and cert Azure Container Apps can bind itself, and
+// Front Door routing for the wildcard hostnames it can't. Either half is a no-op
+// when the service doesn't ask for it.
+func createAppDomains(
+	ctx *pulumi.Context,
+	serviceName string,
+	svc compose.ServiceConfig,
+	containerApp *app.ContainerApp,
+	infra *SharedInfra,
+	opts ...pulumi.ResourceOption,
+) (*containerAppResult, error) {
 	customDomain, err := CreateCustomDomain(ctx, serviceName, svc, containerApp, infra, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("creating custom domain for %s: %w", serviceName, err)
 	}
 
-	return &containerAppResult{App: containerApp, CustomDomain: customDomain}, nil
+	wildcardDomain, err := CreateWildcardDomain(ctx, serviceName, svc, containerApp, infra, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("creating wildcard domain for %s: %w", serviceName, err)
+	}
+
+	return &containerAppResult{
+		App:            containerApp,
+		CustomDomain:   customDomain,
+		WildcardDomain: wildcardDomain,
+	}, nil
 }
 
 // resolveSubscriptionID resolves the Azure subscription for the out-of-band

--- a/provider/defangazure/azure/frontdoor.go
+++ b/provider/defangazure/azure/frontdoor.go
@@ -1,0 +1,419 @@
+// Wildcard custom-domain support for Container Apps, via Azure Front Door.
+//
+// Container Apps binds custom domains one hostname at a time — each with its own
+// `asuid.<label>` TXT record and its own certificate binding (see
+// customdomain.go) — and its ingress routes strictly on the Host header,
+// answering 404 to any hostname it wasn't told about. A wildcard hostname like
+// `*.auth.example.com` therefore can't be served by ACA at all: there is no
+// wildcard binding, and enumerating the subdomains means one ARM call and one
+// certificate each, against the environment's certificate limits.
+//
+// Azure Front Door can serve it. A Standard profile accepts a wildcard custom
+// domain and issues an Azure-managed certificate for it, validated by a DNS TXT
+// record, so one profile and one certificate cover every subdomain and nothing
+// has to be provisioned when a new subdomain starts being used.
+//
+// What gets created, and only when some service declares a wildcard hostname:
+//
+//  1. A project-scoped cdn.Profile plus cdn.AFDEndpoint (EnsureFrontDoor).
+//  2. Per service, a cdn.AFDOriginGroup and cdn.AFDOrigin aimed at the Container
+//     App's stable FQDN, a cdn.AFDCustomDomain per wildcard hostname, and a
+//     cdn.Route joining them (CreateWildcardDomain).
+//
+// The origin is sent OriginHostHeader = the app's own FQDN, because ACA would
+// 404 the hostname the client used. Front Door passes that original hostname on
+// in X-Forwarded-Host, so an app serving per-subdomain content must read that
+// header rather than Host. This differs from the AWS path, where the ALB
+// forwards the client's Host untouched.
+//
+// Two DNS records make a wildcard domain live: a TXT at `_dnsauth.<label>`
+// carrying the validation token, and a wildcard CNAME at `*.<label>` pointing at
+// the Front Door endpoint. The provider writes both itself when the hostname
+// sits under the project's delegate domain, whose zone it owns. A BYOD hostname
+// usually lives in a zone the deployment can't reach — another subscription, or
+// another cloud's DNS entirely — so there it logs the two records and leaves
+// them to the operator, the same warn-and-degrade rule the AWS BYOD path
+// follows. No CAA record is written: Front Door only needs one where the zone
+// already restricts issuance, and adding a CAA where none exists would restrict
+// every other certificate in the zone.
+//
+// Caveat worth knowing about: Front Door does not auto-rotate a managed
+// certificate for a wildcard domain, though it does for subdomains and apex
+// domains. 45 days before expiry the domain moves to Pending revalidation and
+// the TXT record has to be replaced with a fresh token. A redeploy re-reads the
+// token and rewrites the record wherever the provider owns the zone; everywhere
+// else it's a manual step.
+
+package azure
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/DefangLabs/pulumi-defang/provider/common"
+	"github.com/DefangLabs/pulumi-defang/provider/compose"
+	"github.com/pulumi/pulumi-azure-native-sdk/app/v3"
+	"github.com/pulumi/pulumi-azure-native-sdk/cdn/v3"
+	"github.com/pulumi/pulumi-azure-native-sdk/dns/v3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+const (
+	// frontDoorSKU is the cheapest tier that serves wildcard custom domains with
+	// an Azure-managed certificate. Premium adds managed WAF rulesets and Private
+	// Link origins; this path uses neither.
+	frontDoorSKU = "Standard_AzureFrontDoor"
+
+	// frontDoorLocation is the only location an AFD profile or endpoint accepts —
+	// they are global resources.
+	frontDoorLocation = "Global"
+
+	// dnsAuthPrefix names the TXT record Front Door reads to validate ownership
+	// of a domain: `_dnsauth.<label>`.
+	dnsAuthPrefix = "_dnsauth"
+
+	// dnsAuthTTL is the TTL Front Door's docs prescribe for the validation TXT
+	// record (1 hour). A shorter TTL isn't better here: on revalidation the old
+	// record must have expired before the new token is read, so a long-lived
+	// record only delays a rotation that already runs 45 days ahead of expiry.
+	dnsAuthTTL = 3600
+)
+
+// FrontDoorInfra holds the project-scoped Front Door resources that every
+// service with a wildcard hostname shares.
+type FrontDoorInfra struct {
+	Profile  *cdn.Profile
+	Endpoint *cdn.AFDEndpoint
+}
+
+// WildcardDomainResult bundles what CreateWildcardDomain provisioned for one
+// service. All fields are empty when it had nothing to do.
+type WildcardDomainResult struct {
+	// Domains holds one AFDCustomDomain per wildcard hostname, in the order the
+	// hostnames appear in the service's compose config.
+	Domains []*cdn.AFDCustomDomain
+	// Records holds the DNS record sets written into the delegate-domain zone.
+	// Empty when the hostnames live in a zone this deployment doesn't own, in
+	// which case the records were logged for the operator instead.
+	Records []*dns.RecordSet
+}
+
+// HasWildcardHostname reports whether any service in the project asks to be
+// reachable on a wildcard hostname, which is what makes a Front Door profile
+// worth its cost. Used by the project dispatcher to decide whether to call
+// EnsureFrontDoor at all.
+func HasWildcardHostname(services compose.Services) bool {
+	for _, svc := range services {
+		if len(wildcardHostnames(svc)) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// wildcardHostnames returns the service's BYOD hostnames that are wildcards.
+// A service with no ingress ports gets none: Front Door needs a public origin to
+// forward to, and an internal-only service has no reachable hostname to offer.
+func wildcardHostnames(svc compose.ServiceConfig) []string {
+	if !svc.HasIngressPorts() {
+		return nil
+	}
+	var wildcards []string
+	for _, hostname := range common.ByodHostnames(svc) {
+		if common.IsWildcardHost(hostname) {
+			wildcards = append(wildcards, common.NormalizeDNS(hostname))
+		}
+	}
+	return wildcards
+}
+
+// EnsureFrontDoor creates the project's Front Door profile and endpoint.
+//
+// Returns (nil, nil) when no service declares a wildcard hostname, so a project
+// that doesn't need Front Door never pays for one. Both resources are named by
+// Pulumi's auto-naming rather than derived from the project: an endpoint name is
+// capped at 46 characters and a profile name is unique only within its resource
+// group, and auto-naming satisfies both without a truncation scheme. The
+// endpoint's hostname — the CNAME target every wildcard domain points at — is
+// stable across updates because Pulumi persists the generated name.
+func EnsureFrontDoor(
+	ctx *pulumi.Context,
+	services compose.Services,
+	infra *SharedInfra,
+	parentOpt pulumi.ResourceOption,
+) (*FrontDoorInfra, error) {
+	if infra == nil || !HasWildcardHostname(services) {
+		return nil, nil //nolint:nilnil // no wildcard hostnames; the caller treats nil as "not needed"
+	}
+
+	profile, err := cdn.NewProfile(ctx, "front-door", &cdn.ProfileArgs{
+		ResourceGroupName: infra.ResourceGroup.Name,
+		Location:          pulumi.String(frontDoorLocation),
+		Sku:               &cdn.SkuArgs{Name: pulumi.String(frontDoorSKU)},
+	}, parentOpt)
+	if err != nil {
+		return nil, fmt.Errorf("creating Front Door profile: %w", err)
+	}
+
+	endpoint, err := cdn.NewAFDEndpoint(ctx, "front-door", &cdn.AFDEndpointArgs{
+		ResourceGroupName: infra.ResourceGroup.Name,
+		ProfileName:       profile.Name,
+		Location:          pulumi.String(frontDoorLocation),
+		EnabledState:      pulumi.String("Enabled"),
+	}, parentOpt)
+	if err != nil {
+		return nil, fmt.Errorf("creating Front Door endpoint: %w", err)
+	}
+
+	return &FrontDoorInfra{Profile: profile, Endpoint: endpoint}, nil
+}
+
+// CreateWildcardDomain routes the service's wildcard hostnames through the
+// project's Front Door endpoint to its Container App.
+//
+// Returns (nil, nil) — and creates nothing — when the project has no Front Door
+// (no service asked for a wildcard) or when this service declares no wildcard
+// hostname of its own. Non-wildcard hostnames are left alone: ACA binds those
+// directly, with a managed certificate of its own, and sending them through
+// Front Door would add a second TLS hop and a second bill for nothing.
+func CreateWildcardDomain(
+	ctx *pulumi.Context,
+	serviceName string,
+	svc compose.ServiceConfig,
+	containerApp *app.ContainerApp,
+	infra *SharedInfra,
+	opts ...pulumi.ResourceOption,
+) (*WildcardDomainResult, error) {
+	hostnames := wildcardHostnames(svc)
+	if len(hostnames) == 0 {
+		return nil, nil //nolint:nilnil // this service has no wildcard hostname
+	}
+	if infra == nil || infra.FrontDoor == nil {
+		// A standalone Service has no project to hang a Front Door profile off,
+		// so its wildcard hostnames can't be served. Say so rather than drop them
+		// silently — the service still comes up on its other hostnames.
+		_ = ctx.Log.Warn(fmt.Sprintf(
+			"service %q: wildcard hostnames %s need an Azure Front Door profile, which only the Project "+
+				"component provisions; they will not be served.",
+			serviceName, strings.Join(hostnames, ", "),
+		), nil)
+		return nil, nil //nolint:nilnil // nothing provisioned; the caller treats nil as "skipped"
+	}
+
+	fd := infra.FrontDoor
+	rgName := infra.ResourceGroup.Name
+
+	originGroup, err := cdn.NewAFDOriginGroup(ctx, serviceName+"-origin-group", &cdn.AFDOriginGroupArgs{
+		ResourceGroupName: rgName,
+		ProfileName:       fd.Profile.Name,
+		LoadBalancingSettings: &cdn.LoadBalancingSettingsParametersArgs{
+			SampleSize:                      pulumi.Int(4),
+			SuccessfulSamplesRequired:       pulumi.Int(3),
+			AdditionalLatencyInMilliseconds: pulumi.Int(50),
+		},
+		// No HealthProbeSettings, which leaves probing off. The group holds a
+		// single origin, so a probe can only ever take the one backend out of
+		// rotation with nothing to fail over to — and its default probe of "/"
+		// would call an app unhealthy for answering anything but 200, which a
+		// redirect to a login page (the very case this path exists for) does.
+	}, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("creating Front Door origin group for %s: %w", serviceName, err)
+	}
+
+	// The Container App's stable hostname, same target CreateCustomDomain uses:
+	// LatestRevisionFqdn would move on every deploy.
+	appFQDN := pulumi.Sprintf("%s.%s", containerApp.Name, infra.Environment.DefaultDomain)
+	_, err = cdn.NewAFDOrigin(ctx, serviceName+"-origin", &cdn.AFDOriginArgs{
+		ResourceGroupName: rgName,
+		ProfileName:       fd.Profile.Name,
+		OriginGroupName:   originGroup.Name,
+		HostName:          appFQDN,
+		// ACA routes on Host and 404s a hostname it has no binding for, so the
+		// app's own FQDN has to be what reaches it. The hostname the client asked
+		// for arrives as X-Forwarded-Host.
+		OriginHostHeader: appFQDN,
+		HttpsPort:        pulumi.Int(443),
+		HttpPort:         pulumi.Int(80),
+		// The origin hostname is the real certificate subject, so name checking
+		// costs nothing and keeps the hop authenticated.
+		EnforceCertificateNameCheck: pulumi.Bool(true),
+		Priority:                    pulumi.Int(1),
+		Weight:                      pulumi.Int(1000),
+		EnabledState:                pulumi.String("Enabled"),
+	}, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("creating Front Door origin for %s: %w", serviceName, err)
+	}
+
+	result := &WildcardDomainResult{}
+	domainRefs := cdn.ActivatedResourceReferenceArray{}
+	for i, hostname := range hostnames {
+		domain, err := cdn.NewAFDCustomDomain(ctx, fmt.Sprintf("%s-wildcard-%d", serviceName, i), &cdn.AFDCustomDomainArgs{
+			ResourceGroupName: rgName,
+			ProfileName:       fd.Profile.Name,
+			HostName:          pulumi.String(hostname),
+			TlsSettings: &cdn.AFDDomainHttpsParametersArgs{
+				// No MinimumTlsVersion: from API version 2025-06-01 it only
+				// applies alongside a Customized cipherSuiteSetType, and Front
+				// Door's own default minimum is already TLS 1.2.
+				CertificateType: pulumi.String("ManagedCertificate"),
+			},
+		}, opts...)
+		if err != nil {
+			return nil, fmt.Errorf("creating Front Door domain %s for %s: %w", hostname, serviceName, err)
+		}
+		result.Domains = append(result.Domains, domain)
+		domainRefs = append(domainRefs, &cdn.ActivatedResourceReferenceArgs{Id: domain.ID()})
+
+		records, err := publishValidation(ctx, serviceName, hostname, domain, fd, infra, opts...)
+		if err != nil {
+			return nil, err
+		}
+		result.Records = append(result.Records, records...)
+	}
+
+	// The route is created whatever state the domains are in. Front Door accepts
+	// an unvalidated domain on a route — that is the normal add-domain-then-add-DNS
+	// order — and starts serving it the moment validation completes.
+	_, err = cdn.NewRoute(ctx, serviceName+"-route", &cdn.RouteArgs{
+		ResourceGroupName:  rgName,
+		ProfileName:        fd.Profile.Name,
+		EndpointName:       fd.Endpoint.Name,
+		OriginGroup:        &cdn.ResourceReferenceArgs{Id: originGroup.ID()},
+		CustomDomains:      domainRefs,
+		PatternsToMatch:    pulumi.StringArray{pulumi.String("/*")},
+		SupportedProtocols: pulumi.StringArray{pulumi.String("Http"), pulumi.String("Https")},
+		ForwardingProtocol: pulumi.String("HttpsOnly"),
+		HttpsRedirect:      pulumi.String("Enabled"),
+		// The endpoint's own *.azurefd.net hostname stays unrouted: it would be a
+		// second, unauthenticated way into the app that nobody asked for.
+		LinkToDefaultDomain: pulumi.String("Disabled"),
+		EnabledState:        pulumi.String("Enabled"),
+		// No CacheConfiguration, which leaves caching off — these are application
+		// origins, not static assets.
+	}, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("creating Front Door route for %s: %w", serviceName, err)
+	}
+
+	return result, nil
+}
+
+// publishValidation gets the two DNS records a wildcard domain needs into place:
+// the `_dnsauth.<label>` TXT carrying Front Door's validation token, and the
+// `*.<label>` CNAME pointing at the Front Door endpoint.
+//
+// It writes them when the hostname sits inside the project's delegate-domain
+// zone, which the provider owns. Otherwise it logs them — with the token, once
+// Front Door has issued it — and returns no records, leaving the operator to add
+// them wherever the zone actually lives.
+func publishValidation(
+	ctx *pulumi.Context,
+	serviceName, hostname string,
+	domain *cdn.AFDCustomDomain,
+	fd *FrontDoorInfra,
+	infra *SharedInfra,
+	opts ...pulumi.ResourceOption,
+) ([]*dns.RecordSet, error) {
+	token := domain.ValidationProperties.ValidationToken()
+	// Strip the "*." so both records are named from the domain being validated:
+	// "*.auth.example.com" validates via _dnsauth.auth.example.com.
+	base := strings.TrimPrefix(hostname, common.WildcardPrefix)
+
+	label, inZone := relativeRecordName(base, infra.Domain)
+	if !inZone || infra.DomainZone == nil {
+		logManualRecords(ctx, serviceName, hostname, base, token, fd.Endpoint.HostName)
+		return nil, nil
+	}
+
+	rgName := infra.ResourceGroup.Name
+	zoneName := infra.DomainZone.Name
+	tags := ServiceTags(serviceName)
+
+	auth, err := dns.NewRecordSet(ctx, serviceName+"-"+common.SafeLabel(base)+"-dnsauth", &dns.RecordSetArgs{
+		ResourceGroupName:     rgName,
+		ZoneName:              zoneName,
+		RelativeRecordSetName: pulumi.String(joinLabels(dnsAuthPrefix, label)),
+		RecordType:            pulumi.String("TXT"),
+		Ttl:                   pulumi.Float64(dnsAuthTTL),
+		TxtRecords: dns.TxtRecordArray{
+			&dns.TxtRecordArgs{Value: pulumi.StringArray{token}},
+		},
+		Metadata: tags,
+	}, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("creating validation TXT for %s: %w", hostname, err)
+	}
+
+	cname, err := dns.NewRecordSet(ctx, serviceName+"-"+common.SafeLabel(base)+"-wildcard", &dns.RecordSetArgs{
+		ResourceGroupName:     rgName,
+		ZoneName:              zoneName,
+		RelativeRecordSetName: pulumi.String(joinLabels("*", label)),
+		RecordType:            pulumi.String("CNAME"),
+		Ttl:                   pulumi.Float64(60),
+		CnameRecord:           &dns.CnameRecordArgs{Cname: fd.Endpoint.HostName},
+		Metadata:              tags,
+	}, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("creating wildcard CNAME for %s: %w", hostname, err)
+	}
+
+	return []*dns.RecordSet{auth, cname}, nil
+}
+
+// logManualRecords prints the two records the operator has to add for a wildcard
+// hostname whose zone this deployment can't write to. It runs inside an apply so
+// the validation token and endpoint hostname are resolved values; during a
+// preview neither is known yet and nothing is printed.
+func logManualRecords(
+	ctx *pulumi.Context,
+	serviceName, hostname, base string,
+	token, endpointHost pulumi.StringOutput,
+) {
+	pulumi.All(token, endpointHost).ApplyT(func(vs []any) string {
+		validationToken, _ := vs[0].(string)
+		endpoint, _ := vs[1].(string)
+		msg := fmt.Sprintf(
+			"service %q: %s is served by Azure Front Door, but its DNS zone isn't managed by this deployment.\n"+
+				"Add these records to the zone for %s to finish it:\n"+
+				"  TXT    %s.%s    %q\n"+
+				"  CNAME  %s          %s\n"+
+				"Front Door does not auto-renew a wildcard certificate: the TXT record has to be "+
+				"refreshed when the domain enters Pending revalidation, 45 days before expiry.",
+			serviceName, hostname, base,
+			dnsAuthPrefix, base, validationToken,
+			hostname, endpoint,
+		)
+		_ = ctx.Log.Warn(msg, nil)
+		return msg
+	})
+}
+
+// relativeRecordName expresses fqdn relative to zone, the form Azure DNS record
+// sets are named in — "auth.example.com" in zone "example.com" is "auth", and
+// the zone apex is "@". Reports false when fqdn isn't inside zone, or when zone
+// is empty.
+func relativeRecordName(fqdn, zone string) (string, bool) {
+	fqdn, zone = common.NormalizeDNS(fqdn), common.NormalizeDNS(zone)
+	if zone == "" {
+		return "", false
+	}
+	if fqdn == zone {
+		return "@", true
+	}
+	suffix := "." + zone
+	if !strings.HasSuffix(fqdn, suffix) {
+		return "", false
+	}
+	return strings.TrimSuffix(fqdn, suffix), true
+}
+
+// joinLabels prefixes a relative record name with another label, collapsing the
+// apex: "_dnsauth" + "@" is "_dnsauth", not "_dnsauth.@".
+func joinLabels(prefix, relative string) string {
+	if relative == "@" {
+		return prefix
+	}
+	return prefix + "." + relative
+}

--- a/provider/defangazure/azure/frontdoor.go
+++ b/provider/defangazure/azure/frontdoor.go
@@ -47,6 +47,7 @@
 package azure
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -77,6 +78,13 @@ const (
 	// record must have expired before the new token is read, so a long-lived
 	// record only delays a rotation that already runs 45 days ahead of expiry.
 	dnsAuthTTL = 3600
+)
+
+// errWildcardNeedsProject is returned when a service asks for a wildcard
+// hostname on the standalone Service path, which has no project-scoped Front
+// Door profile to route it through.
+var errWildcardNeedsProject = errors.New(
+	"wildcard domains on Azure need an Azure Front Door profile, which only the Project component provisions",
 )
 
 // FrontDoorInfra holds the project-scoped Front Door resources that every
@@ -189,15 +197,10 @@ func CreateWildcardDomain(
 		return nil, nil //nolint:nilnil // this service has no wildcard hostname
 	}
 	if infra == nil || infra.FrontDoor == nil {
-		// A standalone Service has no project to hang a Front Door profile off,
-		// so its wildcard hostnames can't be served. Say so rather than drop them
-		// silently — the service still comes up on its other hostnames.
-		_ = ctx.Log.Warn(fmt.Sprintf(
-			"service %q: wildcard hostnames %s need an Azure Front Door profile, which only the Project "+
-				"component provisions; they will not be served.",
-			serviceName, strings.Join(hostnames, ", "),
-		), nil)
-		return nil, nil //nolint:nilnil // nothing provisioned; the caller treats nil as "skipped"
+		// Only the Project component provisions a Front Door profile, so a
+		// standalone Service can't serve a wildcard. Fail rather than deploy a
+		// service that looks configured for a hostname nothing will answer on.
+		return nil, fmt.Errorf("service %s (%s): %w", serviceName, strings.Join(hostnames, ", "), errWildcardNeedsProject)
 	}
 
 	fd := infra.FrontDoor

--- a/provider/defangazure/azure/frontdoor_test.go
+++ b/provider/defangazure/azure/frontdoor_test.go
@@ -1,0 +1,234 @@
+package azure
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/DefangLabs/pulumi-defang/provider/compose"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+const (
+	testZone     = "example.com"
+	testHost     = "auth." + testZone
+	testWildcard = "*." + testHost
+	testService  = "auth"
+)
+
+func ingressPorts() []compose.ServicePortConfig {
+	return []compose.ServicePortConfig{{Target: 80, Mode: "ingress"}}
+}
+
+func aliasNetwork(aliases ...string) map[compose.NetworkID]compose.ServiceNetworkConfig {
+	return map[compose.NetworkID]compose.ServiceNetworkConfig{
+		compose.DefaultNetwork: {Aliases: aliases},
+	}
+}
+
+// TestWildcardHostnames pins down which compose shapes count as a wildcard
+// request. The two that matter in practice are a wildcard written straight into
+// `domainname` and one added as a network alias next to a plain `domainname` —
+// the second is how a service keeps a canonical hostname and still answers for
+// every subdomain.
+func TestWildcardHostnames(t *testing.T) {
+	tests := []struct {
+		name string
+		svc  compose.ServiceConfig
+		want []string
+	}{
+		{
+			name: "no domainname",
+			svc:  compose.ServiceConfig{Ports: ingressPorts()},
+			want: nil,
+		},
+		{
+			name: "plain domainname only",
+			svc:  compose.ServiceConfig{Ports: ingressPorts(), DomainName: testHost},
+			want: nil,
+		},
+		{
+			name: "wildcard domainname",
+			svc:  compose.ServiceConfig{Ports: ingressPorts(), DomainName: testWildcard},
+			want: []string{testWildcard},
+		},
+		{
+			name: "wildcard alias alongside plain domainname",
+			svc: compose.ServiceConfig{
+				Ports:      ingressPorts(),
+				DomainName: testHost,
+				Networks:   aliasNetwork(testWildcard),
+			},
+			want: []string{testWildcard},
+		},
+		{
+			name: "several wildcards keep compose order",
+			svc: compose.ServiceConfig{
+				Ports:      ingressPorts(),
+				DomainName: "*.a.example.com",
+				Networks:   aliasNetwork("plain.example.com", "*.b.example.com"),
+			},
+			want: []string{"*.a.example.com", "*.b.example.com"},
+		},
+		{
+			name: "hostnames are normalized",
+			svc:  compose.ServiceConfig{Ports: ingressPorts(), DomainName: "*.Auth.Example.COM."},
+			want: []string{testWildcard},
+		},
+		{
+			// Front Door needs a public origin to forward to; an internal-only
+			// service has no reachable hostname to offer it.
+			name: "no ingress ports",
+			svc:  compose.ServiceConfig{DomainName: testWildcard},
+			want: nil,
+		},
+		{
+			// An alias without a domainname isn't a BYOD request at all, matching
+			// the AWS path.
+			name: "wildcard alias without domainname",
+			svc:  compose.ServiceConfig{Ports: ingressPorts(), Networks: aliasNetwork(testWildcard)},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := wildcardHostnames(tt.svc); !slices.Equal(got, tt.want) {
+				t.Errorf("wildcardHostnames() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHasWildcardHostname covers the project-level gate. Getting a false
+// positive here means provisioning a Front Door profile — a real monthly bill —
+// for a project that has no use for one.
+func TestHasWildcardHostname(t *testing.T) {
+	tests := []struct {
+		name     string
+		services compose.Services
+		want     bool
+	}{
+		{name: "no services", services: compose.Services{}, want: false},
+		{
+			name: "plain domains only",
+			services: compose.Services{
+				testService: {Ports: ingressPorts(), DomainName: testHost},
+				"web":       {Ports: ingressPorts(), DomainName: testZone},
+			},
+			want: false,
+		},
+		{
+			name: "one service out of several wants a wildcard",
+			services: compose.Services{
+				testService: {Ports: ingressPorts(), DomainName: testHost, Networks: aliasNetwork(testWildcard)},
+				"web":       {Ports: ingressPorts(), DomainName: testZone},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HasWildcardHostname(tt.services); got != tt.want {
+				t.Errorf("HasWildcardHostname() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRelativeRecordName covers the decision of whether the provider can write a
+// wildcard's DNS records itself. A false "in zone" would make Pulumi write into
+// a zone that doesn't hold the name; a false "not in zone" only downgrades to
+// printing the records, so the two failures are not symmetric.
+func TestRelativeRecordName(t *testing.T) {
+	tests := []struct {
+		name, fqdn, zone string
+		wantName         string
+		wantIn           bool
+	}{
+		{name: "subdomain", fqdn: testHost, zone: testZone, wantName: testService, wantIn: true},
+		{name: "deep subdomain", fqdn: "a.b.example.com", zone: testZone, wantName: "a.b", wantIn: true},
+		{name: "apex", fqdn: testZone, zone: testZone, wantName: "@", wantIn: true},
+		{name: "case and trailing dot", fqdn: "Auth.Example.com.", zone: testZone, wantName: testService, wantIn: true},
+		{name: "different zone", fqdn: "auth.other.com", zone: testZone, wantIn: false},
+		{name: "empty zone", fqdn: testHost, zone: "", wantIn: false},
+		{name: "fqdn is a parent of the zone", fqdn: testZone, zone: testHost, wantIn: false},
+		{
+			// "notexample.com" ends with the zone as a string but is a
+			// different domain — matching on the label boundary is the point.
+			name: "suffix match that isn't a label boundary",
+			fqdn: "auth.notexample.com", zone: testZone, wantIn: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, gotIn := relativeRecordName(tt.fqdn, tt.zone)
+			if gotIn != tt.wantIn {
+				t.Fatalf("relativeRecordName(%q, %q) in-zone = %v, want %v", tt.fqdn, tt.zone, gotIn, tt.wantIn)
+			}
+			if gotIn && gotName != tt.wantName {
+				t.Errorf("relativeRecordName(%q, %q) = %q, want %q", tt.fqdn, tt.zone, gotName, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestJoinLabels(t *testing.T) {
+	tests := []struct{ prefix, relative, want string }{
+		{dnsAuthPrefix, testService, dnsAuthPrefix + "." + testService},
+		{dnsAuthPrefix, "@", dnsAuthPrefix},
+		{"*", testService, "*." + testService},
+		{"*", "@", "*"},
+	}
+	for _, tt := range tests {
+		if got := joinLabels(tt.prefix, tt.relative); got != tt.want {
+			t.Errorf("joinLabels(%q, %q) = %q, want %q", tt.prefix, tt.relative, got, tt.want)
+		}
+	}
+}
+
+// TestFrontDoorShortCircuits checks the branches that must create nothing, so
+// EnsureFrontDoor and CreateWildcardDomain stay callable unconditionally from
+// the project dispatcher and from CreateContainerApp.
+func TestFrontDoorShortCircuits(t *testing.T) {
+	wildcardSvc := compose.ServiceConfig{Ports: ingressPorts(), DomainName: testWildcard}
+	plainSvc := compose.ServiceConfig{Ports: ingressPorts(), DomainName: testHost}
+
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		fd, err := EnsureFrontDoor(ctx, compose.Services{testService: plainSvc}, &SharedInfra{}, nil)
+		if err != nil {
+			t.Errorf("EnsureFrontDoor(no wildcards) err: %v", err)
+		}
+		if fd != nil {
+			t.Errorf("EnsureFrontDoor(no wildcards) = %+v, want nil", fd)
+		}
+
+		if fd, err := EnsureFrontDoor(ctx, compose.Services{testService: wildcardSvc}, nil, nil); err != nil || fd != nil {
+			t.Errorf("EnsureFrontDoor(nil infra) = %+v, %v; want nil, nil", fd, err)
+		}
+
+		// A service with a wildcard but no Front Door (the standalone Service
+		// path) warns and moves on rather than failing the deploy.
+		got, err := CreateWildcardDomain(ctx, testService, wildcardSvc, nil, &SharedInfra{})
+		if err != nil {
+			t.Errorf("CreateWildcardDomain(no front door) err: %v", err)
+		}
+		if got != nil {
+			t.Errorf("CreateWildcardDomain(no front door) = %+v, want nil", got)
+		}
+
+		// No wildcard hostname: nothing to do even with a Front Door present.
+		got, err = CreateWildcardDomain(ctx, testService, plainSvc, nil, &SharedInfra{FrontDoor: &FrontDoorInfra{}})
+		if err != nil {
+			t.Errorf("CreateWildcardDomain(no wildcard) err: %v", err)
+		}
+		if got != nil {
+			t.Errorf("CreateWildcardDomain(no wildcard) = %+v, want nil", got)
+		}
+		return nil
+	}, pulumi.WithMocks("project", "stack", &azureNoopMocks{}))
+	if err != nil {
+		t.Fatalf("pulumi.RunErr: %v", err)
+	}
+}

--- a/provider/defangazure/azure/frontdoor_test.go
+++ b/provider/defangazure/azure/frontdoor_test.go
@@ -1,6 +1,7 @@
 package azure
 
 import (
+	"errors"
 	"slices"
 	"testing"
 
@@ -208,18 +209,16 @@ func TestFrontDoorShortCircuits(t *testing.T) {
 			t.Errorf("EnsureFrontDoor(nil infra) = %+v, %v; want nil, nil", fd, err)
 		}
 
-		// A service with a wildcard but no Front Door (the standalone Service
-		// path) warns and moves on rather than failing the deploy.
-		got, err := CreateWildcardDomain(ctx, testService, wildcardSvc, nil, &SharedInfra{})
-		if err != nil {
-			t.Errorf("CreateWildcardDomain(no front door) err: %v", err)
-		}
-		if got != nil {
-			t.Errorf("CreateWildcardDomain(no front door) = %+v, want nil", got)
+		// A wildcard with no Front Door to serve it is the standalone Service
+		// path. Failing beats deploying a service configured for a hostname that
+		// nothing will answer on.
+		_, err = CreateWildcardDomain(ctx, testService, wildcardSvc, nil, &SharedInfra{})
+		if !errors.Is(err, errWildcardNeedsProject) {
+			t.Errorf("CreateWildcardDomain(no front door) err = %v, want %v", err, errWildcardNeedsProject)
 		}
 
 		// No wildcard hostname: nothing to do even with a Front Door present.
-		got, err = CreateWildcardDomain(ctx, testService, plainSvc, nil, &SharedInfra{FrontDoor: &FrontDoorInfra{}})
+		got, err := CreateWildcardDomain(ctx, testService, plainSvc, nil, &SharedInfra{FrontDoor: &FrontDoorInfra{}})
 		if err != nil {
 			t.Errorf("CreateWildcardDomain(no wildcard) err: %v", err)
 		}

--- a/provider/defangazure/project.go
+++ b/provider/defangazure/project.go
@@ -444,6 +444,15 @@ func setupSharedInfra(
 	}
 	infra.Environment = env
 
+	// Wildcard hostnames can't be bound on a Container App, so they get an Azure
+	// Front Door profile in front of it. Nothing is created — and nothing is
+	// billed — unless a service actually asks for one.
+	frontDoor, err := providerazure.EnsureFrontDoor(ctx, inputs.Services, infra, parentOpt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating Front Door: %w", err)
+	}
+	infra.FrontDoor = frontDoor
+
 	if types.hasLLM {
 		llmInfra, err := providerazure.CreateLLMInfra(ctx, projectName, infra, parentOpt)
 		if err != nil {


### PR DESCRIPTION
Closes #393. Needed for DefangLabs/portal#1012.

## What

A wildcard hostname works on AWS and GCP but was silently dropped on Azure:

```yaml
services:
  auth:
    domainname: auth.defang.io
    networks:
      default:
        aliases:
          - "*.auth.defang.io"
```

Container Apps binds custom domains one hostname at a time — each with its own `asuid` TXT record and its own certificate binding — and its ingress routes strictly on the Host header. Measured against the live production app:

```
GET / Host: auth.defang.io                                -> 302   (bound)
GET / Host: x.auth.defang.io  (SNI = app default FQDN)    -> 404   (not bound)
```

So per-tenant subdomains would need one ARM call and one certificate each at signup, against the environment's certificate limits.

Azure Front Door Standard accepts a wildcard custom domain and issues an **Azure-managed certificate** for it, validated by a DNS TXT record — one profile and one certificate for every subdomain, nothing to provision when a new one starts being used.

## How

`provider/defangazure/azure/frontdoor.go`. When — and only when — some service declares a wildcard hostname:

| Resource | Scope |
| --- | --- |
| `cdn.Profile` (`Standard_AzureFrontDoor`) + `cdn.AFDEndpoint` | project (`EnsureFrontDoor`) |
| `cdn.AFDOriginGroup` + `cdn.AFDOrigin` | per service |
| `cdn.AFDCustomDomain` | per wildcard hostname |
| `cdn.Route` | per service |

A project with no wildcard hostname creates nothing and is billed nothing. Non-wildcard hostnames are untouched — ACA binds those itself with a managed certificate, and sending them through Front Door would add a second TLS hop and a second bill for no gain.

Both resource names come from Pulumi auto-naming: an endpoint name is capped at 46 characters and a profile name is unique only within its resource group, and auto-naming satisfies both without a truncation scheme. The endpoint hostname — the CNAME target — stays stable across updates because Pulumi persists the generated name.

## Two consequences worth reviewing

**Host header.** The origin is sent `OriginHostHeader = <app>.<env.DefaultDomain>`, because ACA 404s anything else. Front Door puts the hostname the client asked for in `X-Forwarded-Host`, so an app serving per-subdomain content must read that header rather than `Host`. This differs from the AWS path, where the ALB forwards the original `Host` untouched — it is a behavior difference between clouds for the same compose file, called out in the file header.

**Certificate rotation.** Front Door auto-rotates a managed certificate for subdomains and apex domains but [not for wildcards](https://learn.microsoft.com/en-us/azure/frontdoor/domain#domain-types). 45 days before expiry the domain enters *Pending revalidation* and the TXT record has to be replaced with a fresh token. A redeploy re-reads the token and rewrites the record wherever the provider owns the zone; elsewhere it's manual, and the log says so.

## DNS

Each wildcard needs a TXT at `_dnsauth.<label>` carrying the validation token and a wildcard CNAME at `*.<label>` pointing at the endpoint. The provider writes both when the hostname sits inside the project delegate zone it owns. A BYOD hostname usually doesn't — `defang.io` is on Route 53, so the portal case certainly doesn't — so there the two records are logged for the operator and the deploy carries on. Same warn-and-degrade rule as the AWS BYOD path.

No CAA record is written. Front Door only needs `0 issue digicert.com` where a zone already restricts issuance, and adding a CAA where none exists would restrict every other certificate in the zone.

## Other decisions

- **No health probe** on the origin group. It holds a single origin, so a probe can only take the one backend out of rotation with nothing to fail over to — and the default probe of `/` would call an app unhealthy for answering anything but 200, which a redirect to a login page (the case this path exists for) does.
- **No `MinimumTlsVersion`** on the domain: from API version 2025-06-01 it only applies alongside a `Customized` cipherSuiteSetType, and Front Door's own default minimum is already TLS 1.2.
- **`LinkToDefaultDomain: Disabled`** — the endpoint's own `*.azurefd.net` hostname would be a second, unauthenticated way into the app.
- **No caching** on the route. These are application origins, not static assets.
- A **standalone `Service`** has no project to hang a profile off, so it warns rather than dropping the hostname silently.

## Shared code

`common.ByodHostnames` replaces the open-coded domainname-plus-aliases append in `aws/cert.go`, so the two clouds agree on what a BYOD hostname is. Behavior is unchanged: it returns nil when `domainname` is empty, which is exactly the early return it replaced.

## Testing

- `go build ./...` (provider, `cd/`, `tests/`), `go vet` clean, `gofmt` clean on every touched file.
- `go test ./provider/...` and `cd tests && go test -short ./...` pass. New unit tests cover which compose shapes count as a wildcard request, the project-level gate that decides whether a profile gets created at all, zone-membership matching (including the `notexample.com` suffix trap), and the short-circuit branches.
- `cd cd && go test ./...` passes except `TestStackConfigJsonAutonaming` and `TestPulumiConfig`, which need the `pulumi` binary on PATH and fail the same way on `main` in this sandbox.
- `golangci-lint run ./provider/...`: 51 issues, identical to the `main` baseline (50 goconst + 1 govet, all pre-existing). `CreateContainerApp` was one line from tripping `funlen`, so the domain wiring moved into `createAppDomains` rather than picking up a suppression.
- **No schema change**: `pulumi package get-schema` for both the azure and aws providers is byte-identical to the committed `schema.json`, so no SDK regeneration is needed. Verified, not assumed.

## Not done here

Provisioning is in place, but nothing has been deployed — the `*.auth.defang.io` records still have to be added to the Route 53 zone for `defang.io`, which this repo can't reach. That's the portal#1012 checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3WmpdY3zc555sNdkY9dzQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Azure Front Door support for wildcard custom domains on Container Apps.
  * Automatically provisions wildcard domains, HTTPS routing, origins, and validation records when configured.
  * Added support for deriving BYOD hostnames from service domains and default network aliases.
  * Added wildcard hostname detection and improved DNS record handling.

* **Bug Fixes**
  * Certificate and DNS setup now safely skips services without configured hostnames.
  * Added clearer handling and guidance for DNS zones not managed by the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->