### PR TITLE
cd: self-destruct stacks after a TTL (AWS)

### DIFF
--- a/cd/go.mod
+++ b/cd/go.mod
@@ -72,6 +72,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.36 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.36 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.37 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ecs v1.90.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.16 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.29 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.36 // indirect
@@ -163,6 +164,7 @@ require (
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 // indirect
+	github.com/pulumi/pulumi-awsx/sdk/v3 v3.1.0 // indirect
 	github.com/pulumi/pulumi-azure-native-sdk/cdn/v3 v3.17.0 // indirect
 	github.com/pulumi/pulumi-azure-native-sdk/cognitiveservices/v3 v3.17.0 // indirect
 	github.com/pulumi/pulumi-azure-native-sdk/containerregistry/v3 v3.17.0 // indirect
@@ -174,6 +176,8 @@ require (
 	github.com/pulumi/pulumi-azure-native-sdk/privatedns/v3 v3.17.0 // indirect
 	github.com/pulumi/pulumi-azure-native-sdk/redisenterprise/v3 v3.17.0 // indirect
 	github.com/pulumi/pulumi-azure-native-sdk/resources/v3 v3.17.0 // indirect
+	github.com/pulumi/pulumi-docker-build/sdk/go/dockerbuild v0.0.3 // indirect
+	github.com/pulumi/pulumi-docker/sdk/v4 v4.5.8 // indirect
 	github.com/pulumi/pulumi-random/sdk/v4 v4.19.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect

--- a/cd/go.sum
+++ b/cd/go.sum
@@ -106,6 +106,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.36 h1:A4N2f4YPcST0v+dWtX
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.36/go.mod h1:B/Qr859uxWUEfZeGotK5KAEoof4Q9YWgNtPSwV6jcyk=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.37 h1:oyd3ke4V9AhKcRR7rRgxk1VyI+DjK2CBQtbxh3OkdaA=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.37/go.mod h1:aA9D7SqfG9IC1b7FLD7Iyc8Q4JN0a8gHhNjN4zPlIaI=
+github.com/aws/aws-sdk-go-v2/service/ecs v1.90.1 h1:X6uVy3H1Xg7GK1SGrhwadV0IBIagB5WD/uO7iKr0ZE8=
+github.com/aws/aws-sdk-go-v2/service/ecs v1.90.1/go.mod h1:sLTx85N+itmZPBvAufetc8CFCBE5RQSEuiaelJuPyVs=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.16 h1:iE4NGbvqUZnHDqddQAauZzCILYtFjOHwRM5MOOKLB5A=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.16/go.mod h1:VsjEgrP+ibcou8TlWA4tYaB+0OojuhirsmCe+U60hTA=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.29 h1:E65Hj648dOV6FuUfI0mYXXhQRHbsi7n+B9h6fZPJO/E=
@@ -354,6 +356,8 @@ github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 h1:vkHw5I/plNdTr435
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231/go.mod h1:murToZ2N9hNJzewjHBgfFdXhZKjY3z5cYC1VXk+lbFE=
 github.com/pulumi/pulumi-aws/sdk/v7 v7.41.0 h1:tT6MC4ZUbh+oyPSN1aCFO7YgJac0hDld+Rg9UUJKMZo=
 github.com/pulumi/pulumi-aws/sdk/v7 v7.41.0/go.mod h1:wImO2X5EeAVjuNtyJF/W/N96Q73tEO9t1Ne9Uqa50Ps=
+github.com/pulumi/pulumi-awsx/sdk/v3 v3.1.0 h1:jphjwZoSnNyW4d3dpS++T+TlZFTy6vb9gJt33u6xf14=
+github.com/pulumi/pulumi-awsx/sdk/v3 v3.1.0/go.mod h1:ALZ8aBuwNtHkhFCY019gJOfgo7q2WYlsL1kM+0apbEA=
 github.com/pulumi/pulumi-azure-native-sdk/app/v3 v3.17.0 h1:QZksspyGhUliOncXYSunj50Rl1OCBp4Z4vDltCtfLyg=
 github.com/pulumi/pulumi-azure-native-sdk/app/v3 v3.17.0/go.mod h1:A4c9UObJvoBe0GZLalGGCf3x4WJsutLuZTgHGB9Du1A=
 github.com/pulumi/pulumi-azure-native-sdk/authorization/v3 v3.17.0 h1:XQ4akM+v4jT6bUDrbzqty0YpwPJAbS/47QzfuAt6+MM=
@@ -384,6 +388,10 @@ github.com/pulumi/pulumi-azure-native-sdk/storage/v3 v3.17.0 h1:P+CuRRxe13YBgiB3
 github.com/pulumi/pulumi-azure-native-sdk/storage/v3 v3.17.0/go.mod h1:G0SZoFekP5XgQxQ0Kd/B7vDPMtMasKMz+ZQPbPvsdvs=
 github.com/pulumi/pulumi-azure-native-sdk/v3 v3.17.0 h1:CFtP/hsyGR2jSAm/Fz+4QW8d/Slw619gUoLuobnCCX8=
 github.com/pulumi/pulumi-azure-native-sdk/v3 v3.17.0/go.mod h1:ELaNq3/fmYWdM6Y4vTQmheO9gGkeCrAMeiOD1XReDwA=
+github.com/pulumi/pulumi-docker-build/sdk/go/dockerbuild v0.0.3 h1:NxCXxRvzhUJP9dIvlpNlZKt/A3NHu3i9pC5XO+i8bR0=
+github.com/pulumi/pulumi-docker-build/sdk/go/dockerbuild v0.0.3/go.mod h1:jw9NcyRXjv5V2HHHJlqUBdXFCFiLfZoCChWEn38LR2A=
+github.com/pulumi/pulumi-docker/sdk/v4 v4.5.8 h1:rik9L2SIpsoDenY51MkogR6GWgu/0Sy/XmyQmKWNUqU=
+github.com/pulumi/pulumi-docker/sdk/v4 v4.5.8/go.mod h1:eph7BPNPkEIIK882/Ll4dbeHl5wZEc/UvTcUW0CK1UY=
 github.com/pulumi/pulumi-gcp/sdk/v9 v9.34.0 h1:geDS7s8LYCbpLFfx8EYiUx9iOzarp0cSP9oofDbSJq4=
 github.com/pulumi/pulumi-gcp/sdk/v9 v9.34.0/go.mod h1:YMIpKrD4W1lhzfiHGCDklsl8qh0jl3dwbc8CRifBzUQ=
 github.com/pulumi/pulumi-random/sdk/v4 v4.19.2 h1:YDGarxRPtAgpnUg7nXVe+gVfVABBjo88UC6EMAmmvhM=

--- a/cd/program/aws.go
+++ b/cd/program/aws.go
@@ -3,6 +3,7 @@ package program
 import (
 	"encoding/base64"
 	"fmt"
+	"time"
 
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 	"github.com/DefangLabs/pulumi-defang/provider/common"
@@ -17,7 +18,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func deployAWS(ctx *pulumi.Context, cf *compose.Project, domain, etag string, projectUpdate *defangv1.ProjectUpdate) (pulumi.StringMapOutput, pulumi.StringPtrOutput, error) {
+func deployAWS(ctx *pulumi.Context, cf *compose.Project, domain, etag string, ttl time.Duration, projectUpdate *defangv1.ProjectUpdate) (pulumi.StringMapOutput, pulumi.StringPtrOutput, error) {
 	providerArgs := &aws.ProviderArgs{
 		Region: pulumi.String(config.GetRegion(ctx)),
 		DefaultTags: &aws.ProviderDefaultTagsArgs{
@@ -54,6 +55,15 @@ func deployAWS(ctx *pulumi.Context, cf *compose.Project, domain, etag string, pr
 	project, err := defangaws.NewProject(ctx, cf.Name, args, pulumi.Provider(awsProvider))
 	if err != nil {
 		return pulumi.StringMapOutput{}, pulumi.StringPtrOutput{}, err
+	}
+
+	// Self-destruct: schedule this stack's own `defang cd down` at now + TTL.
+	// Registered independently of the project component (see
+	// createAWSSelfDestruct for why); every redeploy rewrites the schedule.
+	if ttl > 0 {
+		if err := createAWSSelfDestruct(ctx, cf, ttl, pulumi.Provider(awsProvider)); err != nil {
+			return pulumi.StringMapOutput{}, pulumi.StringPtrOutput{}, err
+		}
 	}
 
 	// Upload ProjectUpdate protobuf as a Pulumi-managed S3 object, gated on

--- a/cd/program/program.go
+++ b/cd/program/program.go
@@ -47,10 +47,10 @@ func NewRun(projectUpdate *defangv1.ProjectUpdate) pulumi.RunFunc {
 			return err
 		}
 
-		if ttl > 0 && provider != "azure" {
+		if ttl > 0 && provider == "gcp" {
 			// Erroring (not warning) is deliberate: a stack that silently
 			// outlives its requested TTL is the failure mode this feature
-			// exists to prevent. Remove per cloud as support lands.
+			// exists to prevent. Remove once GCP support lands.
 			return fmt.Errorf("defang:ttl is not supported on %s yet", provider)
 		}
 
@@ -59,7 +59,7 @@ func NewRun(projectUpdate *defangv1.ProjectUpdate) pulumi.RunFunc {
 
 		switch provider {
 		case "aws":
-			endpoints, loadBalancerDns, err = deployAWS(ctx, project, domain, etag, projectUpdate)
+			endpoints, loadBalancerDns, err = deployAWS(ctx, project, domain, etag, ttl, projectUpdate)
 		case "gcp":
 			endpoints, loadBalancerDns, err = deployGCP(ctx, project, etag, projectUpdate)
 		case "azure":

--- a/cd/program/selfdestruct_aws.go
+++ b/cd/program/selfdestruct_aws.go
@@ -1,0 +1,167 @@
+package program
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"os"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/DefangLabs/pulumi-defang/provider/compose"
+	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/iam"
+	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/scheduler"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// On AWS the CD runs as a CodeBuild build (see AwsCodeBuild.Run in the CLI),
+// so the self-destruct trigger is an EventBridge Scheduler one-time schedule
+// (`at(...)`) whose universal target calls codebuild:StartBuild with the same
+// overrides the CLI passes: this image, a buildspec running `/app/cd down`,
+// and (a filtered copy of) this run's environment.
+const (
+	// codebuildStartBuildTargetArn is the EventBridge Scheduler universal
+	// target for the CodeBuild StartBuild API.
+	codebuildStartBuildTargetArn = "arn:aws:scheduler:::aws-sdk:codebuild:startBuild"
+
+	// selfDestructBuildspec mirrors buildspec() in the CLI's codebuild
+	// package: CodeBuild ignores the image's ENTRYPOINT/WORKDIR, so the spec
+	// recreates them. The paths match this repo's Dockerfile (WORKDIR /app,
+	// ENTRYPOINT /app/cd) — necessarily the layout of the very image this
+	// code runs in, which is also the image the trigger re-runs.
+	selfDestructBuildspec = `version: "0.2"
+phases:
+  build:
+    commands:
+      - mkdir -p /app && cd /app && /app/cd down
+`
+)
+
+// createAWSSelfDestruct schedules this stack's own `defang cd down`. Unlike
+// the Azure variant it deliberately does NOT depend on the project component:
+// the schedule has no resource-level dependency on it, and arming the trigger
+// before the services finish deploying means even a deploy that fails halfway
+// still cleans itself up at the TTL.
+func createAWSSelfDestruct(pctx *pulumi.Context, cf *compose.Project, ttl time.Duration, opts ...pulumi.ResourceOption) error {
+	buildArn := os.Getenv("CODEBUILD_BUILD_ARN")
+	image := os.Getenv("CODEBUILD_BUILD_IMAGE")
+	if buildArn == "" || image == "" {
+		// Local debug runs (DEFANG_PULUMI_DIR) have no CodeBuild identity to
+		// clone; there is nothing to schedule a down against.
+		return fmt.Errorf("defang:ttl requires the CD to run in CodeBuild (CODEBUILD_BUILD_ARN/CODEBUILD_BUILD_IMAGE not set)")
+	}
+	projectName, projectArn, err := codebuildProjectFromBuildArn(buildArn)
+	if err != nil {
+		return err
+	}
+
+	fireAt := time.Now().Add(ttl)
+	input, err := awsSelfDestructInput(projectName, image, os.Environ())
+	if err != nil {
+		return err
+	}
+
+	assumeRole, err := json.Marshal(map[string]any{
+		"Version": "2012-10-17",
+		"Statement": []map[string]any{{
+			"Effect":    "Allow",
+			"Principal": map[string]any{"Service": "scheduler.amazonaws.com"},
+			"Action":    "sts:AssumeRole",
+		}},
+	})
+	if err != nil {
+		return err
+	}
+	policy, err := json.Marshal(map[string]any{
+		"Version": "2012-10-17",
+		"Statement": []map[string]any{{
+			"Effect":   "Allow",
+			"Action":   "codebuild:StartBuild",
+			"Resource": projectArn,
+		}},
+	})
+	if err != nil {
+		return err
+	}
+
+	role, err := iam.NewRole(pctx, "self-destruct", &iam.RoleArgs{
+		AssumeRolePolicy: pulumi.String(assumeRole),
+		InlinePolicies: iam.RoleInlinePolicyArray{
+			iam.RoleInlinePolicyArgs{
+				Name:   pulumi.String("start-cd-down"),
+				Policy: pulumi.String(policy),
+			},
+		},
+	}, opts...)
+	if err != nil {
+		return err
+	}
+
+	_ = pctx.Log.Info(fmt.Sprintf("self-destruct: this stack will run `defang cd down` on itself at %s (ttl %s); redeploying extends it",
+		fireAt.UTC().Format(time.RFC3339), ttl), nil)
+
+	_, err = scheduler.NewSchedule(pctx, "self-destruct", &scheduler.ScheduleArgs{
+		Description: pulumi.Sprintf("defang self-destruct for %s/%s", cf.Name, pctx.Stack()),
+		// One-time schedule, evaluated in UTC (the provider default); a fire
+		// time in the past is rejected at create, which minTTL prevents.
+		ScheduleExpression: pulumi.String(fmt.Sprintf("at(%s)", fireAt.UTC().Format("2006-01-02T15:04:05"))),
+		FlexibleTimeWindow: scheduler.ScheduleFlexibleTimeWindowArgs{
+			Mode: pulumi.String("OFF"),
+		},
+		Target: scheduler.ScheduleTargetArgs{
+			Arn:     pulumi.String(codebuildStartBuildTargetArn),
+			RoleArn: role.Arn,
+			Input:   pulumi.String(input),
+		},
+	}, opts...)
+	return err
+}
+
+// codebuildProjectFromBuildArn derives the CodeBuild project name and project
+// ARN from a build ARN like
+// arn:aws:codebuild:us-west-2:123456789012:build/defang-cd-abc:uuid.
+func codebuildProjectFromBuildArn(buildArn string) (name, arn string, _ error) {
+	prefix, resource, ok := strings.Cut(buildArn, ":build/")
+	if !ok {
+		return "", "", fmt.Errorf("unexpected CODEBUILD_BUILD_ARN %q", buildArn)
+	}
+	name, _, ok = strings.Cut(resource, ":")
+	if !ok || name == "" {
+		return "", "", fmt.Errorf("unexpected CODEBUILD_BUILD_ARN %q", buildArn)
+	}
+	return name, prefix + ":project/" + name, nil
+}
+
+// awsSelfDestructInput renders the codebuild:StartBuild request the schedule
+// fires — the same overrides AwsCodeBuild.Run passes, with args ["down"].
+// Universal-target inputs use the target API's own wire shape, which for
+// CodeBuild is camelCase JSON.
+func awsSelfDestructInput(projectName, image string, environ []string) (string, error) {
+	env := SelfDestructEnv(environ)
+	type envVar struct {
+		Name  string `json:"name"`
+		Value string `json:"value"`
+		Type  string `json:"type"`
+	}
+	envOverrides := make([]envVar, 0, len(env))
+	for _, k := range slices.Sorted(maps.Keys(env)) {
+		envOverrides = append(envOverrides, envVar{Name: k, Value: env[k], Type: "PLAINTEXT"})
+	}
+	input := map[string]any{
+		"projectName":                  projectName,
+		"imageOverride":                image,
+		"buildspecOverride":            selfDestructBuildspec,
+		"environmentVariablesOverride": envOverrides,
+	}
+	// Mirrors AwsCodeBuild.Run: non-"aws/" images pull with the service role
+	// (e.g. via an ECR pull-through cache).
+	if !strings.HasPrefix(image, "aws/") {
+		input["imagePullCredentialsTypeOverride"] = "SERVICE_ROLE"
+	}
+	b, err := json.Marshal(input)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}

--- a/cd/program/selfdestruct_aws.go
+++ b/cd/program/selfdestruct_aws.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
+	defangaws "github.com/DefangLabs/pulumi-defang/provider/defangaws/aws"
 	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/iam"
 	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/scheduler"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -62,23 +63,23 @@ func createAWSSelfDestruct(pctx *pulumi.Context, cf *compose.Project, ttl time.D
 		return err
 	}
 
-	assumeRole, err := json.Marshal(map[string]any{
-		"Version": "2012-10-17",
-		"Statement": []map[string]any{{
-			"Effect":    "Allow",
-			"Principal": map[string]any{"Service": "scheduler.amazonaws.com"},
-			"Action":    "sts:AssumeRole",
+	assumeRole, err := json.Marshal(defangaws.PolicyDocument{
+		Version: iam.PolicyDocumentVersion_2012_10_17,
+		Statement: []defangaws.PolicyStatement{{
+			Effect:    iam.PolicyStatementEffectALLOW,
+			Principal: map[string]any{"Service": "scheduler.amazonaws.com"},
+			Action:    "sts:AssumeRole",
 		}},
 	})
 	if err != nil {
 		return err
 	}
-	policy, err := json.Marshal(map[string]any{
-		"Version": "2012-10-17",
-		"Statement": []map[string]any{{
-			"Effect":   "Allow",
-			"Action":   "codebuild:StartBuild",
-			"Resource": projectArn,
+	policy, err := json.Marshal(defangaws.PolicyDocument{
+		Version: iam.PolicyDocumentVersion_2012_10_17,
+		Statement: []defangaws.PolicyStatement{{
+			Effect:   iam.PolicyStatementEffectALLOW,
+			Action:   "codebuild:StartBuild",
+			Resource: projectArn,
 		}},
 	})
 	if err != nil {
@@ -139,29 +140,41 @@ func codebuildProjectFromBuildArn(buildArn string) (name, arn string, _ error) {
 // CodeBuild is camelCase JSON.
 func awsSelfDestructInput(projectName, image string, environ []string) (string, error) {
 	env := SelfDestructEnv(environ)
-	type envVar struct {
-		Name  string `json:"name"`
-		Value string `json:"value"`
-		Type  string `json:"type"`
-	}
-	envOverrides := make([]envVar, 0, len(env))
+	envOverrides := make([]startBuildEnvVar, 0, len(env))
 	for _, k := range slices.Sorted(maps.Keys(env)) {
-		envOverrides = append(envOverrides, envVar{Name: k, Value: env[k], Type: "PLAINTEXT"})
+		envOverrides = append(envOverrides, startBuildEnvVar{Name: k, Value: env[k], Type: "PLAINTEXT"})
 	}
-	input := map[string]any{
-		"projectName":                  projectName,
-		"imageOverride":                image,
-		"buildspecOverride":            selfDestructBuildspec,
-		"environmentVariablesOverride": envOverrides,
+	input := startBuildInput{
+		ProjectName:                  projectName,
+		ImageOverride:                image,
+		BuildspecOverride:            selfDestructBuildspec,
+		EnvironmentVariablesOverride: envOverrides,
 	}
 	// Mirrors AwsCodeBuild.Run: non-"aws/" images pull with the service role
 	// (e.g. via an ECR pull-through cache).
 	if !strings.HasPrefix(image, "aws/") {
-		input["imagePullCredentialsTypeOverride"] = "SERVICE_ROLE"
+		input.ImagePullCredentialsTypeOverride = "SERVICE_ROLE"
 	}
 	b, err := json.Marshal(input)
 	if err != nil {
 		return "", err
 	}
 	return string(b), nil
+}
+
+// startBuildInput is the subset of the CodeBuild StartBuild request the
+// schedule sends (universal-target inputs use the target API's own camelCase
+// wire shape; see codebuild.StartBuildInput in the AWS SDK for the full set).
+type startBuildInput struct {
+	ProjectName                      string             `json:"projectName"`
+	ImageOverride                    string             `json:"imageOverride"`
+	BuildspecOverride                string             `json:"buildspecOverride"`
+	EnvironmentVariablesOverride     []startBuildEnvVar `json:"environmentVariablesOverride"`
+	ImagePullCredentialsTypeOverride string             `json:"imagePullCredentialsTypeOverride,omitempty"`
+}
+
+type startBuildEnvVar struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+	Type  string `json:"type"`
 }

--- a/cd/program/selfdestruct_aws_test.go
+++ b/cd/program/selfdestruct_aws_test.go
@@ -1,0 +1,83 @@
+package program
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestCodebuildProjectFromBuildArn(t *testing.T) {
+	name, arn, err := codebuildProjectFromBuildArn("arn:aws:codebuild:us-west-2:123456789012:build/defang-cd-abc:1a2b3c")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name != "defang-cd-abc" {
+		t.Errorf("name = %q", name)
+	}
+	if arn != "arn:aws:codebuild:us-west-2:123456789012:project/defang-cd-abc" {
+		t.Errorf("arn = %q", arn)
+	}
+
+	for _, bad := range []string{"", "arn:aws:codebuild:us-west-2:1:project/x", "arn:aws:codebuild:us-west-2:1:build/noid"} {
+		if _, _, err := codebuildProjectFromBuildArn(bad); err == nil {
+			t.Errorf("want error for %q", bad)
+		}
+	}
+}
+
+func TestAwsSelfDestructInput(t *testing.T) {
+	environ := []string{
+		"PROJECT=myproj",
+		"STACK=preview",
+		"DEFANG_STATE_URL=s3://bucket?region=us-west-2",
+		"AWS_SECRET_ACCESS_KEY=shh", // dropped
+		"PATH=/usr/bin",             // dropped
+	}
+	got, err := awsSelfDestructInput("defang-cd-abc", "defangio/cd:public-beta", environ)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var input struct {
+		ProjectName       string `json:"projectName"`
+		ImageOverride     string `json:"imageOverride"`
+		BuildspecOverride string `json:"buildspecOverride"`
+		PullCreds         string `json:"imagePullCredentialsTypeOverride"`
+		Env               []struct {
+			Name  string `json:"name"`
+			Value string `json:"value"`
+			Type  string `json:"type"`
+		} `json:"environmentVariablesOverride"`
+	}
+	if err := json.Unmarshal([]byte(got), &input); err != nil {
+		t.Fatal(err)
+	}
+	if input.ProjectName != "defang-cd-abc" || input.ImageOverride != "defangio/cd:public-beta" {
+		t.Errorf("project/image = %q/%q", input.ProjectName, input.ImageOverride)
+	}
+	if input.PullCreds != "SERVICE_ROLE" {
+		t.Errorf("imagePullCredentialsTypeOverride = %q", input.PullCreds)
+	}
+	if !strings.Contains(input.BuildspecOverride, "/app/cd down") {
+		t.Errorf("buildspec = %q", input.BuildspecOverride)
+	}
+	var names []string
+	for _, e := range input.Env {
+		names = append(names, e.Name)
+		if e.Type != "PLAINTEXT" {
+			t.Errorf("env %s type = %q", e.Name, e.Type)
+		}
+	}
+	if strings.Join(names, ",") != "DEFANG_STATE_URL,PROJECT,STACK" {
+		t.Errorf("env names = %v", names)
+	}
+
+	// "aws/"-prefixed curated images keep the default pull credentials.
+	got, err = awsSelfDestructInput("p", "aws/codebuild/standard:7.0", environ)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(got, "imagePullCredentialsTypeOverride") {
+		t.Errorf("curated image must not override pull credentials: %s", got)
+	}
+}


### PR DESCRIPTION
Stacked on the Azure PR (merge that first; this retargets to main automatically). AWS leg of DefangLabs/defang-mvp#3179.

## What

- On AWS the CD runs as a **CodeBuild build** (`AwsCodeBuild.Run` in the CLI), so the trigger is an EventBridge Scheduler **one-time schedule** — `at(deploy + TTL)`, UTC, no cron workaround needed — whose universal target calls `codebuild:StartBuild`.
- The StartBuild request mirrors the CLI's overrides: this run's own image (`CODEBUILD_BUILD_IMAGE`), a buildspec running `/app/cd down`, the filtered environment (same `selfDestructEnv` as Azure; session credentials dropped), and `SERVICE_ROLE` pull credentials for non-curated images.
- The schedule's IAM role trusts `scheduler.amazonaws.com` and is scoped to `StartBuild` on the CD project only, derived from `CODEBUILD_BUILD_ARN`. No new CLI-passed values, no API reads at deploy time — everything comes from CodeBuild's own environment.
- Deliberate asymmetry with Azure: the trigger does **not** depend on the project component. It has no resource-level dependency (Azure's job needs the project resource group), and arming it before services finish means a deploy that fails halfway still cleans itself up at the TTL.
- `defang:ttl` on a local debug run (`DEFANG_PULUMI_DIR`, no CodeBuild identity) fails with a clear error. GCP still rejects the TTL; that leg follows separately (Cloud Scheduler's OAuth target needs `actAs` on the build service account — permission wiring worth its own review).

## Testing

- `go test ./...` in `cd/` passes (new tests: build-ARN parsing, StartBuild input rendering incl. env filtering and curated-image pull credentials).
- Not yet exercised against a live account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDv8zTnPk7LLhS3hSW8NUA
