### PR TITLE
test: guard azure record-capture mocks against concurrent map writes

### DIFF
--- a/provider/defangazure/azure/byoddomain_test.go
+++ b/provider/defangazure/azure/byoddomain_test.go
@@ -2,6 +2,7 @@ package azure
 
 import (
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
@@ -168,13 +169,19 @@ func TestCreateByodDomainShortCircuits(t *testing.T) {
 
 // recordTypeMocks captures the recordType of each dns RecordSet by its relative
 // name, so CreateByodDomain tests can assert which records (A vs CNAME, asuid
-// TXT) were created.
-type recordTypeMocks struct{ byRelative map[string]string }
+// TXT) were created. Pulumi registers resources from concurrent goroutines, so
+// the map needs a lock.
+type recordTypeMocks struct {
+	mu         sync.Mutex
+	byRelative map[string]string
+}
 
 func (m *recordTypeMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
 	if strings.HasSuffix(args.TypeToken, ":RecordSet") {
 		rel := args.Inputs["relativeRecordSetName"].StringValue()
+		m.mu.Lock()
 		m.byRelative[rel] = args.Inputs["recordType"].StringValue()
+		m.mu.Unlock()
 	}
 	return args.Name + "_id", args.Inputs, nil
 }

--- a/provider/defangazure/azure/byoddomain_test.go
+++ b/provider/defangazure/azure/byoddomain_test.go
@@ -186,7 +186,7 @@ func (m *recordTypeMocks) NewResource(args pulumi.MockResourceArgs) (string, res
 	return args.Name + "_id", args.Inputs, nil
 }
 
-func (recordTypeMocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
+func (*recordTypeMocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
 	return args.Args, nil
 }
 

--- a/provider/defangazure/azure/frontdoor_test.go
+++ b/provider/defangazure/azure/frontdoor_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
@@ -408,15 +409,21 @@ type recordZone struct {
 }
 
 // recordZoneMocks captures every dns RecordSet by its relative name.
-type recordZoneMocks struct{ byRelative map[string]recordZone }
+// Pulumi registers resources from concurrent goroutines, so the map needs a lock.
+type recordZoneMocks struct {
+	mu         sync.Mutex
+	byRelative map[string]recordZone
+}
 
 func (m *recordZoneMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
 	if strings.HasSuffix(args.TypeToken, ":RecordSet") {
+		m.mu.Lock()
 		m.byRelative[args.Inputs["relativeRecordSetName"].StringValue()] = recordZone{
 			recordType:    args.Inputs["recordType"].StringValue(),
 			zone:          args.Inputs["zoneName"].StringValue(),
 			resourceGroup: args.Inputs["resourceGroupName"].StringValue(),
 		}
+		m.mu.Unlock()
 	}
 	return args.Name + "_id", args.Inputs, nil
 }

--- a/provider/defangazure/azure/frontdoor_test.go
+++ b/provider/defangazure/azure/frontdoor_test.go
@@ -428,6 +428,6 @@ func (m *recordZoneMocks) NewResource(args pulumi.MockResourceArgs) (string, res
 	return args.Name + "_id", args.Inputs, nil
 }
 
-func (recordZoneMocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
+func (*recordZoneMocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
 	return args.Args, nil
 }


### PR DESCRIPTION
The `test` job on PR 417 (run 31990118574) died with `fatal error: concurrent map writes` in `provider/defangazure/azure` — unrelated to that PR's cd/-only diff. Pulumi's mock monitor invokes `NewResource` from one goroutine per registered resource, and both record-capture mocks (`recordTypeMocks` in byoddomain_test.go, `recordZoneMocks` in frontdoor_test.go) wrote to a plain map from it.

Fix: a `sync.Mutex` around the map writes in both mocks. Reads stay unlocked — they run after `pulumi.RunErr` returns, which is a happens-after edge.

`go test -count=5 -parallel 8 ./provider/defangazure/azure/` passes locally (the box has no gcc, so `-race` can't run here; CI's `test_cd -race` doesn't cover this package anyway — the flake surfaced through the runtime's unsynchronized-write detector, which the mutex silences for good).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDv8zTnPk7LLhS3hSW8NUA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability when multiple resource registrations occur concurrently.
  * Added synchronization to prevent intermittent failures while recording DNS and routing zone data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->