### PR TITLE
fix(cd): stop generic REGION from falsely triggering AWS provider detection

### DIFF
--- a/cd/config.go
+++ b/cd/config.go
@@ -144,9 +144,14 @@ func setDefaultStackConfig(prefix string, config configMap) {
 // addStackConfigFromEnv adds any stack config from legacy environment variables.
 func addStackConfigFromEnv(config configMap) error {
 	region := os.Getenv("REGION")
-	awsProfile := os.Getenv("AWS_PROFILE")                    // AWS only
-	awsRegion := getenv("AWS_REGION", region)                 // AWS only
-	azureLocation := getenv("AZURE_LOCATION", region)         // Azure only
+	awsProfile := os.Getenv("AWS_PROFILE") // AWS only
+	// AWS only. No fallback to the generic `region`: real AWS builds always
+	// have AWS_REGION set (CodeBuild injects it automatically), so falling
+	// back here only causes false-positive AWS detection on GCP/Azure builds
+	// that pass the generic REGION var for their own region fallback below —
+	// this is exactly what "conflicting cloud providers configured" fired on.
+	awsRegion := os.Getenv("AWS_REGION")
+	azureLocation := getenv("AZURE_LOCATION", region) // Azure only
 	azureSubscriptionId := os.Getenv("AZURE_SUBSCRIPTION_ID") // Azure only; the project RG and Key Vault names are derived from (project, stack, location) and (subscription, RG) respectively — see provider/defangazure/azure/azure.go
 	cdImage := os.Getenv("DEFANG_CD_IMAGE")                   // GCP only; for cleanup
 	delegationSetId := os.Getenv("DELEGATION_SET_ID")         // AWS only

--- a/cd/config_test.go
+++ b/cd/config_test.go
@@ -145,6 +145,36 @@ func TestStackConfigFromEnvGCP(t *testing.T) {
 	}
 }
 
+// Regression test for a real BYOC failure: Fabric sets the generic REGION env
+// var (alongside GCLOUD_REGION) on every GCP build, intending it only as a
+// fallback for gcp:region. Before the fix, awsRegion also fell back to that
+// same generic `region`, so any GCP build with REGION set was wrongly
+// detected as having AWS configured too, and addStackConfigFromEnv failed
+// with "conflicting cloud providers configured: [aws gcp]" on every GCP
+// deploy.
+func TestStackConfigFromEnvGCPWithGenericRegion(t *testing.T) {
+	unsetenv(t, "AWS_REGION", "AZURE_SUBSCRIPTION_ID")
+
+	t.Setenv("REGION", "us-central1") // generic region var Fabric sets for GCP builds
+	t.Setenv("GCLOUD_PROJECT", "my-gcp-project")
+	t.Setenv("GCLOUD_REGION", "us-central1")
+	t.Setenv("DEFANG_ORG", "testorg")
+
+	config := configMap{}
+	setDefaultStackConfig("", config)
+	err := addStackConfigFromEnv(config)
+	if err != nil {
+		t.Fatalf("stackConfig() error: %v", err)
+	}
+
+	if config["defang:provider"].Value != "gcp" {
+		t.Errorf("expected provider gcp, got %q", config["defang:provider"].Value)
+	}
+	if _, ok := config["aws:region"]; ok {
+		t.Error("aws:region should not be set on a GCP-only build")
+	}
+}
+
 func TestStackConfigFromEnvAzure(t *testing.T) {
 	// Clear ambient env that could pick a second provider or override fallbacks.
 	unsetenv(t, "REGION", "AWS_REGION", "GCP_PROJECT", "GCLOUD_PROJECT")


### PR DESCRIPTION
## Summary
Every GCP BYOC deployment on `v2.6.0-gcp` currently fails immediately with:
```
conflicting cloud providers configured: [aws gcp]
```
Reproduced live via the actual Cloud Build failure log (project `defang-playground-dev`, build `adbbd7d1-cff2-4d6c-bf15-11d1d11e99b3`, part of an AWS/GCP provider migration sanity test): the CD's own env-based provider detection in `cd/config.go` wrongly decides both AWS and GCP are configured on a pure GCP deploy, and aborts in `addStackConfigFromEnv` before ever invoking Pulumi.

## Root cause
```go
region := os.Getenv("REGION")
awsRegion := getenv("AWS_REGION", region)   // fallback here is the bug
...
if awsRegion != "" { providers = append(providers, "aws") }
if gcpProject != "" { providers = append(providers, "gcp") }
...
if len(providers) > 1 { return usageError("conflicting cloud providers configured: %v", providers) }
```
Fabric sets a generic `REGION` env var on GCP builds, intended only as `gcpRegion`'s fallback (`gcpRegion := getenv("GCLOUD_REGION", region)`). But `awsRegion` used the *same* generic fallback, so any GCP build with `REGION` set gets misread as "AWS is also configured."

This was invisible on AWS because CodeBuild always injects `AWS_REGION` natively regardless of what Fabric passes — so the fallback was never actually exercised there. It only bites GCP (and structurally Azure, though Azure's provider signal is `AZURE_SUBSCRIPTION_ID`, a separate var, so it's unaffected in practice today).

The existing `TestStackConfigFromEnvGCP` test never caught this because it explicitly `unsetenv`s `REGION` — it doesn't reproduce what Fabric actually sends.

## Fix
Drop the `region` fallback for `awsRegion`; real AWS builds don't need it. Added `TestStackConfigFromEnvGCPWithGenericRegion`, which sets the exact env combination Fabric sends for GCP builds (`REGION` + `GCLOUD_PROJECT` + `GCLOUD_REGION`, no `AWS_REGION`) and asserts the provider resolves cleanly to `gcp`.

## Test plan
- [x] `CGO_ENABLED=0 go test ./...` in `cd/` — all pass, including the new regression test
- [x] `golangci-lint run ./...` in `cd/` — no new issues (pre-existing baseline noise only, per repo's local-lint-is-noisier-than-CI gotcha)
- [ ] Once released, re-run the AWS/GCP provider sanity test (`DefangLabs/defang-mvp` `new-provider-sanity.yml`) against the new tag to confirm the GCP leg gets past this and into an actual deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cloud provider selection so a generic regional setting no longer incorrectly enables AWS configuration.
  * AWS now uses its dedicated regional setting, while Azure continues to support the generic regional setting.
  * Improved handling of GCP configuration when a generic region is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->