### PR TITLE
feat(aws): route CodeBuild docker.io pulls through a public.ecr.aws mirror

### DIFF
--- a/provider/defangaws/aws/codebuild.go
+++ b/provider/defangaws/aws/codebuild.go
@@ -56,8 +56,117 @@ func platformToArch(platform string) ArchType {
 	return X86_64 // default to x86_64; TODO: revisit this default
 }
 
+// dockerhubMirrorContainerName is the name of the local pull-through mirror container.
+const dockerhubMirrorContainerName = "dockerhub-ecr-mirror"
+
+// publicEcrProxyURL is where the local pull-through mirror listens on the CodeBuild host.
+// Both the Docker daemon (registry-mirrors) and BuildKit (buildkitd.toml) point at it.
+const publicEcrProxyURL = "http://localhost:5000"
+
+// publicEcrProxyNginxConf is the nginx config for the Docker Hub -> public.ecr.aws pull-through
+// mirror. Docker Hub images are mirrored by AWS under public.ecr.aws/docker/<repo>, so /v2/<rest>
+// maps to /v2/docker/<rest>; anything the mirror does not have (404) falls back to Docker Hub
+// itself. The __TOKEN__ line is replaced at build time with the public-ECR bearer token.
+// Matches TS getPublicEcrProxySteps' nginxConf.
+//
+// The backslash-escaped $ are for the unquoted shell heredoc that writes this file: they must
+// reach nginx as literal nginx variables, not be expanded by the shell.
+const publicEcrProxyNginxConf = `events {}
+http {
+    server {
+
+        set \$token "";
+__TOKEN__
+
+        listen 80;
+        location = /v2/ {
+            proxy_pass https://public.ecr.aws/v2/;
+            proxy_intercept_errors on;
+            proxy_set_header Authorization "Bearer \$token";
+            proxy_ssl_server_name on;
+
+            error_page 404 = @fallback;
+        }
+
+        location ~ ^/v2/(.+) {
+            # Capture the rest of the path
+            set \$rest \$1;
+
+            # Build upstream path: /v2/docker/<rest>
+            proxy_pass https://public.ecr.aws/v2/docker/\$rest;
+            proxy_intercept_errors on;
+            proxy_set_header Authorization "Bearer \$token";
+            proxy_ssl_server_name on;
+
+            error_page 404 = @fallback;
+        }
+
+        location @fallback {
+            proxy_pass https://registry-1.docker.io;
+            proxy_ssl_server_name on;
+        }
+    }
+}
+`
+
+// getPublicEcrProxySteps returns the pre_build commands that start a local nginx container
+// proxying Docker Hub pulls to public.ecr.aws, so builds are not subject to Docker Hub's
+// anonymous pull rate limits. Matches TS getPublicEcrProxySteps.
+//
+// The bearer token is fetched with docker-credential-ecr-login (valid 12h, see
+// https://docs.aws.amazon.com/AmazonECRPublic/latest/APIReference/API_GetAuthorizationToken.html)
+// and split into 1024-char chunks, because nginx cannot hold a token that long in one directive.
+func getPublicEcrProxySteps() []string {
+	return []string{
+		"cat > /tmp/nginx.conf.tmpl << EOF\n" + publicEcrProxyNginxConf + "\nEOF",
+		`TOKEN_BLOCK=$(echo "https://public.ecr.aws" | docker-credential-ecr-login get | ` +
+			`jq -j '"\(.Username):\(.Secret)"' | base64 -w 1024 | ` +
+			`awk '{ print "set $token \"${token}" $0 "\";" }')`,
+		`awk -v token_block="$TOKEN_BLOCK" '{ if ($0 ~ /__TOKEN__/) { print token_block } else { print } }' ` +
+			`/tmp/nginx.conf.tmpl > /tmp/nginx.conf`,
+		// CodeBuild reuses warm hosts (we enable LOCAL_* caches), so a mirror container from an
+		// earlier build can still be around under this name; remove it before creating our own.
+		"docker rm -f " + dockerhubMirrorContainerName + " || true",
+		// NOTE: intentionally NO restart policy on this container -- do not add --restart=always.
+		// The container only has to live for one build. With a restart policy, the Docker daemon
+		// on a reused host resurrects the previous build's container from its stale
+		// /tmp/nginx.conf bind-mount spec, and Docker creates a missing bind-mount source as a
+		// *directory*, which then breaks this build's own `awk ... > /tmp/nginx.conf` redirect.
+		// See https://github.com/DefangLabs/defang-mvp/issues/2869
+		"docker run -d --rm -p 5000:80 --name " + dockerhubMirrorContainerName +
+			" -v /tmp/nginx.conf:/etc/nginx/nginx.conf:ro public.ecr.aws/nginx/nginx:stable-alpine",
+		"sleep 3", // give the mirror some time to start
+	}
+}
+
+// getSetupMirrorSteps returns the pre_build commands that point the Docker daemon and BuildKit at
+// the given docker.io mirrors. Matches TS getSetupMirrorSteps.
+func getSetupMirrorSteps(mirrors []string) ([]string, error) {
+	if len(mirrors) == 0 {
+		return nil, nil
+	}
+
+	daemonJSON, err := json.Marshal(map[string][]string{"registry-mirrors": mirrors})
+	if err != nil {
+		return nil, fmt.Errorf("marshaling docker daemon.json: %w", err)
+	}
+
+	quoted := make([]string, 0, len(mirrors))
+	for _, m := range mirrors {
+		quoted = append(quoted, `"`+m+`"`)
+	}
+	buildkitdToml := "\n[registry.\"docker.io\"]\n  mirrors = [\n    " + strings.Join(quoted, ", ") + "\n  ]\n"
+
+	return []string{
+		"mkdir -p /etc/docker/ && echo '" + string(daemonJSON) + "' > /etc/docker/daemon.json",
+		"echo '" + buildkitdToml + "' > /tmp/buildkitd.toml",
+		// dockerd only picks up a changed registry-mirrors list on SIGHUP.
+		"kill -HUP $(pidof dockerd)",
+	}, nil
+}
+
 // getBuildSpec generates the CodeBuild buildspec YAML for a Docker image build.
-// Matches TS getBuildSpec: pre_build sets up buildx, build runs docker buildx build --push.
+// Matches TS getBuildSpec: pre_build sets up mirrors and buildx, build runs docker buildx build --push.
 func getBuildSpec(build compose.BuildConfig, destination string) (string, error) {
 	dockerfile := build.GetDockerfile()
 
@@ -90,11 +199,34 @@ func getBuildSpec(build compose.BuildConfig, destination string) (string, error)
 		cacheArgs = append(cacheArgs, "--cache-to="+c)
 	}
 
-	preBuildCommands := []string{
+	preBuildCommands := make([]string, 0, 12)
+	preBuildCommands = append(preBuildCommands,
 		"aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $(aws sts get-caller-identity --query Account --output text).dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com", //nolint:lll
 		"aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws",
-		strings.TrimSpace("docker buildx create --use --driver=docker-container --use " + platformArg),
+	)
+
+	// Route docker.io through a local pull-through mirror backed by public.ecr.aws, so builds do
+	// not hit Docker Hub's anonymous pull rate limits. Matches TS prepareBuildSteps, minus the
+	// hasDockerhubAuth() opt-out: unlike TS, this provider has no way to configure explicit Docker
+	// Hub credentials, so there is never a reason to skip the mirror.
+	// TODO: also honor a user-supplied registry mirror here (TS BuildSpecArgs.registryMirror).
+	mirrors := []string{publicEcrProxyURL}
+	mirrorSteps, err := getSetupMirrorSteps(mirrors)
+	if err != nil {
+		return "", err
 	}
+	preBuildCommands = append(preBuildCommands, mirrorSteps...)
+	preBuildCommands = append(preBuildCommands, getPublicEcrProxySteps()...)
+
+	// BuildKit runs in its own container, so it needs both the mirror config and host networking
+	// to be able to reach the mirror on localhost:5000.
+	var buildkitdCfgArg string
+	if len(mirrors) > 0 {
+		buildkitdCfgArg = "--buildkitd-config=/tmp/buildkitd.toml"
+	}
+	buildxCreate := "docker buildx create --use --driver=docker-container " + buildkitdCfgArg +
+		" --driver-opt network=host --use " + platformArg
+	preBuildCommands = append(preBuildCommands, strings.Join(strings.Fields(buildxCreate), " "))
 
 	buildCmd := fmt.Sprintf("docker buildx build %s %s -t %s -f %s --push %s %s $CODEBUILD_SRC_DIR",
 		platformArg, strings.Join(cacheArgs, " "), destination, dockerfile, buildArgsStr, targetArg)

--- a/provider/defangaws/aws/codebuild.go
+++ b/provider/defangaws/aws/codebuild.go
@@ -151,15 +151,32 @@ func getSetupMirrorSteps(mirrors []string) ([]string, error) {
 		return nil, fmt.Errorf("marshaling docker daemon.json: %w", err)
 	}
 
+	// BuildKit's `mirrors` entries are bare host:port (no scheme), with a separate `http = true`
+	// flag for a plaintext mirror -- unlike Docker's own daemon.json, which wants the full URL.
+	// https://docs.docker.com/build/buildkit/toml-configuration/
+	allHTTP := true
 	quoted := make([]string, 0, len(mirrors))
 	for _, m := range mirrors {
-		quoted = append(quoted, `"`+m+`"`)
+		host, isHTTP := strings.CutPrefix(m, "http://")
+		if !isHTTP {
+			host = strings.TrimPrefix(m, "https://")
+			allHTTP = false
+		}
+		quoted = append(quoted, `"`+host+`"`)
 	}
-	buildkitdToml := "\n[registry.\"docker.io\"]\n  mirrors = [\n    " + strings.Join(quoted, ", ") + "\n  ]\n"
+	var httpLine string
+	if allHTTP {
+		httpLine = "\n  http = true"
+	}
+	buildkitdToml := "\n[registry.\"docker.io\"]\n  mirrors = [\n    " +
+		strings.Join(quoted, ", ") + "\n  ]" + httpLine + "\n"
 
+	// Written via single-quoted heredocs, not `echo '...'`: a mirror value containing a single
+	// quote would otherwise break out of the shell string. These values are internal constants
+	// today, not user input, but this avoids the class of bug entirely rather than relying on that.
 	return []string{
-		"mkdir -p /etc/docker/ && echo '" + string(daemonJSON) + "' > /etc/docker/daemon.json",
-		"echo '" + buildkitdToml + "' > /tmp/buildkitd.toml",
+		"mkdir -p /etc/docker/\ncat > /etc/docker/daemon.json <<'EOF'\n" + string(daemonJSON) + "\nEOF",
+		"cat > /tmp/buildkitd.toml <<'EOF'" + buildkitdToml + "EOF",
 		// dockerd only picks up a changed registry-mirrors list on SIGHUP.
 		"kill -HUP $(pidof dockerd)",
 	}, nil

--- a/provider/defangaws/aws/codebuild_test.go
+++ b/provider/defangaws/aws/codebuild_test.go
@@ -74,7 +74,6 @@ func TestGetBuildSpecDockerhubMirror(t *testing.T) {
 	assert.Contains(t, joined, `"registry-mirrors":["http://localhost:5000"]`)
 	assert.Contains(t, joined, `> /etc/docker/daemon.json`)
 	assert.Contains(t, joined, `[registry."docker.io"]`)
-	assert.Contains(t, joined, `"http://localhost:5000"`)
 	assert.Contains(t, joined, "> /tmp/buildkitd.toml")
 	assert.Contains(t, joined, "kill -HUP $(pidof dockerd)")
 
@@ -86,15 +85,28 @@ func TestGetBuildSpecDockerhubMirror(t *testing.T) {
 	assert.Contains(t, joined, "docker run -d --rm -p 5000:80 --name dockerhub-ecr-mirror")
 	assert.Contains(t, joined, "-v /tmp/nginx.conf:/etc/nginx/nginx.conf:ro")
 
-	// The daemon.json fragment must be valid JSON.
+	// The daemon.json fragment (written via a quoted heredoc, not `echo '...'`, so a mirror value
+	// containing a single quote can't break out of the shell string) must be valid JSON, and Docker
+	// wants the mirror as a full URL there.
 	daemonCmd := cmds[indexOfCommand(cmds, "/etc/docker/daemon.json")]
-	_, jsonPart, ok := strings.Cut(daemonCmd, "echo '")
+	_, jsonPart, ok := strings.Cut(daemonCmd, "daemon.json <<'EOF'\n")
 	require.True(t, ok)
-	jsonPart, _, ok = strings.Cut(jsonPart, "'")
+	jsonPart, _, ok = strings.Cut(jsonPart, "\nEOF")
 	require.True(t, ok)
 	var daemonCfg map[string][]string
 	require.NoError(t, json.Unmarshal([]byte(jsonPart), &daemonCfg))
 	assert.Equal(t, []string{"http://localhost:5000"}, daemonCfg["registry-mirrors"])
+
+	// BuildKit's buildkitd.toml wants bare host:port (no scheme) plus a separate http=true flag
+	// for a plaintext mirror, unlike daemon.json above (https://docs.docker.com/build/buildkit/toml-configuration/).
+	buildkitdCmd := cmds[indexOfCommand(cmds, "/tmp/buildkitd.toml")]
+	_, tomlPart, ok := strings.Cut(buildkitdCmd, "buildkitd.toml <<'EOF'")
+	require.True(t, ok)
+	tomlPart, _, ok = strings.Cut(tomlPart, "EOF")
+	require.True(t, ok)
+	assert.Contains(t, tomlPart, `mirrors = [`+"\n    \"localhost:5000\"\n  ]")
+	assert.NotContains(t, tomlPart, "http://localhost:5000")
+	assert.Contains(t, tomlPart, "\n  http = true")
 }
 
 // The mirror container must never get a restart policy: on a reused CodeBuild host the daemon

--- a/provider/defangaws/aws/codebuild_test.go
+++ b/provider/defangaws/aws/codebuild_test.go
@@ -48,9 +48,88 @@ func TestGetBuildSpecPlatformsAndCache(t *testing.T) {
 	})
 	joined := strings.Join(cmds, "\n")
 	assert.Contains(t, joined,
-		"buildx create --use --driver=docker-container --use --platform linux/arm64,linux/amd64")
+		"buildx create --use --driver=docker-container --buildkitd-config=/tmp/buildkitd.toml"+
+			" --driver-opt network=host --use --platform linux/arm64,linux/amd64")
 	assert.Contains(t, joined,
 		"buildx build --platform linux/arm64,linux/amd64"+
 			" --cache-from=type=registry,ref=my/app:cache"+
 			" --cache-to=type=registry,mode=max,ref=my/app:cache -t ")
+}
+
+// indexOfCommand returns the index of the first command containing substr, or -1.
+func indexOfCommand(cmds []string, substr string) int {
+	for i, c := range cmds {
+		if strings.Contains(c, substr) {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestGetBuildSpecDockerhubMirror(t *testing.T) {
+	cmds := buildSpecCommands(t, compose.BuildConfig{Context: pulumi.String("s3://bucket/ctx")})
+	joined := strings.Join(cmds, "\n")
+
+	// Daemon and BuildKit both point at the local mirror.
+	assert.Contains(t, joined, `"registry-mirrors":["http://localhost:5000"]`)
+	assert.Contains(t, joined, `> /etc/docker/daemon.json`)
+	assert.Contains(t, joined, `[registry."docker.io"]`)
+	assert.Contains(t, joined, `"http://localhost:5000"`)
+	assert.Contains(t, joined, "> /tmp/buildkitd.toml")
+	assert.Contains(t, joined, "kill -HUP $(pidof dockerd)")
+
+	// The mirror itself: token fetch, config render, container start.
+	assert.Contains(t, joined, "docker-credential-ecr-login get")
+	assert.Contains(t, joined, "> /tmp/nginx.conf")
+	assert.Contains(t, joined, "proxy_pass https://public.ecr.aws/v2/docker/")
+	assert.Contains(t, joined, "docker rm -f dockerhub-ecr-mirror || true")
+	assert.Contains(t, joined, "docker run -d --rm -p 5000:80 --name dockerhub-ecr-mirror")
+	assert.Contains(t, joined, "-v /tmp/nginx.conf:/etc/nginx/nginx.conf:ro")
+
+	// The daemon.json fragment must be valid JSON.
+	daemonCmd := cmds[indexOfCommand(cmds, "/etc/docker/daemon.json")]
+	_, jsonPart, ok := strings.Cut(daemonCmd, "echo '")
+	require.True(t, ok)
+	jsonPart, _, ok = strings.Cut(jsonPart, "'")
+	require.True(t, ok)
+	var daemonCfg map[string][]string
+	require.NoError(t, json.Unmarshal([]byte(jsonPart), &daemonCfg))
+	assert.Equal(t, []string{"http://localhost:5000"}, daemonCfg["registry-mirrors"])
+}
+
+// The mirror container must never get a restart policy: on a reused CodeBuild host the daemon
+// would resurrect it from a stale /tmp/nginx.conf bind-mount spec, and Docker creates a missing
+// bind-mount source as a directory, breaking the next build's `awk ... > /tmp/nginx.conf`.
+// See https://github.com/DefangLabs/defang-mvp/issues/2869
+func TestGetBuildSpecMirrorHasNoRestartPolicy(t *testing.T) {
+	cmds := buildSpecCommands(t, compose.BuildConfig{Context: pulumi.String("s3://bucket/ctx")})
+	assert.NotContains(t, strings.Join(cmds, "\n"), "--restart")
+}
+
+func TestGetBuildSpecMirrorStepOrder(t *testing.T) {
+	cmds := buildSpecCommands(t, compose.BuildConfig{Context: pulumi.String("s3://bucket/ctx")})
+
+	publicEcrLogin := indexOfCommand(cmds, "docker login --username AWS --password-stdin public.ecr.aws")
+	hup := indexOfCommand(cmds, "kill -HUP $(pidof dockerd)")
+	rm := indexOfCommand(cmds, "docker rm -f dockerhub-ecr-mirror")
+	run := indexOfCommand(cmds, "docker run -d --rm -p 5000:80")
+	buildxCreate := indexOfCommand(cmds, "docker buildx create")
+	buildxBuild := indexOfCommand(cmds, "docker buildx build")
+
+	for _, i := range []int{publicEcrLogin, hup, rm, run, buildxCreate, buildxBuild} {
+		require.NotEqual(t, -1, i)
+	}
+	// Log in before pulling the mirror image; reload the daemon before starting the mirror;
+	// remove any leftover container before starting ours; have the mirror up before buildx runs.
+	assert.Less(t, publicEcrLogin, hup)
+	assert.Less(t, hup, rm)
+	assert.Less(t, rm, run)
+	assert.Less(t, run, buildxCreate)
+	assert.Less(t, buildxCreate, buildxBuild)
+}
+
+func TestGetSetupMirrorStepsEmpty(t *testing.T) {
+	steps, err := getSetupMirrorSteps(nil)
+	require.NoError(t, err)
+	assert.Empty(t, steps)
 }


### PR DESCRIPTION
Fixes #420

## What this does

AWS CodeBuild image builds pulled base images from Docker Hub anonymously, over a shared NAT egress IP, with nothing in place to avoid Docker Hub's anonymous pull rate limits. The TypeScript provider in `defang-mvp` has solved this for a long time; the mechanism was simply never ported to Go.

This ports it, in `provider/defangaws/aws/codebuild.go`:

- **`getPublicEcrProxySteps()`** — starts a local nginx container (`dockerhub-ecr-mirror`, port 5000) that proxies `docker.io` pulls to `public.ecr.aws/docker/*`, authenticated with a public-ECR bearer token from `docker-credential-ecr-login` (chunked with `base64 -w 1024` because nginx cannot hold the whole token in one directive), falling back to `registry-1.docker.io` on 404.
- **`getSetupMirrorSteps(mirrors)`** — writes `registry-mirrors` into `/etc/docker/daemon.json` and a `[registry."docker.io"]` block into `/tmp/buildkitd.toml`, then `kill -HUP $(pidof dockerd)` so the daemon picks up the new mirror list.
- **`getBuildSpec()`** — wires both into `pre_build` between the existing ECR logins and `docker buildx create`, and creates the builder with `--buildkitd-config=/tmp/buildkitd.toml --driver-opt network=host`. The host networking is not optional: the `docker-container` driver otherwise sits on a bridge network, where `localhost:5000` is not the host's mirror and the mirror would silently do nothing.

No IAM change was needed — the CodeBuild role already grants `ecr-public:GetAuthorizationToken` + `sts:GetServiceBearerToken`.

No schema change, so no `sdk/v2/**` regeneration.

## No restart policy, by design

The mirror container is started **without any `--restart` policy**, and must stay that way.

With `--restart=always`, the Docker daemon on a reused CodeBuild host (we enable `LOCAL_DOCKER_LAYER_CACHE` / `LOCAL_SOURCE_CACHE`) resurrects the *previous* build's mirror container from its now-stale `/tmp/nginx.conf` bind-mount spec. Docker creates a missing bind-mount source as a **directory**, so the next build's own `awk ... > /tmp/nginx.conf` redirect fails with "Is a directory".

That was https://github.com/DefangLabs/defang-mvp/issues/2869, fixed on the TS side by https://github.com/DefangLabs/defang-mvp/pull/3184. This port starts from the corrected design rather than repeating and then fixing the bug. A `docker rm -f dockerhub-ecr-mirror || true` guard is still there for the separate, legitimate case of a same-named leftover container on a warm host, and `docker run` now uses `--rm`.

Both a code comment citing the issue and a test (`TestGetBuildSpecMirrorHasNoRestartPolicy`) guard against someone "helpfully" re-adding the restart policy later.

## Deliberately out of scope

- **TS's registry-auth/login mechanism** (`getRegistryLoginSteps` / `RegistryAuth` / `CI_REGISTRY_CREDENTIALS_*`). This provider has its own, different, already-working `aws ecr get-login-password` approach and this PR does not touch it. A knock-on: with no `RegistryAuth` concept there is no `hasDockerhubAuth()` opt-out either, so unlike TS the mirror is enabled unconditionally. That matches TS's default and common case, since there is no way here to configure explicit Docker Hub credentials that would make the mirror pointless.
- **The optional user-supplied `registryMirror` override** (TS `pulumi/cd/index.ts` config value → `BuildSpecArgs.registryMirror`). Threading it through would need a new `pulumi:`-tagged field on `compose.BuildConfig`, which changes the provider schema and drags an `sdk/v2/**` regeneration into this PR. The plumbing here already takes a `[]string` of mirrors, so adding it later is a couple of lines; there's a `TODO` at the call site. Follow-up, not a blocker for the rate-limit fix.

## Testing

- `TestGetBuildSpecDockerhubMirror` — mirror config lands in `daemon.json` (asserted as *parsed* JSON, not a string match) and `buildkitd.toml`; the proxy steps and container flags are present.
- `TestGetBuildSpecMirrorHasNoRestartPolicy` — no `--restart` anywhere in the generated buildspec.
- `TestGetBuildSpecMirrorStepOrder` — public-ECR login before the mirror image is pulled, dockerd HUP before the mirror starts, `rm -f` before `run`, mirror up before buildx runs.
- `TestGetSetupMirrorStepsEmpty` — empty mirror list produces no steps.
- Existing `TestGetBuildSpecPlatformsAndCache` updated for the new `buildx create` flags.

Beyond the unit tests, the generated `pre_build` script was extracted and executed locally against a stubbed `docker-credential-ecr-login` to verify the heredoc/`awk`/`base64` quoting actually produces a valid nginx config: `__TOKEN__` is fully substituted, the `$token` chunk lines are emitted, and `$token` / `$rest` / `$1` reach nginx as literal nginx variables instead of being eaten by the shell.

`golangci-lint` on `./provider/defangaws/...` is at its pre-existing baseline (50 `goconst` findings, all in untouched files — verified identical on `main`); `go test ./provider/...`, `tests/` (`-short`), and `cd/` all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a local Docker Hub image mirror for builds to improve image retrieval reliability.
  * Configured both Docker and BuildKit to use the mirror.
  * Added automatic authentication and mirror initialization during build setup.
  * Enabled host networking for BuildKit to support mirror access.

* **Bug Fixes**
  * Build setup errors are now surfaced before the build starts.
  * Stale mirror containers are cleaned up automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->