### PR TITLE
[ci-image] Build CD image for PR 467 + #457 smoketest — do not merge

### DIFF
--- a/cd/config.go
+++ b/cd/config.go
@@ -71,6 +71,11 @@ func unmarshalRecipe(recipePulumiConfig string, config configMap) error {
 	return nil
 }
 
+// defaultAutonamingSuffix is the "${project}-${stack}-${name}-${hex(7)}" tail
+// shared by most autonaming pattern overrides below; a prefix (bare, or
+// lowercased) is prepended where one is still wanted.
+const defaultAutonamingSuffix = "${project}-${stack}-${name}-${hex(7)}"
+
 func setDefaultStackConfig(prefix string, config configMap) {
 	// defang:prefix holds the bare prefix (e.g. "Defang"); its consumers
 	// (common.Prefix, e.g. ProjectResourceGroupName) append their own "-"
@@ -82,7 +87,7 @@ func setDefaultStackConfig(prefix string, config configMap) {
 	}
 	lowerPrefix := strings.ToLower(prefix)
 	config["pulumi:autonaming"] = configValue{Value: map[string]any{
-		"pattern": prefix + "${project}-${stack}-${name}-${hex(7)}",
+		"pattern": prefix + defaultAutonamingSuffix,
 		"providers": map[string]any{
 			"aws": map[string]any{
 				"resources": map[string]any{
@@ -91,9 +96,9 @@ func setDefaultStackConfig(prefix string, config configMap) {
 					// ecs.Service is always scoped to an ecs.Cluster, so the cluster's
 					// full prefix already disambiguates it; no need to repeat it here.
 					"aws:ecs/service:Service":                 map[string]string{"pattern": "${name}-${hex(7)}"},
-					"aws:elasticache/subnetGroup:SubnetGroup": map[string]string{"pattern": lowerPrefix + "${project}-${stack}-${name}-${hex(7)}"}, // lowercase
-					"aws:ecr/repository:Repository":           map[string]string{"pattern": lowerPrefix + "${project}-${stack}-${name}-${hex(7)}"}, // lowercase
-					"aws:rds/subnetGroup:SubnetGroup":         map[string]string{"pattern": lowerPrefix + "${project}-${stack}-${name}-${hex(7)}"}, // lowercase
+					"aws:elasticache/subnetGroup:SubnetGroup": map[string]string{"pattern": lowerPrefix + defaultAutonamingSuffix}, // lowercase
+					"aws:ecr/repository:Repository":           map[string]string{"pattern": lowerPrefix + defaultAutonamingSuffix}, // lowercase
+					"aws:rds/subnetGroup:SubnetGroup":         map[string]string{"pattern": lowerPrefix + defaultAutonamingSuffix}, // lowercase
 				},
 			},
 			"azure-native": map[string]any{
@@ -123,7 +128,7 @@ func setDefaultStackConfig(prefix string, config configMap) {
 			// (lowercase only, max 63 chars). The default prefix may contain capitals
 			// (e.g. "Defang-"), so force the entire pattern to use the lowercased prefix.
 			"gcp": map[string]any{
-				"pattern": lowerPrefix + "${project}-${stack}-${name}-${hex(7)}", // TODO: sanitize project name
+				"pattern": lowerPrefix + defaultAutonamingSuffix, // TODO: sanitize project name
 				"resources": map[string]any{
 					// Service account ID must be between 6 and 30 characters.
 					// Service account ID must start with a lower case letter, followed by one or more lower case alphanumerical characters that can be separated by hyphens.
@@ -131,10 +136,36 @@ func setDefaultStackConfig(prefix string, config configMap) {
 					// Cloud Run service name max 49 chars (^[a-z][a-z0-9-]{0,47}[a-z0-9]$).
 					// Default prefix-project-stack pattern overflows on longer inputs;
 					// drop the prefix to mirror old cloudrunServiceName (49 char budget).
-					"gcp:cloudrunv2/service:Service": map[string]string{"pattern": "${project}-${stack}-${name}-${hex(7)}"}, // TODO: sanitize project name
+					"gcp:cloudrunv2/service:Service": map[string]string{"pattern": defaultAutonamingSuffix}, // TODO: sanitize project name
 					// Memorystore Redis instance ID max 40 chars (^[a-z][a-z0-9-]{0,38}[a-z0-9]$).
 					// Drop the prefix to mirror old redisInstanceName (40 char budget).
 					"gcp:redis/instance:Instance": map[string]string{"pattern": "${project}-${name}-${hex(7)}"}, // TODO: sanitize project name
+					// Compute Engine resource names (health check, firewall, MIG, instance
+					// template) are capped at 63 chars, same regex as above. Their logical
+					// ${name} already includes the compose service name (and for the health
+					// check/firewall, the port and a "-mig-hc" role suffix), so the full
+					// default pattern (prefix-project-stack-name-hex7) overflows well before
+					// arbitrary-length service names would on their own -- surfaced live via
+					// defang-mvp#3181 against pulumi-defang#358. Drop just the prefix, same
+					// rationale as CloudRunService above.
+					"gcp:compute/healthCheck:HealthCheck": map[string]string{
+						"pattern": defaultAutonamingSuffix,
+					},
+					"gcp:compute/firewall:Firewall": map[string]string{
+						"pattern": defaultAutonamingSuffix,
+					},
+					"gcp:compute/regionInstanceGroupManager:RegionInstanceGroupManager": map[string]string{
+						"pattern": defaultAutonamingSuffix,
+					},
+					"gcp:compute/instanceTemplate:InstanceTemplate": map[string]string{
+						"pattern": defaultAutonamingSuffix,
+					},
+					"gcp:compute/regionBackendService:RegionBackendService": map[string]string{
+						"pattern": defaultAutonamingSuffix,
+					},
+					"gcp:compute/forwardingRule:ForwardingRule": map[string]string{
+						"pattern": defaultAutonamingSuffix,
+					},
 				},
 			},
 		},

--- a/cd/config_test.go
+++ b/cd/config_test.go
@@ -31,7 +31,7 @@ func Test_setDefaultStackConfig(t *testing.T) {
 	if !ok {
 		t.Fatal("pattern is not a string")
 	}
-	if pattern != "TestPrefix-${project}-${stack}-${name}-${hex(7)}" {
+	if pattern != "TestPrefix-"+defaultAutonamingSuffix {
 		t.Errorf("unexpected pattern: %s", pattern)
 	}
 
@@ -50,11 +50,44 @@ func Test_setDefaultStackConfigEmptyPrefix(t *testing.T) {
 	autonamingMap := autonaming.Value.(map[string]any)
 	pattern := autonamingMap["pattern"].(string)
 	// With empty prefix, pattern should not have a leading prefix-
-	if pattern != "${project}-${stack}-${name}-${hex(7)}" {
+	if pattern != defaultAutonamingSuffix {
 		t.Errorf("unexpected pattern with empty prefix: %s", pattern)
 	}
 	if got := config["defang:prefix"].Value; got != "" {
 		t.Errorf("unexpected defang:prefix with empty prefix: %q", got)
+	}
+}
+
+// Test_setDefaultStackConfigGCPComputeOverrides guards against the health
+// check naming bug surfaced live via defang-mvp#3181 against
+// pulumi-defang#358: the default "gcp" pattern's lowerPrefix only applies to
+// resources with no more specific override, and GCP Compute Engine resources
+// (health check, firewall, MIG, instance template) need the "Defang-" prefix
+// dropped entirely to stay within the 63-char limit -- see setDefaultStackConfig.
+func Test_setDefaultStackConfigGCPComputeOverrides(t *testing.T) {
+	config := configMap{}
+	setDefaultStackConfig("Defang", config)
+
+	autonamingMap := config["pulumi:autonaming"].Value.(map[string]any)
+	providers := autonamingMap["providers"].(map[string]any)
+	gcp := providers["gcp"].(map[string]any)
+	resources := gcp["resources"].(map[string]any)
+
+	for _, resourceType := range []string{
+		"gcp:compute/healthCheck:HealthCheck",
+		"gcp:compute/firewall:Firewall",
+		"gcp:compute/regionInstanceGroupManager:RegionInstanceGroupManager",
+		"gcp:compute/instanceTemplate:InstanceTemplate",
+		"gcp:compute/regionBackendService:RegionBackendService",
+		"gcp:compute/forwardingRule:ForwardingRule",
+	} {
+		override, ok := resources[resourceType].(map[string]string)
+		if !ok {
+			t.Fatalf("missing override for %s", resourceType)
+		}
+		if override["pattern"] != defaultAutonamingSuffix {
+			t.Errorf("%s: pattern = %q, want %q", resourceType, override["pattern"], defaultAutonamingSuffix)
+		}
 	}
 }
 

--- a/provider/defangaws/aws/codebuild.go
+++ b/provider/defangaws/aws/codebuild.go
@@ -2,7 +2,9 @@ package aws
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/DefangLabs/pulumi-defang/provider/common"
@@ -14,6 +16,49 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
+
+var (
+	errCodeBuildS3NoObjectKey = errors.New("CodeBuild S3 source URL has no object key")
+	errCodeBuildNotS3URL      = errors.New("CodeBuild source must be an S3 URL")
+	errCodeBuildS3Incomplete  = errors.New("CodeBuild source must include an S3 bucket and object key")
+)
+
+func normalizeCodeBuildS3Location(rawURL string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("parsing CodeBuild source URL: %w", err)
+	}
+
+	object := strings.TrimPrefix(u.EscapedPath(), "/")
+	var bucket string
+	switch u.Scheme {
+	case "s3":
+		bucket = u.Host
+	case "http", "https":
+		host := u.Hostname()
+		if before, _, ok := strings.Cut(host, ".s3."); ok {
+			// Virtual-hosted style: https://bucket.s3.region.amazonaws.com/key.
+			bucket = before
+		} else if before, _, ok := strings.Cut(host, ".s3-"); ok {
+			// Legacy virtual-hosted style: https://bucket.s3-region.amazonaws.com/key.
+			bucket = before
+		} else if strings.HasPrefix(host, "s3.") || strings.HasPrefix(host, "s3-") {
+			// Path style: https://s3.region.amazonaws.com/bucket/key.
+			var found bool
+			bucket, object, found = strings.Cut(object, "/")
+			if !found {
+				return "", fmt.Errorf("%w: %q", errCodeBuildS3NoObjectKey, rawURL)
+			}
+		}
+	default:
+		return "", fmt.Errorf("%w: got %q", errCodeBuildNotS3URL, rawURL)
+	}
+
+	if bucket == "" || object == "" {
+		return "", fmt.Errorf("%w: got %q", errCodeBuildS3Incomplete, rawURL)
+	}
+	return bucket + "/" + object, nil
+}
 
 // codeBuildResult holds the outputs of creating a CodeBuild project.
 type codeBuildResult struct {
@@ -216,8 +261,15 @@ func getBuildSpec(build compose.BuildConfig, destination string) (string, error)
 		cacheArgs = append(cacheArgs, "--cache-to="+c)
 	}
 
-	preBuildCommands := make([]string, 0, 12)
+	preBuildCommands := make([]string, 0, 13)
 	preBuildCommands = append(preBuildCommands,
+		// CodeBuild's S3 source only auto-extracts .zip; the CLI uploads the
+		// build context as a .tar.gz (same format for every provider -- GCP's
+		// Cloud Build extracts that natively, CodeBuild does not), so a
+		// non-zip source lands here as a single untouched archive file with
+		// no Dockerfile anywhere. Extract it ourselves; a no-op if the source
+		// was already a zip (nothing named *.tar.gz to find).
+		`archive=$(ls *.tar.gz 2>/dev/null | head -n1); if [ -n "$archive" ]; then tar xzf "$archive"; fi`,
 		"aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $(aws sts get-caller-identity --query Account --output text).dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com", //nolint:lll
 		"aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws",
 	)
@@ -332,11 +384,13 @@ func createCodeBuildProject(
 		})
 	}
 
-	// Context must be an S3 URL
+	// CodeBuild expects S3 sources as bucket/key, while the CLI supplies either
+	// an s3:// URL or the query-free HTTPS URL returned by S3's presigner.
 	sourceType := "S3"
-	sourceLocation := pulumix.Apply(pulumix.Output[string](build.Context.ToStringOutput()), func(s string) string {
-		return strings.TrimPrefix(s, "s3://")
-	})
+	sourceLocation := pulumix.ApplyErr(
+		pulumix.Output[string](build.Context.ToStringOutput()),
+		normalizeCodeBuildS3Location,
+	)
 
 	project, err := codebuild.NewProject(ctx, name, &codebuild.ProjectArgs{
 		Description: pulumi.Sprintf("Build image for %s", name),

--- a/provider/defangaws/aws/codebuild.go
+++ b/provider/defangaws/aws/codebuild.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"path"
 	"regexp"
 	"strings"
 
@@ -63,6 +64,32 @@ func normalizeCodeBuildS3Location(rawURL string) (string, error) {
 		return "", fmt.Errorf("%w: got %q", errCodeBuildS3Incomplete, rawURL)
 	}
 	return bucket + "/" + object, nil
+}
+
+// codeBuildExtractArchiveCommand returns the pre_build shell command that extracts the
+// uploaded build context, or "" if the context is a .zip -- CodeBuild's S3 source only
+// auto-extracts .zip, so a .zip context arrives in $CODEBUILD_SRC_DIR already extracted
+// and there is nothing to do.
+//
+// The CLI uploads the build context as .tar.gz (or .tgz) for every non-Railpack build on
+// every provider (GCP's Cloud Build extracts that natively, CodeBuild does not), so a
+// non-zip source otherwise lands here as a single untouched archive file with no Dockerfile
+// anywhere. CodeBuild downloads a non-zip S3 source into $CODEBUILD_SRC_DIR under the same
+// filename as the object key, so that name is known up front from the source URL -- extract
+// that exact file rather than glob-discovering it (matches the legacy TS CD's use of the
+// known contextFile path). The archive is removed afterward so a Dockerfile that COPYs the
+// whole build context doesn't also pick up its own multi-megabyte source tarball.
+func codeBuildExtractArchiveCommand(contextURL string) (string, error) {
+	loc, err := normalizeCodeBuildS3Location(contextURL)
+	if err != nil {
+		return "", err
+	}
+	archive := path.Base(loc)
+	if !strings.HasSuffix(archive, ".tar.gz") && !strings.HasSuffix(archive, ".tgz") {
+		return "", nil
+	}
+	quoted := "'" + strings.ReplaceAll(archive, "'", `'\''`) + "'"
+	return fmt.Sprintf("tar xzf %s && rm %s", quoted, quoted), nil
 }
 
 // codeBuildResult holds the outputs of creating a CodeBuild project.
@@ -233,9 +260,16 @@ func getSetupMirrorSteps(mirrors []string) ([]string, error) {
 }
 
 // getBuildSpec generates the CodeBuild buildspec YAML for a Docker image build.
+// contextURL is the same S3 location used as the CodeBuild project's source, so the
+// generated extraction step can name the archive exactly rather than glob-discovering it.
 // Matches TS getBuildSpec: pre_build sets up mirrors and buildx, build runs docker buildx build --push.
-func getBuildSpec(build compose.BuildConfig, destination string) (string, error) {
+func getBuildSpec(build compose.BuildConfig, destination, contextURL string) (string, error) {
 	dockerfile := build.GetDockerfile()
+
+	extractArchiveCmd, err := codeBuildExtractArchiveCommand(contextURL)
+	if err != nil {
+		return "", err
+	}
 
 	// Build args in deterministic order (matches TS: Object.keys(buildArgs).sort())
 	var buildArgsStr string
@@ -267,18 +301,10 @@ func getBuildSpec(build compose.BuildConfig, destination string) (string, error)
 	}
 
 	preBuildCommands := make([]string, 0, 13)
+	if extractArchiveCmd != "" {
+		preBuildCommands = append(preBuildCommands, extractArchiveCmd)
+	}
 	preBuildCommands = append(preBuildCommands,
-		// CodeBuild's S3 source only auto-extracts .zip; the CLI uploads the
-		// build context as a .tar.gz (same format for every provider -- GCP's
-		// Cloud Build extracts that natively, CodeBuild does not), so a
-		// non-zip source lands here as a single untouched archive file with
-		// no Dockerfile anywhere. Extract it ourselves; a no-op if the source
-		// was already a zip (nothing named *.tar.gz to find). Remove the
-		// archive afterward (matching the legacy TS CD's behavior) so a
-		// Dockerfile that COPYs the whole build context doesn't also pick up
-		// its own multi-megabyte source tarball.
-		`archive=$(ls *.tar.gz 2>/dev/null | head -n1); ` +
-			`if [ -n "$archive" ]; then tar xzf "$archive" && rm "$archive"; fi`,
 		"aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $(aws sts get-caller-identity --query Account --output text).dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com", //nolint:lll
 		"aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws",
 	)
@@ -374,9 +400,12 @@ func createCodeBuildProject(
 		return url + ":latest"
 	})
 
-	// The buildspec needs the destination at apply time
-	buildspecOutput := pulumix.ApplyErr(destination, func(dest string) (string, error) {
-		return getBuildSpec(build, dest)
+	contextOutput := pulumix.Output[string](build.Context.ToStringOutput())
+
+	// The buildspec needs the destination and the resolved build-context URL (so its
+	// extraction step can name the uploaded archive exactly) at apply time.
+	buildspecOutput := pulumix.Apply2Err(destination, contextOutput, func(dest, contextURL string) (string, error) {
+		return getBuildSpec(build, dest, contextURL)
 	})
 
 	// Build environment variables (build args become env vars)
@@ -396,10 +425,7 @@ func createCodeBuildProject(
 	// CodeBuild expects S3 sources as bucket/key, while the CLI supplies either
 	// an s3:// URL or the query-free HTTPS URL returned by S3's presigner.
 	sourceType := "S3"
-	sourceLocation := pulumix.ApplyErr(
-		pulumix.Output[string](build.Context.ToStringOutput()),
-		normalizeCodeBuildS3Location,
-	)
+	sourceLocation := pulumix.ApplyErr(contextOutput, normalizeCodeBuildS3Location)
 
 	project, err := codebuild.NewProject(ctx, name, &codebuild.ProjectArgs{
 		Description: pulumi.Sprintf("Build image for %s", name),

--- a/provider/defangaws/aws/codebuild.go
+++ b/provider/defangaws/aws/codebuild.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/DefangLabs/pulumi-defang/provider/common"
@@ -23,6 +24,13 @@ var (
 	errCodeBuildS3Incomplete  = errors.New("CodeBuild source must include an S3 bucket and object key")
 )
 
+// s3HostPattern matches real AWS S3 HTTPS endpoint hostnames -- both
+// virtual-hosted ("bucket.s3[-.]<region>.amazonaws.com") and path-style
+// ("s3[-.]<region>.amazonaws.com") -- anchored on both ends so a lookalike
+// like "bucket.s3.evil.example" or "s3.evil.example" cannot be mistaken for
+// one (a naive substring/prefix check on the hostname would accept both).
+var s3HostPattern = regexp.MustCompile(`^(?:(?P<bucket>[^.]+)\.)?s3(?:[.-][a-z0-9-]+)?\.amazonaws\.com$`)
+
 func normalizeCodeBuildS3Location(rawURL string) (string, error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
@@ -35,14 +43,11 @@ func normalizeCodeBuildS3Location(rawURL string) (string, error) {
 	case "s3":
 		bucket = u.Host
 	case "http", "https":
-		host := u.Hostname()
-		if before, _, ok := strings.Cut(host, ".s3."); ok {
-			// Virtual-hosted style: https://bucket.s3.region.amazonaws.com/key.
-			bucket = before
-		} else if before, _, ok := strings.Cut(host, ".s3-"); ok {
-			// Legacy virtual-hosted style: https://bucket.s3-region.amazonaws.com/key.
-			bucket = before
-		} else if strings.HasPrefix(host, "s3.") || strings.HasPrefix(host, "s3-") {
+		m := s3HostPattern.FindStringSubmatch(u.Hostname())
+		if m == nil {
+			return "", fmt.Errorf("%w: got %q", errCodeBuildNotS3URL, rawURL)
+		}
+		if bucket = m[s3HostPattern.SubexpIndex("bucket")]; bucket == "" {
 			// Path style: https://s3.region.amazonaws.com/bucket/key.
 			var found bool
 			bucket, object, found = strings.Cut(object, "/")
@@ -268,8 +273,12 @@ func getBuildSpec(build compose.BuildConfig, destination string) (string, error)
 		// Cloud Build extracts that natively, CodeBuild does not), so a
 		// non-zip source lands here as a single untouched archive file with
 		// no Dockerfile anywhere. Extract it ourselves; a no-op if the source
-		// was already a zip (nothing named *.tar.gz to find).
-		`archive=$(ls *.tar.gz 2>/dev/null | head -n1); if [ -n "$archive" ]; then tar xzf "$archive"; fi`,
+		// was already a zip (nothing named *.tar.gz to find). Remove the
+		// archive afterward (matching the legacy TS CD's behavior) so a
+		// Dockerfile that COPYs the whole build context doesn't also pick up
+		// its own multi-megabyte source tarball.
+		`archive=$(ls *.tar.gz 2>/dev/null | head -n1); ` +
+			`if [ -n "$archive" ]; then tar xzf "$archive" && rm "$archive"; fi`,
 		"aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $(aws sts get-caller-identity --query Account --output text).dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com", //nolint:lll
 		"aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws",
 	)

--- a/provider/defangaws/aws/codebuild.go
+++ b/provider/defangaws/aws/codebuild.go
@@ -30,7 +30,14 @@ var (
 // ("s3[-.]<region>.amazonaws.com") -- anchored on both ends so a lookalike
 // like "bucket.s3.evil.example" or "s3.evil.example" cannot be mistaken for
 // one (a naive substring/prefix check on the hostname would accept both).
-var s3HostPattern = regexp.MustCompile(`^(?:(?P<bucket>[^.]+)\.)?s3(?:[.-][a-z0-9-]+)?\.amazonaws\.com$`)
+//
+// The optional "dualstack" label covers the IPv6 dual-stack endpoints
+// ("s3.dualstack.<region>.amazonaws.com" and its virtual-hosted form), which
+// the AWS SDK emits when it is configured with AWS_USE_DUALSTACK_ENDPOINT --
+// without it a dual-stack presigned context URL would fail this check and
+// surface as a confusing "must be an S3 URL" error at project-creation time.
+var s3HostPattern = regexp.MustCompile(
+	`^(?:(?P<bucket>[^.]+)\.)?s3(?:\.dualstack)?(?:[.-][a-z0-9-]+)?\.amazonaws\.com$`)
 
 func normalizeCodeBuildS3Location(rawURL string) (string, error) {
 	u, err := url.Parse(rawURL)

--- a/provider/defangaws/aws/codebuild_test.go
+++ b/provider/defangaws/aws/codebuild_test.go
@@ -16,9 +16,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// buildSpecCommands generates a buildspec for a realistic .tar.gz build context. Tests that
+// specifically exercise the context-extraction step should call buildSpecCommandsWithContext
+// instead, so they control the source URL (and therefore the archive filename/extension).
 func buildSpecCommands(t *testing.T, build compose.BuildConfig) []string {
 	t.Helper()
-	spec, err := getBuildSpec(build, "123.dkr.ecr.us-test-2.amazonaws.com/repo:latest")
+	return buildSpecCommandsWithContext(t, build, "s3://bucket/context.tar.gz")
+}
+
+func buildSpecCommandsWithContext(t *testing.T, build compose.BuildConfig, contextURL string) []string {
+	t.Helper()
+	spec, err := getBuildSpec(build, "123.dkr.ecr.us-test-2.amazonaws.com/repo:latest", contextURL)
 	require.NoError(t, err)
 	var parsed struct {
 		Phases struct {
@@ -85,48 +93,66 @@ func TestGetBuildSpecDefault(t *testing.T) {
 // "open Dockerfile: no such file or directory" because $CODEBUILD_SRC_DIR
 // held the untouched archive, not its contents.
 func TestGetBuildSpecExtractsArchiveBeforeAnythingElse(t *testing.T) {
-	cmds := buildSpecCommands(t, compose.BuildConfig{Context: pulumi.String("s3://bucket/ctx")})
+	cmds := buildSpecCommands(t, compose.BuildConfig{})
 	require.NotEmpty(t, cmds)
 	assert.Contains(t, cmds[0], "tar xzf",
 		"extraction must be the first pre_build command, before anything else needs the source tree")
+	assert.Contains(t, cmds[0], "context.tar.gz",
+		"must name the archive CodeBuild will actually download, taken from the source URL")
+	assert.NotContains(t, cmds[0], "ls ",
+		"the archive name is known up front from the source URL; no need to glob-discover it")
 }
 
-// Runs the actual generated extraction command (not just asserting on the
-// spec text) against a real tarball, and confirms it's a safe no-op for a
-// zip-sourced build (CodeBuild already extracted that itself, so there's
-// nothing named *.tar.gz to find).
+// The legacy TS CD also accepted ".tgz" (not just ".tar.gz"); keep parity.
+func TestGetBuildSpecExtractsTgzArchive(t *testing.T) {
+	cmds := buildSpecCommandsWithContext(t, compose.BuildConfig{}, "s3://bucket/uploads/context.tgz")
+	require.NotEmpty(t, cmds)
+	assert.Contains(t, cmds[0], "tar xzf")
+	assert.Contains(t, cmds[0], "context.tgz")
+}
+
+// A .zip source is already extracted by CodeBuild itself, so there's nothing named
+// *.tar.gz/*.tgz to find -- getBuildSpec must not emit an extraction step at all.
+func TestGetBuildSpecSkipsExtractionForZipSource(t *testing.T) {
+	cmds := buildSpecCommandsWithContext(t, compose.BuildConfig{}, "s3://bucket/uploads/context.zip")
+	assert.NotContains(t, strings.Join(cmds, "\n"), "tar xzf")
+}
+
+// Only the archive's basename is used, even when the S3 object key has a path prefix
+// (as real CLI uploads do, e.g. "uploads/<hash>.tar.gz") -- CodeBuild downloads the object
+// into $CODEBUILD_SRC_DIR under that basename, not the full key.
+func TestGetBuildSpecExtractionUsesArchiveBasename(t *testing.T) {
+	cmds := buildSpecCommandsWithContext(t, compose.BuildConfig{}, "s3://bucket/uploads/nested/abc123.tar.gz")
+	require.NotEmpty(t, cmds)
+	assert.Contains(t, cmds[0], "abc123.tar.gz")
+	assert.NotContains(t, cmds[0], "uploads/nested")
+}
+
+// Runs the actual generated extraction command (not just asserting on the spec text)
+// against a real tarball, confirming it extracts the exact archive named in the command
+// and removes it afterward.
 func TestBuildSpecExtractionCommandExtractsRealArchive(t *testing.T) {
-	cmds := buildSpecCommands(t, compose.BuildConfig{Context: pulumi.String("s3://bucket/ctx")})
+	cmds := buildSpecCommandsWithContext(t, compose.BuildConfig{}, "s3://bucket/uploads/abc123.tar.gz")
 	extractCmd := cmds[0]
 
-	t.Run("extracts a tar.gz source and removes the archive", func(t *testing.T) {
-		dir := t.TempDir()
-		archivePath := filepath.Join(dir, "abc123.tar.gz")
-		writeTestTarGz(t, archivePath, map[string]string{"Dockerfile": "FROM scratch\n"})
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "abc123.tar.gz")
+	writeTestTarGz(t, archivePath, map[string]string{"Dockerfile": "FROM scratch\n"})
 
-		cmd := exec.CommandContext(t.Context(), "bash", "-c", extractCmd) //nolint:gosec // G204: test-authored command
-		cmd.Dir = dir
-		output, err := cmd.CombinedOutput()
-		require.NoError(t, err, "output: %s", output)
+	cmd := exec.CommandContext(t.Context(), "bash", "-c", extractCmd) //nolint:gosec // G204: test-authored command
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "output: %s", output)
 
-		//nolint:gosec // G304: test-authored path in t.TempDir()
-		content, err := os.ReadFile(filepath.Join(dir, "Dockerfile"))
-		require.NoError(t, err)
-		assert.Equal(t, "FROM scratch\n", string(content))
+	//nolint:gosec // G304: test-authored path in t.TempDir()
+	content, err := os.ReadFile(filepath.Join(dir, "Dockerfile"))
+	require.NoError(t, err)
+	assert.Equal(t, "FROM scratch\n", string(content))
 
-		// Not removing it risks a naive `COPY . .` Dockerfile picking up its
-		// own multi-megabyte source tarball as part of the image.
-		_, err = os.Stat(archivePath)
-		assert.True(t, os.IsNotExist(err), "archive should be removed after extraction")
-	})
-
-	t.Run("no-op when there is nothing to extract", func(t *testing.T) {
-		dir := t.TempDir()
-		cmd := exec.CommandContext(t.Context(), "bash", "-c", extractCmd) //nolint:gosec // G204: test-authored command
-		cmd.Dir = dir
-		output, err := cmd.CombinedOutput()
-		require.NoError(t, err, "output: %s", output)
-	})
+	// Not removing it risks a naive `COPY . .` Dockerfile picking up its
+	// own multi-megabyte source tarball as part of the image.
+	_, err = os.Stat(archivePath)
+	assert.True(t, os.IsNotExist(err), "archive should be removed after extraction")
 }
 
 func writeTestTarGz(t *testing.T, path string, files map[string]string) {

--- a/provider/defangaws/aws/codebuild_test.go
+++ b/provider/defangaws/aws/codebuild_test.go
@@ -1,7 +1,12 @@
 package aws
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -29,6 +34,27 @@ func buildSpecCommands(t *testing.T, build compose.BuildConfig) []string {
 	return append(parsed.Phases.PreBuild.Commands, parsed.Phases.Build.Commands...)
 }
 
+func TestNormalizeCodeBuildS3Location(t *testing.T) {
+	tests := map[string]string{
+		"s3://bucket/uploads/context.tar.gz":                                     "bucket/uploads/context.tar.gz",
+		"https://bucket.s3.amazonaws.com/uploads/context.tar.gz?signature=value": "bucket/uploads/context.tar.gz",
+		"https://bucket.s3.us-west-2.amazonaws.com/uploads/context.tar.gz":       "bucket/uploads/context.tar.gz",
+		"https://s3.us-west-2.amazonaws.com/bucket/uploads/context.tar.gz":       "bucket/uploads/context.tar.gz",
+	}
+	for input, expected := range tests {
+		t.Run(input, func(t *testing.T) {
+			actual, err := normalizeCodeBuildS3Location(input)
+			require.NoError(t, err)
+			assert.Equal(t, expected, actual)
+		})
+	}
+}
+
+func TestNormalizeCodeBuildS3LocationRejectsInvalidURL(t *testing.T) {
+	_, err := normalizeCodeBuildS3Location("https://example.com/context.tar.gz")
+	require.Error(t, err)
+}
+
 func TestGetBuildSpecDefault(t *testing.T) {
 	cmds := buildSpecCommands(t, compose.BuildConfig{Context: pulumi.String("s3://bucket/ctx")})
 	joined := strings.Join(cmds, "\n")
@@ -37,6 +63,68 @@ func TestGetBuildSpecDefault(t *testing.T) {
 	assert.NotContains(t, joined, "--cache-to")
 	assert.Contains(t, joined,
 		"docker buildx build -t 123.dkr.ecr.us-test-2.amazonaws.com/repo:latest -f Dockerfile --push $CODEBUILD_SRC_DIR")
+}
+
+// CodeBuild's S3 source only auto-extracts .zip; the CLI uploads the build
+// context as .tar.gz for every non-Railpack build on every provider (GCP's
+// Cloud Build extracts that natively, CodeBuild does not). A live smoketest
+// (defang-mvp#3181) hit this for real: the build phase failed with
+// "open Dockerfile: no such file or directory" because $CODEBUILD_SRC_DIR
+// held the untouched archive, not its contents.
+func TestGetBuildSpecExtractsArchiveBeforeAnythingElse(t *testing.T) {
+	cmds := buildSpecCommands(t, compose.BuildConfig{Context: pulumi.String("s3://bucket/ctx")})
+	require.NotEmpty(t, cmds)
+	assert.Contains(t, cmds[0], "tar xzf",
+		"extraction must be the first pre_build command, before anything else needs the source tree")
+}
+
+// Runs the actual generated extraction command (not just asserting on the
+// spec text) against a real tarball, and confirms it's a safe no-op for a
+// zip-sourced build (CodeBuild already extracted that itself, so there's
+// nothing named *.tar.gz to find).
+func TestBuildSpecExtractionCommandExtractsRealArchive(t *testing.T) {
+	cmds := buildSpecCommands(t, compose.BuildConfig{Context: pulumi.String("s3://bucket/ctx")})
+	extractCmd := cmds[0]
+
+	t.Run("extracts a tar.gz source", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTestTarGz(t, filepath.Join(dir, "abc123.tar.gz"), map[string]string{"Dockerfile": "FROM scratch\n"})
+
+		cmd := exec.CommandContext(t.Context(), "bash", "-c", extractCmd) //nolint:gosec // G204: test-authored command
+		cmd.Dir = dir
+		output, err := cmd.CombinedOutput()
+		require.NoError(t, err, "output: %s", output)
+
+		//nolint:gosec // G304: test-authored path in t.TempDir()
+		content, err := os.ReadFile(filepath.Join(dir, "Dockerfile"))
+		require.NoError(t, err)
+		assert.Equal(t, "FROM scratch\n", string(content))
+	})
+
+	t.Run("no-op when there is nothing to extract", func(t *testing.T) {
+		dir := t.TempDir()
+		cmd := exec.CommandContext(t.Context(), "bash", "-c", extractCmd) //nolint:gosec // G204: test-authored command
+		cmd.Dir = dir
+		output, err := cmd.CombinedOutput()
+		require.NoError(t, err, "output: %s", output)
+	})
+}
+
+func writeTestTarGz(t *testing.T, path string, files map[string]string) {
+	t.Helper()
+	f, err := os.Create(path) //nolint:gosec // G304: test-authored path in t.TempDir()
+	require.NoError(t, err)
+	gz := gzip.NewWriter(f)
+	tw := tar.NewWriter(gz)
+	for name, content := range files {
+		require.NoError(t, tw.WriteHeader(&tar.Header{Name: name, Size: int64(len(content)), Mode: 0o644}))
+		_, err := tw.Write([]byte(content))
+		require.NoError(t, err)
+	}
+	// Close in dependency order: tar writer flushes into gzip, gzip flushes into the file.
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+	require.NoError(t, f.Close())
 }
 
 func TestGetBuildSpecPlatformsAndCache(t *testing.T) {

--- a/provider/defangaws/aws/codebuild_test.go
+++ b/provider/defangaws/aws/codebuild_test.go
@@ -48,6 +48,10 @@ func TestNormalizeCodeBuildS3Location(t *testing.T) {
 		"https://bucket.s3.amazonaws.com/uploads/context.tar.gz?signature=value": "bucket/uploads/context.tar.gz",
 		"https://bucket.s3.us-west-2.amazonaws.com/uploads/context.tar.gz":       "bucket/uploads/context.tar.gz",
 		"https://s3.us-west-2.amazonaws.com/bucket/uploads/context.tar.gz":       "bucket/uploads/context.tar.gz",
+		// IPv6 dual-stack endpoints, in both virtual-hosted and path style. The
+		// SDK emits these when AWS_USE_DUALSTACK_ENDPOINT is set.
+		"https://bucket.s3.dualstack.us-west-2.amazonaws.com/uploads/context.tar.gz": "bucket/uploads/context.tar.gz",
+		"https://s3.dualstack.us-west-2.amazonaws.com/bucket/uploads/context.tar.gz": "bucket/uploads/context.tar.gz",
 	}
 	for input, expected := range tests {
 		t.Run(input, func(t *testing.T) {
@@ -67,6 +71,9 @@ func TestNormalizeCodeBuildS3LocationRejectsInvalidURL(t *testing.T) {
 		"https://bucket.s3.evil.example/context.tar.gz",
 		"https://s3.evil.example/bucket/context.tar.gz",
 		"https://bucket.s3.amazonaws.com.evil.example/context.tar.gz",
+		// The dual-stack label must not become an escape hatch for lookalikes.
+		"https://s3.dualstack.evil.example/bucket/context.tar.gz",
+		"https://bucket.s3.dualstack.us-west-2.amazonaws.com.evil.example/context.tar.gz",
 	}
 	for _, input := range tests {
 		t.Run(input, func(t *testing.T) {

--- a/provider/defangaws/aws/codebuild_test.go
+++ b/provider/defangaws/aws/codebuild_test.go
@@ -51,8 +51,21 @@ func TestNormalizeCodeBuildS3Location(t *testing.T) {
 }
 
 func TestNormalizeCodeBuildS3LocationRejectsInvalidURL(t *testing.T) {
-	_, err := normalizeCodeBuildS3Location("https://example.com/context.tar.gz")
-	require.Error(t, err)
+	tests := []string{
+		"https://example.com/context.tar.gz",
+		// Lookalike hosts: a naive substring/prefix check on the hostname
+		// (".s3." anywhere, or a "s3." prefix) would accept these as if they
+		// were real S3 endpoints.
+		"https://bucket.s3.evil.example/context.tar.gz",
+		"https://s3.evil.example/bucket/context.tar.gz",
+		"https://bucket.s3.amazonaws.com.evil.example/context.tar.gz",
+	}
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			_, err := normalizeCodeBuildS3Location(input)
+			require.Error(t, err)
+		})
+	}
 }
 
 func TestGetBuildSpecDefault(t *testing.T) {
@@ -86,9 +99,10 @@ func TestBuildSpecExtractionCommandExtractsRealArchive(t *testing.T) {
 	cmds := buildSpecCommands(t, compose.BuildConfig{Context: pulumi.String("s3://bucket/ctx")})
 	extractCmd := cmds[0]
 
-	t.Run("extracts a tar.gz source", func(t *testing.T) {
+	t.Run("extracts a tar.gz source and removes the archive", func(t *testing.T) {
 		dir := t.TempDir()
-		writeTestTarGz(t, filepath.Join(dir, "abc123.tar.gz"), map[string]string{"Dockerfile": "FROM scratch\n"})
+		archivePath := filepath.Join(dir, "abc123.tar.gz")
+		writeTestTarGz(t, archivePath, map[string]string{"Dockerfile": "FROM scratch\n"})
 
 		cmd := exec.CommandContext(t.Context(), "bash", "-c", extractCmd) //nolint:gosec // G204: test-authored command
 		cmd.Dir = dir
@@ -99,6 +113,11 @@ func TestBuildSpecExtractionCommandExtractsRealArchive(t *testing.T) {
 		content, err := os.ReadFile(filepath.Join(dir, "Dockerfile"))
 		require.NoError(t, err)
 		assert.Equal(t, "FROM scratch\n", string(content))
+
+		// Not removing it risks a naive `COPY . .` Dockerfile picking up its
+		// own multi-megabyte source tarball as part of the image.
+		_, err = os.Stat(archivePath)
+		assert.True(t, os.IsNotExist(err), "archive should be removed after extraction")
 	})
 
 	t.Run("no-op when there is nothing to extract", func(t *testing.T) {

--- a/provider/defangaws/aws/lb.go
+++ b/provider/defangaws/aws/lb.go
@@ -155,7 +155,8 @@ func createTgLrPair(
 
 	// Only create TG/LR for http, http2, grpc (matches TS createTgLrPair)
 	appProto := port.GetAppProtocol()
-	if appProto != "http" && appProto != "http2" && appProto != "grpc" {
+	if appProto != compose.PortAppProtocolHTTP &&
+		appProto != compose.PortAppProtocolHTTP2 && appProto != compose.PortAppProtocolGRPC {
 		return nil, nil, nil // skip
 	}
 

--- a/provider/defangaws/aws/naming.go
+++ b/provider/defangaws/aws/naming.go
@@ -16,7 +16,7 @@ func targetGroupName(
 	service string, port int, appProtocol compose.PortAppProtocol, listener compose.PortListenerProtocol,
 ) string {
 	suffix := fmt.Sprintf("-%d", port)
-	if appProtocol != "" && appProtocol != "http" {
+	if appProtocol != "" && appProtocol != compose.PortAppProtocolHTTP {
 		suffix += string(appProtocol)
 	}
 	// HTTPS is the default listener, so only non-default listeners get a suffix

--- a/provider/defanggcp/gcp/alb.go
+++ b/provider/defanggcp/gcp/alb.go
@@ -47,7 +47,7 @@ func CreateLoadBalancers(
 	config *SharedInfra,
 	opts ...pulumi.ResourceOption,
 ) error {
-	if err := createInternalLoadBalancer(ctx, projectName, config, services, opts...); err != nil {
+	if err := createInternalLoadBalancer(ctx, config, services, opts...); err != nil {
 		return err
 	}
 
@@ -118,7 +118,11 @@ func createExternalLoadBalancers(
 	}
 
 	if config.WildcardCertId != nil {
-		if _, err := certificatemanager.NewCertificateMapEntry(ctx, projectName+"-cert-map-entry",
+		// Logical name deliberately omits projectName, same as the VPC/firewalls in
+		// gcp.go: Pulumi's default resource ID already prefixes it with
+		// <pulumi-project>-<stack>, which includes projectName, so repeating it here
+		// risked exceeding GCP's 63-char resource ID limit.
+		if _, err := certificatemanager.NewCertificateMapEntry(ctx, "cert-map-entry",
 			&certificatemanager.CertificateMapEntryArgs{
 				Map:          certMap.Name,
 				Certificates: pulumi.StringArray{config.WildcardCertId},
@@ -128,22 +132,21 @@ func createExternalLoadBalancers(
 		}
 	}
 
-	urlMap, err := buildURLMap(ctx, projectName, ingressEntries, config.Region, opts...)
+	urlMap, err := buildURLMap(ctx, ingressEntries, config.Region, opts...)
 	if err != nil {
 		return err
 	}
 
-	if err := createHTTPSForwardingRule(ctx, projectName, config.PublicIP, urlMap, certMap, opts...); err != nil {
+	if err := createHTTPSForwardingRule(ctx, config.PublicIP, urlMap, certMap, opts...); err != nil {
 		return err
 	}
 
-	return createHTTPRedirectForwardingRule(ctx, projectName, config.PublicIP, opts...)
+	return createHTTPRedirectForwardingRule(ctx, config.PublicIP, opts...)
 }
 
 //nolint:funlen,maintidx
 func createInternalLoadBalancer(
 	ctx *pulumi.Context,
-	projectName string,
 	config *SharedInfra,
 	services []LBServiceEntry,
 	opts ...pulumi.ResourceOption,
@@ -154,9 +157,13 @@ func createInternalLoadBalancer(
 	var privatePathMatchers compute.RegionUrlMapPathMatcherArray
 	for _, service := range services {
 		// Managed services: always create private DNS regardless of ports.
+		// Logical names below deliberately omit projectName: Pulumi's default
+		// resource ID already prefixes it with <pulumi-project>-<stack>, which
+		// includes projectName, so repeating it here risked exceeding GCP's
+		// 63-char resource ID limit.
 		switch {
 		case service.Config.Postgres != nil:
-			if _, err := dns.NewRecordSet(ctx, projectName+"-"+service.Name+"-private-db-dns", &dns.RecordSetArgs{
+			if _, err := dns.NewRecordSet(ctx, service.Name+"-private-db-dns", &dns.RecordSetArgs{
 				Name:        pulumi.String(internalServiceDns(service.Name)),
 				Type:        pulumi.String("A"),
 				Ttl:         pulumi.Int(60),
@@ -167,7 +174,7 @@ func createInternalLoadBalancer(
 			}
 			continue
 		case service.Config.Redis != nil:
-			if _, err := dns.NewRecordSet(ctx, projectName+"-"+service.Name+"-private-redis-dns", &dns.RecordSetArgs{
+			if _, err := dns.NewRecordSet(ctx, service.Name+"-private-redis-dns", &dns.RecordSetArgs{
 				Name:        pulumi.String(internalServiceDns(service.Name)),
 				Type:        pulumi.String("A"),
 				Ttl:         pulumi.Int(60),
@@ -194,6 +201,7 @@ func createInternalLoadBalancer(
 						Service: pulumi.StringPtrInput(service.CloudRunService.Name),
 					},
 				},
+				opts...,
 			)
 			if err != nil {
 				return err
@@ -212,6 +220,7 @@ func createInternalLoadBalancer(
 						},
 					},
 				},
+				opts...,
 			)
 			if err != nil {
 				return err
@@ -264,6 +273,7 @@ func createInternalLoadBalancer(
 						},
 						Direction: pulumi.String("INGRESS"),
 					},
+					opts...,
 				)
 				if err != nil {
 					return err
@@ -279,7 +289,7 @@ func createInternalLoadBalancer(
 							RequestPath: pulumi.String(healthCheckPath),
 						},
 					},
-					pulumi.DependsOn([]pulumi.Resource{firewall}),
+					append(opts, pulumi.DependsOn([]pulumi.Resource{firewall}))...,
 				)
 				if err != nil {
 					return err
@@ -298,6 +308,7 @@ func createInternalLoadBalancer(
 						HealthChecks: healthCheck.ID(),
 						PortName:     pulumi.String(fmt.Sprintf("port-%v-%v", portProto, port.Target)), // Matching compute.go
 					},
+					opts...,
 				)
 				if err != nil {
 					return err
@@ -330,6 +341,7 @@ func createInternalLoadBalancer(
 						Region:      pulumi.String(config.Region),
 						Purpose:     pulumi.String("SHARED_LOADBALANCER_VIP"),
 					},
+					opts...,
 				)
 				if err != nil {
 					return err
@@ -371,13 +383,18 @@ func createInternalLoadBalancer(
 						},
 						Direction: pulumi.String("INGRESS"),
 					},
+					opts...,
 				)
 				if err != nil {
 					return err
 				}
 
+				// "-hc" distinguishes this from trafficFirewall above: both are
+				// gcp:compute/firewall:Firewall for the same service, so they can't
+				// share trafficFirewall's bare service.Name -- Pulumi rejects that
+				// as a duplicate URN (same type + name + parent).
 				healthCheckFirewall, err := compute.NewFirewall(ctx,
-					service.Name,
+					service.Name+"-hc",
 					&compute.FirewallArgs{
 						Network: config.VpcId,
 						// Fixed health check IP ranges for internal passthrough NLB:
@@ -395,6 +412,7 @@ func createInternalLoadBalancer(
 						},
 						Direction: pulumi.String("INGRESS"),
 					},
+					opts...,
 				)
 				if err != nil {
 					return err
@@ -412,7 +430,7 @@ func createInternalLoadBalancer(
 							Port: pulumi.Int(*tcpHealthCheckPort),
 						},
 					},
-					pulumi.DependsOn([]pulumi.Resource{healthCheckFirewall}),
+					append(opts, pulumi.DependsOn([]pulumi.Resource{healthCheckFirewall}))...,
 				)
 				if err != nil {
 					return err
@@ -426,9 +444,16 @@ func createInternalLoadBalancer(
 					// https://cloud.google.com/load-balancing/docs/forwarding-rule-concepts#port_specifications
 					for ports := range slices.Chunk(allPorts, 5) {
 						portsName := strings.Trim(strings.ReplaceAll(fmt.Sprint(ports), " ", "-"), "[]")
+						// No "-backend-service"/"-forwarding-rule" suffix (the type token
+						// already says what each is); protocol is included since two
+						// protocols can chunk to the same port set, which would otherwise
+						// collide on a shared logical name (a live smoketest, defang-mvp#3181,
+						// hit this bug's sibling missing-separator variant: "smokeworkerhost-
+						// 6379-backend-service", also 68 chars -- one more reason to keep it
+						// short instead of just re-adding a "-" before "host").
+						name := fmt.Sprintf("%s-%s-%s", service.Name, strings.ToLower(string(protocol)), portsName)
 
-						backendService, err := compute.NewRegionBackendService(ctx,
-							service.Name+fmt.Sprintf("host-%v-backend-service", portsName),
+						backendService, err := compute.NewRegionBackendService(ctx, name,
 							&compute.RegionBackendServiceArgs{
 								Region:              pulumi.String(config.Region),
 								LoadBalancingScheme: pulumi.String("INTERNAL"),
@@ -443,6 +468,7 @@ func createInternalLoadBalancer(
 								ConnectionDrainingTimeoutSec: pulumi.Int(0), // Make configurable?
 								HealthChecks:                 healthCheck.ID(),
 							},
+							opts...,
 						)
 						if err != nil {
 							return err
@@ -453,8 +479,7 @@ func createInternalLoadBalancer(
 							portsInput = append(portsInput, pulumi.String(strconv.FormatUint(uint64(port), 10)))
 						}
 						// Create a forwarding rule
-						_, err = compute.NewForwardingRule(ctx,
-							service.Name+fmt.Sprintf("host-%v-forwarding-rule", portsName),
+						_, err = compute.NewForwardingRule(ctx, name,
 							&compute.ForwardingRuleArgs{
 								LoadBalancingScheme: pulumi.String("INTERNAL"),
 								IpProtocol:          pulumi.String(strings.ToUpper(string(protocol))),
@@ -466,6 +491,7 @@ func createInternalLoadBalancer(
 								// Multiple forwarding rules share the same IP so internal DNS works.
 								IpAddress: internalNlbIP.Address,
 							},
+							opts...,
 						)
 						if err != nil {
 							return err
@@ -473,13 +499,13 @@ func createInternalLoadBalancer(
 					}
 				}
 
-				if _, err := dns.NewRecordSet(ctx, projectName+"-"+service.Name+"-private-lb-dns", &dns.RecordSetArgs{
+				if _, err := dns.NewRecordSet(ctx, service.Name+"-private-lb-dns", &dns.RecordSetArgs{
 					Name:        pulumi.String(internalServiceDns(service.Name)),
 					Type:        pulumi.String("A"),
 					Ttl:         pulumi.Int(60),
 					ManagedZone: config.PrivateZone,
 					Rrdatas:     pulumi.StringArray{internalNlbIP.Address},
-				}, pulumi.DependsOn([]pulumi.Resource{trafficFirewall})); err != nil {
+				}, append(opts, pulumi.DependsOn([]pulumi.Resource{trafficFirewall}))...); err != nil {
 					return err
 				}
 			}
@@ -504,6 +530,7 @@ func createInternalLoadBalancer(
 					Role:        pulumi.String("ACTIVE"),
 					Network:     config.VpcId,
 				},
+				opts...,
 			)
 		}
 		if err != nil {
@@ -518,6 +545,7 @@ func createInternalLoadBalancer(
 				HostRules:      privateHostRules,
 				PathMatchers:   privatePathMatchers,
 			},
+			opts...,
 		)
 		if err != nil {
 			return err
@@ -529,7 +557,7 @@ func createInternalLoadBalancer(
 				Region: pulumi.String(config.Region),
 				UrlMap: privateUrlMap.SelfLink,
 			},
-			pulumi.DependsOn([]pulumi.Resource{regionalManagedProxySubnet}),
+			append(opts, pulumi.DependsOn([]pulumi.Resource{regionalManagedProxySubnet}))...,
 		)
 		if err != nil {
 			return err
@@ -545,19 +573,19 @@ func createInternalLoadBalancer(
 				PortRange:           pulumi.String("80"),
 				LoadBalancingScheme: pulumi.String("INTERNAL_MANAGED"),
 			},
-			pulumi.DependsOn([]pulumi.Resource{regionalManagedProxySubnet}),
+			append(opts, pulumi.DependsOn([]pulumi.Resource{regionalManagedProxySubnet}))...,
 		)
 		if err != nil {
 			return err
 		}
 		for _, serviceName := range internalAlbServices {
-			if _, err := dns.NewRecordSet(ctx, projectName+"-"+serviceName+"-private-lb-dns", &dns.RecordSetArgs{
+			if _, err := dns.NewRecordSet(ctx, serviceName+"-private-lb-dns", &dns.RecordSetArgs{
 				Name:        pulumi.String(internalServiceDns(serviceName)),
 				Type:        pulumi.String("A"),
 				Ttl:         pulumi.Int(60),
 				ManagedZone: config.PrivateZone,
 				Rrdatas:     pulumi.StringArray{forwardingRule.IpAddress},
-			}); err != nil {
+			}, opts...); err != nil {
 				return err
 			}
 		}
@@ -589,12 +617,15 @@ func newCertMap(
 	args := &certificatemanager.CertificateMapResourceArgs{
 		Description: pulumi.String(projectName + " public load balancer certificate map"),
 	}
-	return certificatemanager.NewCertificateMapResource(ctx, projectName+"-cert-map", args, opts...)
+	// Logical name deliberately omits projectName: Pulumi's default resource ID
+	// already prefixes it with <pulumi-project>-<stack>, which includes
+	// projectName, so repeating it here risked exceeding GCP's 63-char resource
+	// ID limit.
+	return certificatemanager.NewCertificateMapResource(ctx, "cert-map", args, opts...)
 }
 
 func buildURLMap(
 	ctx *pulumi.Context,
-	projectName string,
 	entries []LBServiceEntry,
 	region string,
 	opts ...pulumi.ResourceOption,
@@ -622,7 +653,11 @@ func buildURLMap(
 		}
 	}
 
-	return compute.NewURLMap(ctx, projectName+"-urlmap", &compute.URLMapArgs{
+	// Logical name deliberately omits projectName: Pulumi's default resource ID
+	// already prefixes it with <pulumi-project>-<stack>, which includes
+	// projectName, so repeating it here risked exceeding GCP's 63-char resource
+	// ID limit.
+	return compute.NewURLMap(ctx, "urlmap", &compute.URLMapArgs{
 		DefaultService: firstBackendID,
 		HostRules:      hostRules,
 		PathMatchers:   pathMatchers,
@@ -754,9 +789,12 @@ func migBackend(entry LBServiceEntry) *compute.BackendServiceBackendArgs {
 	return backend
 }
 
+// Logical names in createHTTPSForwardingRule and createHTTPRedirectForwardingRule
+// deliberately omit projectName: Pulumi's default resource ID already prefixes it
+// with <pulumi-project>-<stack>, which includes projectName, so repeating it here
+// risked exceeding GCP's 63-char resource ID limit.
 func createHTTPSForwardingRule(
 	ctx *pulumi.Context,
-	projectName string,
 	publicIP *compute.GlobalAddress,
 	urlMap *compute.URLMap,
 	certMap *certificatemanager.CertificateMapResource,
@@ -766,7 +804,7 @@ func createHTTPSForwardingRule(
 		return fmt.Sprintf("//certificatemanager.googleapis.com/%v", id), nil
 	}).(pulumi.StringOutput)
 
-	httpsProxy, err := compute.NewTargetHttpsProxy(ctx, projectName+"-https-proxy",
+	httpsProxy, err := compute.NewTargetHttpsProxy(ctx, "https-proxy",
 		&compute.TargetHttpsProxyArgs{
 			UrlMap:         urlMap.SelfLink,
 			CertificateMap: certMapRef,
@@ -775,7 +813,7 @@ func createHTTPSForwardingRule(
 		return err
 	}
 
-	_, err = compute.NewGlobalForwardingRule(ctx, projectName+"-https-rule",
+	_, err = compute.NewGlobalForwardingRule(ctx, "https-rule",
 		&compute.GlobalForwardingRuleArgs{
 			Target:              httpsProxy.SelfLink,
 			IpAddress:           publicIP.Address,
@@ -787,11 +825,10 @@ func createHTTPSForwardingRule(
 
 func createHTTPRedirectForwardingRule(
 	ctx *pulumi.Context,
-	projectName string,
 	publicIP *compute.GlobalAddress,
 	opts ...pulumi.ResourceOption,
 ) error {
-	redirectMap, err := compute.NewURLMap(ctx, projectName+"-http-urlmap",
+	redirectMap, err := compute.NewURLMap(ctx, "http-urlmap",
 		&compute.URLMapArgs{
 			DefaultUrlRedirect: &compute.URLMapDefaultUrlRedirectArgs{
 				HttpsRedirect:        pulumi.Bool(true),
@@ -803,13 +840,13 @@ func createHTTPRedirectForwardingRule(
 		return err
 	}
 
-	httpProxy, err := compute.NewTargetHttpProxy(ctx, projectName+"-http-proxy",
+	httpProxy, err := compute.NewTargetHttpProxy(ctx, "http-proxy",
 		&compute.TargetHttpProxyArgs{UrlMap: redirectMap.ID()}, opts...)
 	if err != nil {
 		return err
 	}
 
-	_, err = compute.NewGlobalForwardingRule(ctx, projectName+"-http-rule",
+	_, err = compute.NewGlobalForwardingRule(ctx, "http-rule",
 		&compute.GlobalForwardingRuleArgs{
 			IpAddress:           publicIP.Address,
 			IpProtocol:          pulumi.String("TCP"),

--- a/provider/defanggcp/gcp/alb_test.go
+++ b/provider/defanggcp/gcp/alb_test.go
@@ -14,6 +14,7 @@ type albResource struct {
 	name   string
 	typeof string
 	inputs resource.PropertyMap
+	parent string
 }
 
 type albMocks struct {
@@ -21,7 +22,13 @@ type albMocks struct {
 }
 
 func (m *albMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
-	m.resources = append(m.resources, albResource{name: args.Name, typeof: args.TypeToken, inputs: args.Inputs})
+	var parent string
+	if args.RegisterRPC != nil {
+		parent = args.RegisterRPC.GetParent()
+	}
+	m.resources = append(m.resources, albResource{
+		name: args.Name, typeof: args.TypeToken, inputs: args.Inputs, parent: parent,
+	})
 	return args.Name + "_id", args.Inputs, nil
 }
 
@@ -100,6 +107,82 @@ func TestCreateLoadBalancersMIGMultipleIngressPortsReturnsActionableError(t *tes
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "service api has multiple ingress ports")
 	require.Contains(t, err.Error(), "use at most one ingress port")
+}
+
+// createInternalLoadBalancer's host-mode branch (a single non-ingress TCP
+// port, e.g. a Redis-like service on 6379) never forwarded opts to any of
+// the resources it creates. Live smoketest result (defang-mvp#3181): every
+// one of them tried to use the ambient default "gcp" provider instead of the
+// explicit one this stack configures, and defang-playground-dev disables
+// that default -- "Default provider for 'gcp' disabled ... must use an
+// explicit provider." This exercises the exact failing shape and asserts
+// opts (here, an explicit Parent) actually reaches each resource.
+func TestCreateLoadBalancersHostModePropagatesOpts(t *testing.T) {
+	mocks := &albMocks{}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		mig, err := testMIG(ctx, "smokeworker")
+		if err != nil {
+			return err
+		}
+		parent, err := compute.NewNetwork(ctx, "test-parent", &compute.NetworkArgs{})
+		if err != nil {
+			return err
+		}
+		return CreateLoadBalancers(ctx, "proj", []LBServiceEntry{{
+			Name:          "smokeworker",
+			InstanceGroup: mig,
+			PrivateFqdn:   "smokeworker.google.internal",
+			Config: testServiceConfig([]compose.ServicePortConfig{
+				{Target: 6379, Mode: compose.PortModeHost},
+			}),
+		}}, testInfra(ctx), pulumi.Parent(parent))
+	}, pulumi.WithMocks("proj", "stack", mocks))
+	require.NoError(t, err)
+
+	for _, typ := range []string{
+		"gcp:compute/address:Address",
+		"gcp:compute/firewall:Firewall",
+		"gcp:compute/healthCheck:HealthCheck",
+		"gcp:compute/regionBackendService:RegionBackendService",
+		"gcp:compute/forwardingRule:ForwardingRule",
+	} {
+		found := false
+		for _, r := range mocks.resources {
+			if r.typeof == typ {
+				found = true
+				// Pulumi always assigns *some* parent (the implicit stack
+				// pseudo-resource when none is given), so a plain non-empty
+				// check would pass even with opts dropped -- assert it's
+				// specifically our explicit parent.
+				require.Contains(t, r.parent, "test-parent",
+					"%s %q has parent %q, not the explicit one from opts -- opts not propagated", typ, r.name, r.parent)
+			}
+		}
+		require.True(t, found, "no resource of type %s was created", typ)
+	}
+
+	// Two firewalls exist for one host-mode service (traffic + health-check
+	// source ranges): a live smoketest hit "Duplicate resource URN" because
+	// both used the bare service name. Pulumi's mocks don't enforce URN
+	// uniqueness themselves, so check it explicitly.
+	seen := map[string]bool{}
+	for _, r := range mocks.resources {
+		key := r.typeof + "::" + r.name
+		require.False(t, seen[key], "duplicate resource: type=%s name=%q", r.typeof, r.name)
+		seen[key] = true
+	}
+
+	// A live smoketest hit "smokeworkerhost-6379-backend-service" (68 chars,
+	// over GCP's 63-char limit) from a missing separator plus a redundant
+	// "-backend-service" type suffix. Assert the fixed, protocol-qualified
+	// name (protocol matters: two protocols chunking to the same port set
+	// would otherwise collide on one logical name).
+	for _, typ := range []string{
+		"gcp:compute/regionBackendService:RegionBackendService",
+		"gcp:compute/forwardingRule:ForwardingRule",
+	} {
+		requireResource(t, mocks.resources, typ, "smokeworker-tcp-6379")
+	}
 }
 
 func testInfra(ctx *pulumi.Context) *SharedInfra {

--- a/provider/defanggcp/gcp/artifact_registry.go
+++ b/provider/defanggcp/gcp/artifact_registry.go
@@ -3,11 +3,12 @@ package gcp
 import (
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/DefangLabs/pulumi-defang/provider/common"
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/artifactregistry"
-	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/config"
+	gcpconfig "github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/config"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/projects"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/serviceaccount"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/storage"
@@ -84,25 +85,43 @@ func collectExternalRegistries(services map[string]compose.ServiceConfig) []stri
 	return result
 }
 
+// artifactRegistryRepositoryID returns the explicit physical ID required by
+// the Artifact Registry API. Pulumi cannot auto-name this property, so mirror
+// the configured autonaming rule when present: AutonamingPrefix already
+// checks for one and returns logicalName unchanged when none is set, so that
+// no-op return is what tells us to fall back to the legacy prefix/project/
+// stack scoping ourselves instead of re-parsing the pulumi:autonaming config.
+func artifactRegistryRepositoryID(ctx *pulumi.Context, projectName, logicalName string) string {
+	name := common.AutonamingPrefix(ctx, logicalName)
+	if name == logicalName {
+		parts := make([]string, 0, 4)
+		if prefix := common.Prefix.Get(ctx); prefix != "" {
+			parts = append(parts, prefix)
+		}
+		parts = append(parts, projectName, ctx.Stack(), logicalName)
+		name = strings.Join(parts, "-")
+	}
+	return sanitizeRepoName(name)
+}
+
 // createRemoteRepos creates Artifact Registry REMOTE repositories that act as
 // pull-through caches for external Docker registries not natively supported by
-// Cloud Run. One repository is created per unique registry. The repository ID
-// matches sanitizeRepoName(registry), which is the same name GetServiceImage
-// uses when rewriting image references.
+// Cloud Run. One stack-scoped repository is created per unique registry.
 func createRemoteRepos(
 	ctx *pulumi.Context,
+	projectName string,
 	registries []string,
 	opts ...pulumi.ResourceOption,
 ) (map[string]*artifactregistry.Repository, error) {
 	repos := make(map[string]*artifactregistry.Repository, len(registries))
 	for _, registry := range registries {
-		repoId := sanitizeRepoName(registry)
+		repoID := artifactRegistryRepositoryID(ctx, projectName, registry)
 		repo, err := artifactregistry.NewRepository(ctx, registry, &artifactregistry.RepositoryArgs{
 			// RepositoryId must be set explicitly. Some AWS resources say "if omitted, the provider
 			// will assign a random, unique name" (e.g. https://www.pulumi.com/registry/packages/aws/api-docs/s3/bucket/),
 			// but the GCP Artifact Registry docs make no such promise:
 			// https://www.pulumi.com/registry/packages/gcp/api-docs/artifactregistry/repository/
-			RepositoryId: pulumi.String(repoId),
+			RepositoryId: pulumi.String(repoID),
 			// Location:     pulumi.String(region),
 			Description: pulumi.String("Remote pull-through cache for " + registry),
 			Format:      pulumi.String("DOCKER"),
@@ -112,7 +131,9 @@ func createRemoteRepos(
 					Uri: pulumi.String("https://" + registry),
 				},
 			},
-		}, append(opts, pulumi.RetainOnDelete(true))...)
+			// Remote repositories contain only an upstream cache. Delete them normally;
+			// retaining one after `down` leaves an untracked ID that blocks the next `up`.
+		}, opts...)
 		if err != nil {
 			return nil, fmt.Errorf("creating remote repository for %s: %w", registry, err)
 		}
@@ -134,7 +155,7 @@ func createBuildInfra(
 	opts ...pulumi.ResourceOption,
 ) (*BuildInfra, error) {
 	region := GcpRegion(ctx)
-	gcpProject := config.GetProject(ctx)
+	gcpProject := gcpconfig.GetProject(ctx)
 
 	bsa, err := serviceaccount.NewAccount(ctx, "builder", &serviceaccount.AccountArgs{
 		DisplayName: pulumi.String("Image build service account for " + projectName),
@@ -145,7 +166,7 @@ func createBuildInfra(
 
 	ar, err := artifactregistry.NewRepository(ctx, "repo", &artifactregistry.RepositoryArgs{
 		// RepositoryId is required by the GCP API; unlike AWS, GCP does not auto-generate resource IDs.
-		RepositoryId: pulumi.String(sanitizeRepoName(projectName)),
+		RepositoryId: pulumi.String(artifactRegistryRepositoryID(ctx, projectName, "repo")),
 		Location:     pulumi.String(region),
 		Description:  pulumi.String("Docker images for " + projectName),
 		Format:       pulumi.String("DOCKER"),
@@ -157,15 +178,22 @@ func createBuildInfra(
 	saOpts := make([]pulumi.ResourceOption, 0, len(opts)+1)
 	saOpts = append(append(saOpts, opts...), pulumi.DeleteBeforeReplace(true))
 
+	// Project is deliberately omitted: RepositoryIamBinding falls back to the
+	// provider's configured project when unset (unlike projects.IAMMember
+	// below, whose Project field is required and not inferred from the
+	// provider -- see https://github.com/DefangLabs/pulumi-defang/pull/423#discussion_r3832857083).
 	repoIAMArgs := &artifactregistry.RepositoryIamBindingArgs{
 		Location:   pulumi.String(region),
-		Project:    pulumi.String(gcpProject),
 		Repository: ar.Name,
 		Role:       pulumi.String("roles/artifactregistry.admin"),
 		Members:    pulumi.StringArray{pulumi.Sprintf("serviceAccount:%v", bsa.Email)},
 	}
+	// Logical names below deliberately omit projectName, same as the VPC/firewalls
+	// in gcp.go: Pulumi's default resource ID already prefixes it with
+	// <pulumi-project>-<stack>, which includes projectName, so repeating it here
+	// risked exceeding GCP's 63-char resource ID limit.
 	if _, err := artifactregistry.NewRepositoryIamBinding(
-		ctx, projectName, repoIAMArgs, saOpts...,
+		ctx, "registry-admin", repoIAMArgs, saOpts...,
 	); err != nil {
 		return nil, fmt.Errorf("binding artifact registry admin role: %w", err)
 	}
@@ -178,7 +206,7 @@ func createBuildInfra(
 	sourceBucket := cdSourceBucket(ctx)
 	var sourceViewer *storage.BucketIAMMember
 	if sourceBucket != "" {
-		sourceViewer, err = storage.NewBucketIAMMember(ctx, projectName+"-source-viewer", &storage.BucketIAMMemberArgs{
+		sourceViewer, err = storage.NewBucketIAMMember(ctx, "source-viewer", &storage.BucketIAMMemberArgs{
 			Bucket: pulumi.String(sourceBucket),
 			Role:   pulumi.String("roles/storage.objectViewer"),
 			Member: pulumi.Sprintf("serviceAccount:%v", bsa.Email),
@@ -188,7 +216,7 @@ func createBuildInfra(
 		}
 	}
 
-	if _, err := projects.NewIAMMember(ctx, projectName+"-logWriter", &projects.IAMMemberArgs{
+	if _, err := projects.NewIAMMember(ctx, "logWriter", &projects.IAMMemberArgs{
 		Project: pulumi.String(gcpProject),
 		Role:    pulumi.String("roles/logging.logWriter"),
 		Member:  pulumi.Sprintf("serviceAccount:%v", bsa.Email),
@@ -196,7 +224,7 @@ func createBuildInfra(
 		return nil, fmt.Errorf("binding logging.logWriter role: %w", err)
 	}
 
-	if _, err := projects.NewIAMMember(ctx, projectName+"-bucketWriter", &projects.IAMMemberArgs{
+	if _, err := projects.NewIAMMember(ctx, "bucketWriter", &projects.IAMMemberArgs{
 		Project: pulumi.String(gcpProject),
 		Role:    pulumi.String("roles/logging.bucketWriter"),
 		Member:  pulumi.Sprintf("serviceAccount:%v", bsa.Email),
@@ -204,7 +232,7 @@ func createBuildInfra(
 		return nil, fmt.Errorf("binding logging.bucketWriter role: %w", err)
 	}
 
-	repoURL := pulumi.Sprintf("%s-docker.pkg.dev/%s/%s", region, gcpProject, ar.Name)
+	repoURL := pulumi.Sprintf("%s-docker.pkg.dev/%s/%s", region, gcpProject, ar.RepositoryId)
 
 	return &BuildInfra{
 		Repository:      ar,

--- a/provider/defanggcp/gcp/artifact_registry_test.go
+++ b/provider/defanggcp/gcp/artifact_registry_test.go
@@ -1,12 +1,172 @@
 package gcp
 
 import (
+	"strings"
+	"sync"
 	"testing"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const ghcrRegistry = "ghcr.io"
+
+// pulumiAutonamingConfigKey is the stack config key AutonamingPrefix reads.
+// Shared across test files so the literal isn't repeated (goconst).
+const pulumiAutonamingConfigKey = "pulumi:autonaming"
+
+type artifactRepositoryRegistration struct {
+	logicalName    string
+	repositoryID   string
+	retainOnDelete bool
+}
+
+type artifactRepositoryMocks struct {
+	mu           sync.Mutex
+	repositories []artifactRepositoryRegistration
+}
+
+func (m *artifactRepositoryMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+	outputs := args.Inputs.Copy()
+	if args.TypeToken == "gcp:artifactregistry/repository:Repository" {
+		registration := artifactRepositoryRegistration{
+			logicalName:  args.Name,
+			repositoryID: args.Inputs["repositoryId"].StringValue(),
+		}
+		if args.RegisterRPC != nil {
+			registration.retainOnDelete = args.RegisterRPC.GetRetainOnDelete()
+		}
+
+		m.mu.Lock()
+		m.repositories = append(m.repositories, registration)
+		m.mu.Unlock()
+
+		outputs["name"] = resource.NewStringProperty(
+			"projects/gcp-project/locations/us-central1/repositories/" + registration.repositoryID,
+		)
+	}
+	if args.TypeToken == "gcp:serviceaccount/account:Account" {
+		outputs["email"] = resource.NewStringProperty(args.Name + "@gcp-project.iam.gserviceaccount.com")
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	}
+	if args.TypeToken == "gcp:storage/bucket:Bucket" {
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	}
+	return args.Name + "_id", outputs, nil
+}
+
+func (m *artifactRepositoryMocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
+	return args.Args, nil
+}
+
+func withPulumiConfig(config map[string]string) pulumi.RunOption {
+	return func(info *pulumi.RunInfo) {
+		info.Config = config
+	}
+}
+
+func repositoryIDForTest(
+	t *testing.T,
+	stack, composeProject, logicalName string,
+	config map[string]string,
+) string {
+	t.Helper()
+
+	var repositoryID string
+	opts := []pulumi.RunOption{pulumi.WithMocks("pulumi-project", stack, testMocks{})}
+	if config != nil {
+		opts = append(opts, withPulumiConfig(config))
+	}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		repositoryID = artifactRegistryRepositoryID(ctx, composeProject, logicalName)
+		return nil
+	}, opts...)
+	require.NoError(t, err)
+	return repositoryID
+}
+
+func TestArtifactRegistryRepositoryIDFallsBackToLegacyScope(t *testing.T) {
+	devID := repositoryIDForTest(t, "dev", "compose-project", "repo", nil)
+	prodID := repositoryIDForTest(t, "prod", "compose-project", "repo", nil)
+	renamedID := repositoryIDForTest(t, "dev", "renamed-project", "repo", nil)
+
+	assert.Equal(t, "defang-compose-project-dev-repo", devID)
+	assert.Equal(t, "defang-compose-project-prod-repo", prodID)
+	assert.Equal(t, "defang-renamed-project-dev-repo", renamedID)
+	assert.NotEqual(t, devID, prodID)
+	assert.NotEqual(t, devID, renamedID)
+}
+
+func TestArtifactRegistryRepositoryIDHonorsCustomAutonaming(t *testing.T) {
+	config := map[string]string{
+		pulumiAutonamingConfigKey: `{"pattern":"Custom-${project}-${stack}-${name}-${hex(7)}"}`,
+	}
+
+	repositoryID := repositoryIDForTest(t, "dev", "compose-project", "repo", config)
+	assert.Equal(t, "custom-pulumi-project-dev-repo", repositoryID)
+}
+
+func TestArtifactRegistryRepositoryIDCustomLongNamesAreTruncated(t *testing.T) {
+	config := map[string]string{
+		pulumiAutonamingConfigKey: `{"pattern":"${project}-${stack}-${name}-${hex(7)}"}`,
+	}
+	commonPrefix := strings.Repeat("long", 20)
+
+	firstID := repositoryIDForTest(t, "dev", "compose-project", commonPrefix+"first", config)
+
+	require.Len(t, firstID, artifactRegistryRepositoryIDMaxLength)
+	assert.Equal(t, firstID, repositoryIDForTest(t, "dev", "compose-project", commonPrefix+"first", config),
+		"repository IDs must be deterministic")
+}
+
+func TestCreateRemoteReposKeepsLogicalNameAndDoesNotRetain(t *testing.T) {
+	mocks := &artifactRepositoryMocks{}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		_, err := createRemoteRepos(ctx, "compose-project", []string{ghcrRegistry})
+		return err
+	}, pulumi.WithMocks("pulumi-project", "dev", mocks))
+	require.NoError(t, err)
+
+	require.Len(t, mocks.repositories, 1)
+	assert.Equal(t, artifactRepositoryRegistration{
+		logicalName:    ghcrRegistry,
+		repositoryID:   "defang-compose-project-dev-ghcr-io",
+		retainOnDelete: false,
+	}, mocks.repositories[0])
+}
+
+func TestCreateBuildInfraUsesScopedRepositoryIDInImageURL(t *testing.T) {
+	mocks := &artifactRepositoryMocks{}
+	url := make(chan string, 1)
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		infra, err := createBuildInfra(ctx, "compose-project")
+		if err != nil {
+			return err
+		}
+		infra.RepositoryURL.ApplyT(func(repositoryURL string) string {
+			url <- repositoryURL
+			return repositoryURL
+		})
+		return nil
+	},
+		pulumi.WithMocks("pulumi-project", "dev", mocks),
+		withPulumiConfig(map[string]string{"gcp:project": "gcp-project"}),
+	)
+	require.NoError(t, err)
+
+	require.Len(t, mocks.repositories, 1)
+	assert.Equal(t, artifactRepositoryRegistration{
+		logicalName:    "repo",
+		repositoryID:   "defang-compose-project-dev-repo",
+		retainOnDelete: false,
+	}, mocks.repositories[0])
+	assert.Equal(t,
+		"us-central1-docker.pkg.dev/gcp-project/defang-compose-project-dev-repo",
+		<-url,
+	)
+}
 
 // TestCdSourceBucket checks that the shared CD bucket is parsed out of the
 // defang:stateUrl config the CD program sets from DEFANG_STATE_URL, and that a

--- a/provider/defanggcp/gcp/compute.go
+++ b/provider/defanggcp/gcp/compute.go
@@ -9,6 +9,7 @@ import (
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/compute"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/projects"
+	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/secretmanager"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -39,6 +40,7 @@ type ComputeEngineArgs struct {
 // run on Cloud Run (e.g. background workers with no listening port).
 func CreateComputeEngine(
 	ctx *pulumi.Context,
+	configProvider compose.ConfigProvider,
 	serviceName string,
 	image pulumi.StringInput,
 	svc compose.ServiceConfig,
@@ -56,6 +58,20 @@ func CreateComputeEngine(
 			"roles/monitoring.metricWriter",
 			"roles/cloudtrace.agent",
 		}, gcpConfig, parentOpt)
+	}
+
+	// Classify each container's env into inline values and native secret refs,
+	// then grant the instance SA access to every referenced secret. Bare ${VAR}
+	// / null "KEY:" values are boot-fetched (see secretFetchScript) rather than
+	// embedded in instance metadata.
+	mainPlan := classifyComputeSecretEnv(ctx, configProvider, svc.Environment)
+	sidecarPlans := make(map[string]containerSecretPlan, len(args.Sidecars))
+	for name, sc := range args.Sidecars {
+		sidecarPlans[name] = classifyComputeSecretEnv(ctx, configProvider, sc.Environment)
+	}
+	secretMembers, err := grantSecretAccess(ctx, serviceName, args.SA, mainPlan, sidecarPlans, parentOpt)
+	if err != nil {
+		return nil, err
 	}
 
 	namedPorts := make(compute.RegionInstanceGroupManagerNamedPortArray, len(svc.Ports))
@@ -83,11 +99,16 @@ func CreateComputeEngine(
 	fqdn := common.ServiceFQDN(serviceName, svc, gcpConfig.Domain, "google.internal")
 	cloudInit := getCloudInitConfig(
 		serviceName, image, svc, gcpConfig.Region, gcpConfig.Etag, gcpConfig.ProjectName, gcpConfig.Stack, fqdn,
-		addHealthCheckSidecar, args.Sidecars)
+		gcpConfig.GcpProject, addHealthCheckSidecar, args.Sidecars, mainPlan, sidecarPlans)
 
+	// The instance template must depend on the secret IAM bindings so instances
+	// don't boot (and run the fetch script) before they can read the secrets.
 	templateOpts := []pulumi.ResourceOption{parentOpt}
-	if len(args.PolicyDeps) > 0 {
-		templateOpts = append(templateOpts, pulumi.DependsOn(args.PolicyDeps))
+	templateDeps := make([]pulumi.Resource, 0, len(args.PolicyDeps)+len(secretMembers))
+	templateDeps = append(templateDeps, args.PolicyDeps...)
+	templateDeps = append(templateDeps, secretMembers...)
+	if len(templateDeps) > 0 {
+		templateOpts = append(templateOpts, pulumi.DependsOn(templateDeps))
 	}
 	instanceTemplate, err := createInstanceTemplate(
 		ctx, serviceName, serviceName, machineType, getComputeBootImage(svc), cloudInit,
@@ -340,6 +361,52 @@ func buildMIGUpdatePolicy(numZones, targetSize int) *compute.RegionInstanceGroup
 	return policy
 }
 
+// grantSecretAccess grants the instance service account
+// roles/secretmanager.secretAccessor on every Secret Manager secret referenced
+// (as a bare ${VAR} or null "KEY:") by the main container or any sidecar, so the
+// boot-time fetch script can read them. Secret IDs are deduped across
+// containers. Returns the created members for use as instance-template
+// dependencies.
+func grantSecretAccess(
+	ctx *pulumi.Context,
+	serviceName string,
+	sa *ServiceIdentity,
+	mainPlan containerSecretPlan,
+	sidecarPlans map[string]containerSecretPlan,
+	parentOpt pulumi.ResourceOrInvokeOption,
+) ([]pulumi.Resource, error) {
+	seen := make(map[string]struct{})
+	var ids []string
+	collect := func(plan containerSecretPlan) {
+		for _, r := range plan.secretRefs {
+			if _, ok := seen[r.secretID]; !ok {
+				seen[r.secretID] = struct{}{}
+				ids = append(ids, r.secretID)
+			}
+		}
+	}
+	collect(mainPlan)
+	for _, plan := range common.Sorted(sidecarPlans) {
+		collect(plan)
+	}
+
+	var members []pulumi.Resource
+	for _, sid := range ids {
+		opts := append([]pulumi.ResourceOption{parentOpt}, sa.deleteOpts()...)
+		member, err := secretmanager.NewSecretIamMember(ctx, serviceName+"-secret-"+sid,
+			&secretmanager.SecretIamMemberArgs{
+				SecretId: pulumi.String(sid),
+				Role:     pulumi.String("roles/secretmanager.secretAccessor"),
+				Member:   pulumi.Sprintf("serviceAccount:%v", sa.Email),
+			}, opts...)
+		if err != nil {
+			return nil, fmt.Errorf("granting secret access for %s: %w", sid, err)
+		}
+		members = append(members, member)
+	}
+	return members, nil
+}
+
 // AddRolesToServiceAccount grants IAM roles to a service account at the project level.
 // Returns a resource array output that can be used as a dependency.
 func AddRolesToServiceAccount(
@@ -492,6 +559,100 @@ func dockerRunFlags(
 	return params, command
 }
 
+// computeSecretEnv maps a container env var to the Secret Manager secret ID
+// whose latest version supplies its value. The value is fetched at container
+// start (see secretFetchScript) instead of being embedded in instance metadata,
+// which is readable unauthenticated from the instance.
+type computeSecretEnv struct {
+	envKey   string
+	secretID string
+}
+
+// containerSecretPlan is the per-container result of classifyComputeSecretEnv:
+// the env values inlined into `docker run -e` and the ones boot-fetched from
+// Secret Manager.
+type containerSecretPlan struct {
+	inline     compose.Environment
+	secretRefs []computeSecretEnv
+}
+
+// classifyComputeSecretEnv splits a container's environment into values inlined
+// into the `docker run` command (static literals and dynamic Outputs) and
+// native secret references (bare ${VAR} or null "KEY:") that are boot-fetched
+// from Secret Manager. Interpolated values (mixed literal + ${VAR}) stay on the
+// inline path for now; resolving them without leaking plaintext into instance
+// metadata needs deploy-time derived configs — see issue 293. With no config
+// provider (e.g. standalone with no secrets), everything is inlined.
+func classifyComputeSecretEnv(
+	ctx *pulumi.Context, cp compose.ConfigProvider, env compose.Environment,
+) containerSecretPlan {
+	if cp == nil {
+		return containerSecretPlan{inline: env}
+	}
+	plan := containerSecretPlan{inline: make(compose.Environment, len(env))}
+	// Iterate sorted so the generated fetch script and IAM bindings are stable.
+	for k, v := range common.Sorted(env) {
+		if configKey := compose.GetConfigName2(k, v); configKey != "" {
+			if secretID, err := cp.GetSecretRef(ctx, configKey); err == nil && secretID != "" {
+				plan.secretRefs = append(plan.secretRefs, computeSecretEnv{envKey: k, secretID: secretID})
+				continue
+			}
+			// Couldn't resolve a ref: fall through and inline (matches the
+			// pre-secrets behavior rather than dropping the variable).
+		}
+		plan.inline[k] = v
+	}
+	return plan
+}
+
+// secretFetchScript returns the cloud-init write_files block for the boot-time
+// secret fetch script, the systemd ExecStartPre line that runs it, and the
+// `docker run --env-file` flag that injects the fetched values. All three are
+// empty when there are no secret refs.
+//
+// The script reads the instance service account's OAuth token from the metadata
+// server and fetches each secret's latest version from the Secret Manager REST
+// API — no gcloud (absent on Container-Optimized OS) required. Values land in a
+// tmpfs file (0600, /run) that never touches disk or instance metadata.
+//
+// NOTE: docker --env-file is line-oriented, so a secret whose value contains a
+// newline (e.g. a PEM key) cannot be injected this way. Such values need a
+// per-secret file mount; tracked as a follow-up.
+func secretFetchScript(gcpProject, unit string, refs []computeSecretEnv) (writeFile, execStartPre, envFileFlag string) {
+	if len(refs) == 0 {
+		return "", "", ""
+	}
+	scriptPath := "/opt/defang/" + unit + "-secrets.sh"
+	envFile := "/run/defang/" + unit + ".env"
+
+	var s strings.Builder
+	s.WriteString("#!/bin/bash\n")
+	s.WriteString("set -uo pipefail\n")
+	s.WriteString("umask 077\n")
+	s.WriteString("mkdir -p /run/defang\n")
+	s.WriteString(`tok=$(curl -s -H "Metadata-Flavor: Google" ` +
+		`http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token ` +
+		`| grep -o '"access_token":"[^"]*"' | cut -d'"' -f4)` + "\n")
+	fmt.Fprintf(&s, `sm() { curl -s -H "Authorization: Bearer $tok" `+
+		`"https://secretmanager.googleapis.com/v1/projects/%s/secrets/$1/versions/latest:access" `+
+		`| grep -o '"data":"[^"]*"' | cut -d'"' -f4 | base64 -d; }`+"\n", gcpProject)
+	s.WriteString("{\n")
+	for _, r := range refs {
+		fmt.Fprintf(&s, "printf '%%s=%%s\\n' '%s' \"$(sm '%s')\"\n", r.envKey, r.secretID)
+	}
+	fmt.Fprintf(&s, "} > %s\n", envFile)
+
+	// Indent the script body under the write_files `content: |` block (6 spaces).
+	var wf strings.Builder
+	fmt.Fprintf(&wf, "\n  - path: %s\n    permissions: \"0700\"\n    owner: root\n    content: |\n", scriptPath)
+	for _, line := range strings.Split(strings.TrimRight(s.String(), "\n"), "\n") {
+		wf.WriteString("      ")
+		wf.WriteString(line)
+		wf.WriteString("\n")
+	}
+	return wf.String(), "ExecStartPre=" + scriptPath, "--env-file " + envFile
+}
+
 // flattenEnvFlags renders `-e "K=V"` docker flags for the given static env
 // pairs followed by the service's compose environment. Dynamic (Output)
 // values are threaded through a Sprintf so they resolve at apply time.
@@ -541,14 +702,26 @@ func getCloudInitConfig(
 	image pulumi.StringInput,
 	svc compose.ServiceConfig,
 	region, etag, projectName, stack, fqdn string,
+	gcpProject string,
 	addHealthCheckSidecar bool,
 	sidecars map[string]compose.ServiceConfig,
+	mainPlan containerSecretPlan,
+	sidecarPlans map[string]containerSecretPlan,
 ) pulumi.StringOutput {
 	var buf strings.Builder
 	buf.WriteString("#cloud-config\n\nwrite_files:")
 
 	containerName := svc.GetContainerName(serviceName)
 	params, command := dockerRunFlags(svc, sidecars)
+
+	// Secret env vars are boot-fetched into a tmpfs env-file rather than embedded
+	// in instance metadata. The fetch script is written first so it precedes the
+	// service unit in write_files.
+	secretWriteFile, secretExecPre, secretEnvFileFlag := secretFetchScript(gcpProject, serviceName, mainPlan.secretRefs)
+	if secretEnvFileFlag != "" {
+		params = append(params, secretEnvFileFlag)
+	}
+	buf.WriteString(escapePercent(secretWriteFile))
 
 	// Defang-injected runtime vars, mirroring the Cloud Run path (buildEnvVars).
 	staticEnv := [][2]string{{"DEFANG_SERVICE", serviceName}}
@@ -558,7 +731,7 @@ func getCloudInitConfig(
 	if fqdn != "" {
 		staticEnv = append(staticEnv, [2]string{"DEFANG_FQDN", fqdn})
 	}
-	envFlags := flattenEnvFlags(staticEnv, svc.Environment)
+	envFlags := flattenEnvFlags(staticEnv, mainPlan.inline)
 
 	var dependencies strings.Builder
 	dependencies.WriteString("Wants=gcr-online.target docker.socket\n      After=gcr-online.target docker.socket")
@@ -589,7 +762,7 @@ func getCloudInitConfig(
 	}
 	for name, sc := range common.Sorted(sidecars) {
 		var unitText pulumi.StringInput
-		unitText, runcmds = buildSidecarUnit(serviceName, name, region, sc, sidecars, runcmds)
+		unitText, runcmds = buildSidecarUnit(serviceName, name, region, gcpProject, sc, sidecars, sidecarPlans[name], runcmds)
 		extraUnitsFmt.WriteString("%s")
 		extraUnitsArgs = append(extraUnitsArgs, unitText)
 	}
@@ -613,6 +786,7 @@ func getCloudInitConfig(
       Restart=always
       RestartSec=30
       Environment="HOME=/home/container-user"
+      %[9]s
       ExecStartPre=/usr/bin/docker-credential-gcr configure-docker --registries %[5]s-docker.pkg.dev
       ExecStart=/usr/bin/docker run --pull=always --rm --name=%[7]s %[3]s %%s%%s %[4]s
       ExecStop=/usr/bin/docker stop -t %[6]d %[7]s
@@ -632,7 +806,8 @@ runcmd:
 		region,
 		stopGraceSeconds(svc),
 		containerName,
-		escapePercent(strings.Join(runcmds, "\n  - ")))
+		escapePercent(strings.Join(runcmds, "\n  - ")),
+		escapePercent(secretExecPre))
 
 	// buf now contains exactly three %s placeholders (env flags, image, and
 	// extra units — the Inputs that may resolve at apply time); all other
@@ -677,15 +852,22 @@ func sidecarUnitName(serviceName, sidecarName string) string {
 // --volumes-from keeps working across restarts; a run-once sidecar (restart: "no")
 // becomes a oneshot unit the main service can order After=.
 func buildSidecarUnit(
-	serviceName, sidecarName, region string,
+	serviceName, sidecarName, region, gcpProject string,
 	sc compose.ServiceConfig,
 	sidecars map[string]compose.ServiceConfig,
+	plan containerSecretPlan,
 	runcmds []string,
 ) (pulumi.StringInput, []string) {
 	unit := sidecarUnitName(serviceName, sidecarName)
 	containerName := sc.GetContainerName(sidecarName)
 	params, command := dockerRunFlags(sc, sidecars)
-	envFlags := flattenEnvFlags(nil, sc.Environment)
+
+	// Boot-fetch this sidecar's secret env into its own tmpfs env-file.
+	secretWriteFile, secretExecPre, secretEnvFileFlag := secretFetchScript(gcpProject, unit, plan.secretRefs)
+	if secretEnvFileFlag != "" {
+		params = append(params, secretEnvFileFlag)
+	}
+	envFlags := flattenEnvFlags(nil, plan.inline)
 
 	var serviceSection string
 	if sc.Restart == "no" {
@@ -695,7 +877,10 @@ func buildSidecarUnit(
 			stopGraceSeconds(sc), containerName)
 	}
 
-	units := pulumi.Sprintf(`
+	// %[11]s (secret fetch script write_files entry) and %[12]s (its
+	// ExecStartPre) are passed as Sprintf argument values, so any '%' in the
+	// script survives literally without escaping.
+	units := pulumi.Sprintf(`%[11]s
   - path: /etc/systemd/system/%[1]s.service
     permissions: "0644"
     owner: root
@@ -709,6 +894,7 @@ func buildSidecarUnit(
       [Service]
       %[4]s
       Environment="HOME=/home/container-user"
+      %[12]s
       ExecStartPre=/usr/bin/docker-credential-gcr configure-docker --registries %[5]s-docker.pkg.dev
       ExecStartPre=-/usr/bin/docker rm -f %[6]s
       ExecStart=/usr/bin/docker run --pull=always --name=%[6]s %[7]s %[8]s%[9]s %[10]s
@@ -727,7 +913,9 @@ func buildSidecarUnit(
 		strings.Join(params, " "),
 		envFlags,
 		sc.Image, // validated non-nil in createService; may resolve at apply time
-		strings.Join(command, " "))
+		strings.Join(command, " "),
+		secretWriteFile,
+		secretExecPre)
 
 	runcmds = append(runcmds,
 		fmt.Sprintf("systemctl enable %s.service", unit),

--- a/provider/defanggcp/gcp/compute.go
+++ b/provider/defanggcp/gcp/compute.go
@@ -139,7 +139,10 @@ func CreateComputeEngine(
 	if len(zoneNames) < len(zones.Names) {
 		migArgs.DistributionPolicyZones = pulumi.ToStringArray(zoneNames)
 	}
-	instanceGroup, err := compute.NewRegionInstanceGroupManager(ctx, serviceName+"-instance-group",
+	// No "-instance-group" suffix: the type token (RegionInstanceGroupManager)
+	// already says what this is, matching the bare-name convention used for
+	// its sibling resources (Address, HealthCheck, Firewall) in this file.
+	instanceGroup, err := compute.NewRegionInstanceGroupManager(ctx, serviceName,
 		migArgs, parentOpt, pulumi.DependsOn([]pulumi.Resource{instanceTemplate}))
 	if err != nil {
 		return nil, fmt.Errorf("creating instance group for %s: %w", serviceName, err)
@@ -257,7 +260,13 @@ func createInstanceTemplate(
 	if sa.Account != nil {
 		templateOpts = append(templateOpts, pulumi.DependsOnInputs(iamDeps))
 	}
-	tmpl, err := compute.NewInstanceTemplate(ctx, serviceName+"-instance-template",
+	// "-tmpl", not "-instance-template": autonaming's pattern for this resource
+	// type is "${project}-${stack}-${name}-${hex(7)}" (cd/config.go), and a
+	// longer logical name here left no headroom for longer project/stack
+	// names before hitting GCP Compute's 63-char physical-name limit -- a live
+	// smoketest (defang-mvp#3181) hit exactly that with project "html-css-js"
+	// and stack "newprovidergcp".
+	tmpl, err := compute.NewInstanceTemplate(ctx, serviceName+"-tmpl",
 		&compute.InstanceTemplateArgs{
 			MachineType: pulumi.String(machineType),
 			Scheduling: &compute.InstanceTemplateSchedulingArgs{
@@ -296,6 +305,7 @@ func createMIGAutoHealing(
 		return nil, nil //nolint:nilnil
 	}
 
+	hcName := serviceName + "-" + strconv.Itoa(*healthCheckPort) + "-mig-hc"
 	hcArgs := &compute.HealthCheckArgs{
 		CheckIntervalSec:   pulumi.Int(30),
 		TimeoutSec:         pulumi.Int(30),
@@ -312,14 +322,16 @@ func createMIGAutoHealing(
 		}
 	}
 
-	hcName := serviceName + "-" + strconv.Itoa(*healthCheckPort) + "-mig-hc"
 	healthCheck, err := compute.NewHealthCheck(ctx, hcName, hcArgs, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("creating health check for %s: %w", serviceName, err)
 	}
 
+	// No "-fw" suffix: the GCP console's own type column already says
+	// "Firewall rule", and sharing the health check's logical name is fine --
+	// Pulumi's URN disambiguates by resource type, not name alone.
 	portStr := strconv.Itoa(*healthCheckPort)
-	if _, err := compute.NewFirewall(ctx, serviceName+"-mig-hc-fw", &compute.FirewallArgs{
+	if _, err := compute.NewFirewall(ctx, hcName, &compute.FirewallArgs{
 		Network: network,
 		// https://cloud.google.com/load-balancing/docs/health-checks#firewall_rules
 		SourceRanges: pulumi.StringArray{
@@ -633,7 +645,12 @@ func secretFetchScript(gcpProject, unit string, refs []computeSecretEnv) (string
 	if len(refs) == 0 {
 		return "", "", ""
 	}
-	scriptPath := "/opt/defang/" + unit + "-secrets.sh"
+	// /run, not /opt: Container-Optimized OS mounts its root filesystem
+	// read-only, so cloud-init's write_files fails with EROFS creating any
+	// directory under /opt -- surfaced live via defang-mvp#3181 (real GCE
+	// boot: "OSError: [Errno 30] Read-only file system: '/opt/defang'").
+	// /run is tmpfs, always writable, and already used for the env file below.
+	scriptPath := "/run/defang/" + unit + "-secrets.sh"
 	envFile := "/run/defang/" + unit + ".env"
 
 	// Fail fast: a fetch that errors out (or yields an empty token) must fail
@@ -647,13 +664,18 @@ func secretFetchScript(gcpProject, unit string, refs []computeSecretEnv) (string
 	s.WriteString("set -euo pipefail\n")
 	s.WriteString("umask 077\n")
 	s.WriteString("mkdir -p /run/defang\n")
+	// Google APIs pretty-print JSON by default (a space after the colon, e.g.
+	// `"data": "..."`), so the extraction must tolerate optional whitespace
+	// there -- a bare `":"` pattern never matches a real response and every
+	// secret-backed boot would fail fetching. See
+	// https://cloud.google.com/apis/docs/system-parameters (prettyPrint).
 	s.WriteString(`tok=$(curl -fsS -H "Metadata-Flavor: Google" ` +
 		`http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token ` +
-		`| grep -o '"access_token":"[^"]*"' | cut -d'"' -f4)` + "\n")
+		`| grep -o '"access_token": *"[^"]*"' | cut -d'"' -f4)` + "\n")
 	s.WriteString(`[ -n "$tok" ] || { echo "defang: empty metadata token" >&2; exit 1; }` + "\n")
 	fmt.Fprintf(&s, `sm() { curl -fsS -H "Authorization: Bearer $tok" `+
 		`"https://secretmanager.googleapis.com/v1/projects/%s/secrets/$1/versions/latest:access" `+
-		`| grep -o '"data":"[^"]*"' | cut -d'"' -f4 | base64 -d; }`+"\n", gcpProject)
+		`| grep -o '"data": *"[^"]*"' | cut -d'"' -f4 | base64 -d; }`+"\n", gcpProject)
 	s.WriteString("{\n")
 	for _, r := range refs {
 		fmt.Fprintf(&s, `v=$(sm '%s') || { echo "defang: failed to fetch secret %s" >&2; exit 1; }`+"\n",

--- a/provider/defanggcp/gcp/compute.go
+++ b/provider/defanggcp/gcp/compute.go
@@ -656,7 +656,8 @@ func secretFetchScript(gcpProject, unit string, refs []computeSecretEnv) (string
 		`| grep -o '"data":"[^"]*"' | cut -d'"' -f4 | base64 -d; }`+"\n", gcpProject)
 	s.WriteString("{\n")
 	for _, r := range refs {
-		fmt.Fprintf(&s, `v=$(sm '%s') || { echo "defang: failed to fetch secret %s" >&2; exit 1; }`+"\n", r.secretID, r.secretID)
+		fmt.Fprintf(&s, `v=$(sm '%s') || { echo "defang: failed to fetch secret %s" >&2; exit 1; }`+"\n",
+			r.secretID, r.secretID)
 		fmt.Fprintf(&s, "printf '%%s=%%s\\n' '%s' \"$v\"\n", r.envKey)
 	}
 	fmt.Fprintf(&s, "} > %s\n", envFile)

--- a/provider/defanggcp/gcp/compute.go
+++ b/provider/defanggcp/gcp/compute.go
@@ -636,20 +636,28 @@ func secretFetchScript(gcpProject, unit string, refs []computeSecretEnv) (string
 	scriptPath := "/opt/defang/" + unit + "-secrets.sh"
 	envFile := "/run/defang/" + unit + ".env"
 
+	// Fail fast: a fetch that errors out (or yields an empty token) must fail
+	// ExecStartPre so the unit does not start the container with an empty
+	// secret value — a silent empty credential is far harder to diagnose than
+	// a unit that refuses to start. `curl -f` turns HTTP errors into non-zero
+	// exits and `grep` exits 1 when the expected field is absent (e.g. an
+	// error payload), so with pipefail every failure mode is caught.
 	var s strings.Builder
 	s.WriteString("#!/bin/bash\n")
-	s.WriteString("set -uo pipefail\n")
+	s.WriteString("set -euo pipefail\n")
 	s.WriteString("umask 077\n")
 	s.WriteString("mkdir -p /run/defang\n")
-	s.WriteString(`tok=$(curl -s -H "Metadata-Flavor: Google" ` +
+	s.WriteString(`tok=$(curl -fsS -H "Metadata-Flavor: Google" ` +
 		`http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token ` +
 		`| grep -o '"access_token":"[^"]*"' | cut -d'"' -f4)` + "\n")
-	fmt.Fprintf(&s, `sm() { curl -s -H "Authorization: Bearer $tok" `+
+	s.WriteString(`[ -n "$tok" ] || { echo "defang: empty metadata token" >&2; exit 1; }` + "\n")
+	fmt.Fprintf(&s, `sm() { curl -fsS -H "Authorization: Bearer $tok" `+
 		`"https://secretmanager.googleapis.com/v1/projects/%s/secrets/$1/versions/latest:access" `+
 		`| grep -o '"data":"[^"]*"' | cut -d'"' -f4 | base64 -d; }`+"\n", gcpProject)
 	s.WriteString("{\n")
 	for _, r := range refs {
-		fmt.Fprintf(&s, "printf '%%s=%%s\\n' '%s' \"$(sm '%s')\"\n", r.envKey, r.secretID)
+		fmt.Fprintf(&s, `v=$(sm '%s') || { echo "defang: failed to fetch secret %s" >&2; exit 1; }`+"\n", r.secretID, r.secretID)
+		fmt.Fprintf(&s, "printf '%%s=%%s\\n' '%s' \"$v\"\n", r.envKey)
 	}
 	fmt.Fprintf(&s, "} > %s\n", envFile)
 

--- a/provider/defanggcp/gcp/compute.go
+++ b/provider/defanggcp/gcp/compute.go
@@ -74,24 +74,7 @@ func CreateComputeEngine(
 		return nil, err
 	}
 
-	namedPorts := make(compute.RegionInstanceGroupManagerNamedPortArray, len(svc.Ports))
-	var healthCheckPort *int
-	for i, port := range svc.Ports {
-		proto := port.GetProtocol()
-		namedPorts[i] = &compute.RegionInstanceGroupManagerNamedPortArgs{
-			Name: pulumi.String(fmt.Sprintf("port-%s-%d", proto, port.Target)),
-			Port: pulumi.Int(port.Target),
-		}
-		if proto == "tcp" {
-			p := int(port.Target)
-			healthCheckPort = &p
-		}
-	}
-	addHealthCheckSidecar := healthCheckPort == nil
-	if addHealthCheckSidecar {
-		p := 8080
-		healthCheckPort = &p
-	}
+	namedPorts, healthCheckPort, addHealthCheckSidecar := computeNamedPorts(svc)
 
 	// DEFANG_FQDN: custom domain, else public FQDN (ingress), else the private
 	// FQDN (<label>.google.internal) for internal services — the private zone is
@@ -163,6 +146,33 @@ func CreateComputeEngine(
 	}
 
 	return &ComputeEngineResult{InstanceGroup: instanceGroup}, nil
+}
+
+// computeNamedPorts builds the MIG named-port array from the service's ports and
+// determines the health-check port. Services with no TCP port get a dedicated
+// HTTP health-check sidecar on 8080 so the MIG auto-healer can probe liveness.
+func computeNamedPorts(svc compose.ServiceConfig) (
+	compute.RegionInstanceGroupManagerNamedPortArray, *int, bool,
+) {
+	namedPorts := make(compute.RegionInstanceGroupManagerNamedPortArray, len(svc.Ports))
+	var healthCheckPort *int
+	for i, port := range svc.Ports {
+		proto := port.GetProtocol()
+		namedPorts[i] = &compute.RegionInstanceGroupManagerNamedPortArgs{
+			Name: pulumi.String(fmt.Sprintf("port-%s-%d", proto, port.Target)),
+			Port: pulumi.Int(port.Target),
+		}
+		if proto == "tcp" {
+			p := int(port.Target)
+			healthCheckPort = &p
+		}
+	}
+	addHealthCheckSidecar := healthCheckPort == nil
+	if addHealthCheckSidecar {
+		p := 8080
+		healthCheckPort = &p
+	}
+	return namedPorts, healthCheckPort, addHealthCheckSidecar
 }
 
 // networkID returns the network to attach instances and firewalls to: the
@@ -618,7 +628,8 @@ func classifyComputeSecretEnv(
 // NOTE: docker --env-file is line-oriented, so a secret whose value contains a
 // newline (e.g. a PEM key) cannot be injected this way. Such values need a
 // per-secret file mount; tracked as a follow-up.
-func secretFetchScript(gcpProject, unit string, refs []computeSecretEnv) (writeFile, execStartPre, envFileFlag string) {
+// Returns (write_files block, ExecStartPre line, docker --env-file flag).
+func secretFetchScript(gcpProject, unit string, refs []computeSecretEnv) (string, string, string) {
 	if len(refs) == 0 {
 		return "", "", ""
 	}
@@ -692,6 +703,25 @@ func stopGraceSeconds(svc compose.ServiceConfig) int {
 	return 30
 }
 
+// buildUnitDependencies renders the [Unit] ordering directives for the main
+// service: it always waits on gcr-online + docker, and additionally requires and
+// orders After each same-instance sidecar named in depends_on (cross-instance
+// dependencies aren't enforceable from a single unit).
+func buildUnitDependencies(
+	serviceName string, svc compose.ServiceConfig, sidecars map[string]compose.ServiceConfig,
+) string {
+	var dependencies strings.Builder
+	dependencies.WriteString("Wants=gcr-online.target docker.socket\n      After=gcr-online.target docker.socket")
+	for name := range common.Sorted(svc.DependsOn) {
+		if _, ok := sidecars[name]; !ok {
+			continue // only same-instance sidecar dependencies are enforceable here
+		}
+		unit := sidecarUnitName(serviceName, name)
+		fmt.Fprintf(&dependencies, "\n      Requires=%s.service\n      After=%s.service", unit, unit)
+	}
+	return dependencies.String()
+}
+
 // getCloudInitConfig generates a cloud-init YAML string for running a container on
 // Container-Optimized OS using systemd. For portless services it adds an HTTP health
 // check sidecar so the MIG auto-healer can probe container liveness. User-defined
@@ -733,15 +763,7 @@ func getCloudInitConfig(
 	}
 	envFlags := flattenEnvFlags(staticEnv, mainPlan.inline)
 
-	var dependencies strings.Builder
-	dependencies.WriteString("Wants=gcr-online.target docker.socket\n      After=gcr-online.target docker.socket")
-	for name := range common.Sorted(svc.DependsOn) {
-		if _, ok := sidecars[name]; !ok {
-			continue // only same-instance sidecar dependencies are enforceable here
-		}
-		unit := sidecarUnitName(serviceName, name)
-		fmt.Fprintf(&dependencies, "\n      Requires=%s.service\n      After=%s.service", unit, unit)
-	}
+	dependencies := buildUnitDependencies(serviceName, svc, sidecars)
 
 	runcmds := make([]string, 0, 5+4+2*len(sidecars)+2)
 	runcmds = append(runcmds,
@@ -800,7 +822,7 @@ runcmd:
   - %[8]s
 `,
 		serviceName,
-		escapePercent(dependencies.String()),
+		escapePercent(dependencies),
 		escapePercent(strings.Join(params, " ")),
 		escapePercent(strings.Join(command, " ")),
 		region,

--- a/provider/defanggcp/gcp/compute_test.go
+++ b/provider/defanggcp/gcp/compute_test.go
@@ -218,7 +218,9 @@ func TestClassifyComputeSecretEnv(t *testing.T) {
 
 	// secret refs are sorted by env key: BARE, NULLED
 	require.Len(t, plan.secretRefs, 2)
+	//nolint:gosec // G101: secret resource names (IDs), not credential values.
 	assert.Equal(t, computeSecretEnv{envKey: "BARE", secretID: "Defang_proj_stack_SECRET_ONE"}, plan.secretRefs[0])
+	//nolint:gosec // G101: secret resource names (IDs), not credential values.
 	assert.Equal(t, computeSecretEnv{envKey: "NULLED", secretID: "Defang_proj_stack_NULLED"}, plan.secretRefs[1])
 	// literals and mixed interpolation stay inline
 	assert.Contains(t, plan.inline, "PLAIN")
@@ -237,8 +239,8 @@ func TestClassifyComputeSecretEnv(t *testing.T) {
 // flag that consume it.
 func TestSecretFetchScript(t *testing.T) {
 	refs := []computeSecretEnv{
-		{envKey: "DB", secretID: "Defang_p_s_DBPASS"},
-		{envKey: "API", secretID: "Defang_p_s_APIKEY"},
+		{envKey: "DB", secretID: "Defang_p_s_DBPASS"},  //nolint:gosec // G101 false positive
+		{envKey: "API", secretID: "Defang_p_s_APIKEY"}, //nolint:gosec // G101 false positive
 	}
 	wf, pre, flag := secretFetchScript("my-proj", "svc", refs)
 
@@ -268,7 +270,7 @@ func TestGetCloudInitConfigSecrets(t *testing.T) {
 	plan := containerSecretPlan{
 		inline: compose.Environment{"PLAIN": pulumi.String("x")},
 		secretRefs: []computeSecretEnv{
-			{envKey: "SECRET_ENV", secretID: "Defang_proj_stack_SECRET_ENV"},
+			{envKey: "SECRET_ENV", secretID: "Defang_proj_stack_SECRET_ENV"}, //nolint:gosec // G101 false positive
 		},
 	}
 

--- a/provider/defanggcp/gcp/compute_test.go
+++ b/provider/defanggcp/gcp/compute_test.go
@@ -45,7 +45,8 @@ func TestGetCloudInitConfigDefangEnv(t *testing.T) {
 			wg.Add(1)
 			err := pulumi.RunErr(func(ctx *pulumi.Context) error {
 				out := getCloudInitConfig(
-					"api", pulumi.String("img:latest"), svc, "us-central1", tt.etag, "", "", tt.fqdn, false, nil)
+					"api", pulumi.String("img:latest"), svc, "us-central1", tt.etag, "", "", tt.fqdn, "",
+					false, nil, containerSecretPlan{inline: svc.Environment}, nil)
 				out.ApplyT(func(s string) string {
 					defer wg.Done()
 					cloudInit = s
@@ -100,7 +101,8 @@ func TestGetCloudInitConfigLogLabels(t *testing.T) {
 			wg.Add(1)
 			err := pulumi.RunErr(func(ctx *pulumi.Context) error {
 				out := getCloudInitConfig(
-					"api", pulumi.String("img:latest"), svc, "us-central1", tt.etag, tt.projectName, tt.stack, "", false, nil)
+					"api", pulumi.String("img:latest"), svc, "us-central1", tt.etag, tt.projectName, tt.stack, "", "",
+					false, nil, containerSecretPlan{inline: svc.Environment}, nil)
 				out.ApplyT(func(s string) string {
 					defer wg.Done()
 					cloudInit = s
@@ -148,7 +150,9 @@ func TestGetCloudInitConfigSidecars(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
-		out := getCloudInitConfig("cd", pulumi.String("img:latest"), svc, "us-central1", "", "", "", "", true, sidecars)
+		out := getCloudInitConfig("cd", pulumi.String("img:latest"), svc, "us-central1", "", "", "", "", "",
+			true, sidecars, containerSecretPlan{inline: svc.Environment},
+			map[string]containerSecretPlan{"handler": {inline: sidecars["handler"].Environment}})
 		out.ApplyT(func(s string) string {
 			defer wg.Done()
 			cloudInit = s
@@ -179,5 +183,119 @@ func TestGetCloudInitConfigSidecars(t *testing.T) {
 	// '%' escaping: env value intact, image substituted
 	assert.Contains(t, cloudInit, `-e "RATIO=100%"`)
 	assert.Contains(t, cloudInit, "img:latest")
+	assert.NotContains(t, cloudInit, "%!")
+}
+
+// mockSecretConfigProvider resolves bare ${VAR} / null env refs to a
+// deterministic Secret Manager ID so the classify/cloud-init paths can be
+// tested without a live backend.
+type mockSecretConfigProvider struct{ prefix string }
+
+func (m *mockSecretConfigProvider) GetConfigValue(
+	_ *pulumi.Context, key string, _ ...pulumi.InvokeOption,
+) pulumi.StringOutput {
+	return pulumi.String("val-" + key).ToStringOutput()
+}
+
+func (m *mockSecretConfigProvider) GetSecretRef(
+	_ *pulumi.Context, key string, _ ...pulumi.InvokeOption,
+) (string, error) {
+	return m.prefix + key, nil
+}
+
+// classifyComputeSecretEnv routes bare ${VAR} and null "KEY:" values to native
+// secret refs, and leaves literals and interpolated (mixed) values inline.
+func TestClassifyComputeSecretEnv(t *testing.T) {
+	env := compose.Environment{
+		"PLAIN":  pulumi.String("literal"),
+		"BARE":   pulumi.String("${SECRET_ONE}"),
+		"NULLED": nil,
+		"MIXED":  pulumi.String("pre-${SECRET_TWO}-post"),
+	}
+	cp := &mockSecretConfigProvider{prefix: "Defang_proj_stack_"}
+
+	plan := classifyComputeSecretEnv(nil, cp, env)
+
+	// secret refs are sorted by env key: BARE, NULLED
+	require.Len(t, plan.secretRefs, 2)
+	assert.Equal(t, computeSecretEnv{envKey: "BARE", secretID: "Defang_proj_stack_SECRET_ONE"}, plan.secretRefs[0])
+	assert.Equal(t, computeSecretEnv{envKey: "NULLED", secretID: "Defang_proj_stack_NULLED"}, plan.secretRefs[1])
+	// literals and mixed interpolation stay inline
+	assert.Contains(t, plan.inline, "PLAIN")
+	assert.Contains(t, plan.inline, "MIXED")
+	assert.NotContains(t, plan.inline, "BARE")
+	assert.NotContains(t, plan.inline, "NULLED")
+
+	// with no config provider, everything is inlined
+	nilPlan := classifyComputeSecretEnv(nil, nil, env)
+	assert.Nil(t, nilPlan.secretRefs)
+	assert.Equal(t, env, nilPlan.inline)
+}
+
+// secretFetchScript emits a COS-compatible boot fetch (metadata token + Secret
+// Manager REST API) writing a tmpfs env-file, plus the ExecStartPre + env-file
+// flag that consume it.
+func TestSecretFetchScript(t *testing.T) {
+	refs := []computeSecretEnv{
+		{envKey: "DB", secretID: "Defang_p_s_DBPASS"},
+		{envKey: "API", secretID: "Defang_p_s_APIKEY"},
+	}
+	wf, pre, flag := secretFetchScript("my-proj", "svc", refs)
+
+	assert.Equal(t, "ExecStartPre=/opt/defang/svc-secrets.sh", pre)
+	assert.Equal(t, "--env-file /run/defang/svc.env", flag)
+	assert.Contains(t, wf, "path: /opt/defang/svc-secrets.sh")
+	assert.Contains(t, wf, `permissions: "0700"`)
+	assert.Contains(t, wf, "metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")
+	assert.Contains(t, wf, "https://secretmanager.googleapis.com/v1/projects/my-proj/secrets/")
+	assert.Contains(t, wf, `printf '%s=%s\n' 'DB' "$(sm 'Defang_p_s_DBPASS')"`)
+	assert.Contains(t, wf, `printf '%s=%s\n' 'API' "$(sm 'Defang_p_s_APIKEY')"`)
+	assert.Contains(t, wf, "} > /run/defang/svc.env")
+
+	// no refs -> no output
+	wf2, pre2, flag2 := secretFetchScript("p", "svc", nil)
+	assert.Empty(t, wf2)
+	assert.Empty(t, pre2)
+	assert.Empty(t, flag2)
+}
+
+// getCloudInitConfig must boot-fetch secret env (not inline it) while still
+// inlining plain values, and wire up the ExecStartPre + --env-file.
+func TestGetCloudInitConfigSecrets(t *testing.T) {
+	svc := compose.ServiceConfig{
+		Ports: []compose.ServicePortConfig{{Target: 8080, Mode: compose.PortModeHost}},
+	}
+	plan := containerSecretPlan{
+		inline: compose.Environment{"PLAIN": pulumi.String("x")},
+		secretRefs: []computeSecretEnv{
+			{envKey: "SECRET_ENV", secretID: "Defang_proj_stack_SECRET_ENV"},
+		},
+	}
+
+	var cloudInit string
+	var wg sync.WaitGroup
+	wg.Add(1)
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		out := getCloudInitConfig(
+			"api", pulumi.String("img:latest"), svc, "us-central1", "", "", "", "", "gcp-proj",
+			false, nil, plan, nil)
+		out.ApplyT(func(s string) string {
+			defer wg.Done()
+			cloudInit = s
+			return s
+		})
+		return nil
+	}, pulumi.WithMocks("proj", "stack", testMocks{}))
+	require.NoError(t, err)
+	wg.Wait()
+
+	assert.Contains(t, cloudInit, "ExecStartPre=/opt/defang/api-secrets.sh")
+	assert.Contains(t, cloudInit, "--env-file /run/defang/api.env")
+	assert.Contains(t, cloudInit, "https://secretmanager.googleapis.com/v1/projects/gcp-proj/secrets/")
+	assert.Contains(t, cloudInit, `printf '%s=%s\n' 'SECRET_ENV' "$(sm 'Defang_proj_stack_SECRET_ENV')"`)
+	// plain value inlined, secret value NOT inlined
+	assert.Contains(t, cloudInit, `-e "PLAIN=x"`)
+	assert.NotContains(t, cloudInit, `-e "SECRET_ENV`)
+	// no leftover format artifacts
 	assert.NotContains(t, cloudInit, "%!")
 }

--- a/provider/defanggcp/gcp/compute_test.go
+++ b/provider/defanggcp/gcp/compute_test.go
@@ -1,15 +1,46 @@
 package gcp
 
 import (
+	"encoding/base64"
+	"errors"
+	"os/exec"
 	"strings"
 	"sync"
 	"testing"
 
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// namedResourceMocks records the Pulumi logical name of every resource it
+// creates, keyed by Pulumi type token. Physical naming (length, case,
+// project/stack scoping) is Pulumi autonaming's job, configured in
+// cd/config.go -- these resources deliberately don't override Name.
+type namedResourceMocks struct {
+	mu    sync.Mutex
+	names map[string]string
+}
+
+func (m *namedResourceMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+	outputs := args.Inputs.Copy()
+	m.mu.Lock()
+	if m.names == nil {
+		m.names = map[string]string{}
+	}
+	m.names[args.TypeToken] = args.Name
+	m.mu.Unlock()
+	if _, ok := outputs["selfLink"]; !ok {
+		outputs["selfLink"] = resource.NewStringProperty("https://compute.googleapis.com/" + args.Name)
+	}
+	return args.Name + "_id", outputs, nil
+}
+
+func (m *namedResourceMocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
+	return args.Args, nil
+}
 
 // getCloudInitConfig must inject the Defang runtime env vars into the
 // `docker run` command, mirroring the Cloud Run path. DEFANG_SERVICE is always
@@ -244,9 +275,9 @@ func TestSecretFetchScript(t *testing.T) {
 	}
 	wf, pre, flag := secretFetchScript("my-proj", "svc", refs)
 
-	assert.Equal(t, "ExecStartPre=/opt/defang/svc-secrets.sh", pre)
+	assert.Equal(t, "ExecStartPre=/run/defang/svc-secrets.sh", pre)
 	assert.Equal(t, "--env-file /run/defang/svc.env", flag)
-	assert.Contains(t, wf, "path: /opt/defang/svc-secrets.sh")
+	assert.Contains(t, wf, "path: /run/defang/svc-secrets.sh")
 	assert.Contains(t, wf, `permissions: "0700"`)
 	assert.Contains(t, wf, "metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")
 	assert.Contains(t, wf, "https://secretmanager.googleapis.com/v1/projects/my-proj/secrets/")
@@ -267,6 +298,74 @@ func TestSecretFetchScript(t *testing.T) {
 	assert.Empty(t, wf2)
 	assert.Empty(t, pre2)
 	assert.Empty(t, flag2)
+}
+
+// Google's REST APIs pretty-print JSON by default (a space after every colon,
+// e.g. `"data": "..."`), unlike the metadata server's own minified responses.
+// The generated script's extraction must handle both, or every secret-backed
+// Compute Engine boot fails fetching. This runs the actual generated sm()
+// function against a realistic pretty-printed response instead of asserting
+// on the script text.
+func TestSecretFetchScriptExtractsPrettyPrintedJSON(t *testing.T) {
+	wf, _, _ := secretFetchScript("my-proj", "svc", []computeSecretEnv{{envKey: "DB", secretID: "my-secret"}})
+
+	// Reconstruct the raw script from the write_files `content: |` block
+	// (each line indented 6 spaces further, see secretFetchScript).
+	var raw []string
+	inContent := false
+	for _, line := range strings.Split(wf, "\n") {
+		if strings.Contains(line, "content: |") {
+			inContent = true
+			continue
+		}
+		if inContent {
+			raw = append(raw, strings.TrimPrefix(line, "      "))
+		}
+	}
+	require.NotEmpty(t, raw)
+
+	// Keep everything through the sm() definition. Drop the /run write (no
+	// permission to create it in a test sandbox) and stop before the block
+	// that would actually invoke it against the real envFile.
+	var setup []string
+	for _, line := range raw {
+		if strings.Contains(line, "mkdir -p /run/defang") {
+			continue
+		}
+		setup = append(setup, line)
+		if strings.HasPrefix(line, "sm() {") {
+			break
+		}
+	}
+	require.Contains(t, setup[len(setup)-1], "sm() {")
+
+	const secretValue = "s3cr3t"
+	encoded := base64.StdEncoding.EncodeToString([]byte(secretValue))
+	script := `
+curl() {
+  case "$*" in
+  *metadata.google.internal*) echo '{
+  "access_token": "test-token",
+  "expires_in": 3599
+}' ;;
+  *secretmanager.googleapis.com*) echo '{
+  "name": "projects/p/secrets/my-secret/versions/1",
+  "payload": {
+    "data": "` + encoded + `"
+  }
+}' ;;
+  esac
+}
+export -f curl
+` + strings.Join(setup, "\n") + "\nsm 'my-secret'\n"
+	//nolint:gosec // G204: script is test-authored, not external input
+	out, err := exec.CommandContext(t.Context(), "bash", "-c", script).Output()
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		t.Fatalf("script failed: %v\nstderr: %s", err, ee.Stderr)
+	}
+	require.NoError(t, err)
+	assert.Equal(t, secretValue, strings.TrimSpace(string(out)))
 }
 
 // getCloudInitConfig must boot-fetch secret env (not inline it) while still
@@ -299,7 +398,7 @@ func TestGetCloudInitConfigSecrets(t *testing.T) {
 	require.NoError(t, err)
 	wg.Wait()
 
-	assert.Contains(t, cloudInit, "ExecStartPre=/opt/defang/api-secrets.sh")
+	assert.Contains(t, cloudInit, "ExecStartPre=/run/defang/api-secrets.sh")
 	assert.Contains(t, cloudInit, "--env-file /run/defang/api.env")
 	assert.Contains(t, cloudInit, "https://secretmanager.googleapis.com/v1/projects/gcp-proj/secrets/")
 	assert.Contains(t, cloudInit, `v=$(sm 'Defang_proj_stack_SECRET_ENV')`)
@@ -309,4 +408,59 @@ func TestGetCloudInitConfigSecrets(t *testing.T) {
 	assert.NotContains(t, cloudInit, `-e "SECRET_ENV`)
 	// no leftover format artifacts
 	assert.NotContains(t, cloudInit, "%!")
+}
+
+// A long compose service name combined with a configured autonaming pattern
+// used to push the health check and firewall physical names over GCP's
+// 63-char RFC1035 limit (Pulumi's autoname appends <project>-<stack>-<name>
+// plus a random suffix). gcpComputeName caps them explicitly instead.
+// The MIG health check's firewall shares its logical name rather than
+// appending a "-fw" suffix: the GCP console's own type column already
+// identifies it as a firewall rule, so a type-naming suffix is redundant.
+// Physical naming (length, case, project/stack scoping) is Pulumi
+// autonaming's job, configured via the per-resource-type overrides in
+// cd/config.go -- not asserted here.
+func TestCreateMIGAutoHealingFirewallSharesHealthCheckName(t *testing.T) {
+	mocks := &namedResourceMocks{}
+	port := 6379
+
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		_, err := createMIGAutoHealing(
+			ctx, "smokeworker", "smokeworker", &port, false, pulumi.String("projects/p/global/networks/vpc"))
+		return err
+	}, pulumi.WithMocks("pulumi-project", "dev", mocks))
+	require.NoError(t, err)
+
+	hcName := mocks.names["gcp:compute/healthCheck:HealthCheck"]
+	fwName := mocks.names["gcp:compute/firewall:Firewall"]
+	assert.Equal(t, "smokeworker-6379-mig-hc", hcName)
+	assert.Equal(t, hcName, fwName, "firewall should share the health check's logical name, not append -fw")
+}
+
+// A live smoketest (defang-mvp#3181) hit GCP's 63-char compute resource name
+// limit: autonaming's pattern for InstanceTemplate is
+// "${project}-${stack}-${name}-${hex(7)}" (cd/config.go), and with the
+// logical name "smokeworker-instance-template" plus a realistic
+// project/stack ("html-css-js"/"newprovidergcp"), the physical name came to
+// 64 chars -- one over the limit. Assert the shorter "-tmpl" suffix instead
+// of re-deriving the exact character budget here (that belongs to
+// autonaming's own pattern, not this package).
+func TestCreateInstanceTemplateUsesShortSuffix(t *testing.T) {
+	mocks := &namedResourceMocks{}
+
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		_, err := createInstanceTemplate(
+			ctx, "smokeworker", "smokeworker", "e2-small", "debian-cloud/debian-12",
+			pulumi.String("#!/bin/sh\n"),
+			&ServiceIdentity{Email: pulumi.String("test@example.com")},
+			nil,
+			testInfra(ctx),
+			pulumi.ResourceArrayOutput{},
+		)
+		return err
+	}, pulumi.WithMocks("pulumi-project", "dev", mocks))
+	require.NoError(t, err)
+
+	tmplName := mocks.names["gcp:compute/instanceTemplate:InstanceTemplate"]
+	assert.Equal(t, "smokeworker-tmpl", tmplName)
 }

--- a/provider/defanggcp/gcp/compute_test.go
+++ b/provider/defanggcp/gcp/compute_test.go
@@ -250,9 +250,15 @@ func TestSecretFetchScript(t *testing.T) {
 	assert.Contains(t, wf, `permissions: "0700"`)
 	assert.Contains(t, wf, "metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")
 	assert.Contains(t, wf, "https://secretmanager.googleapis.com/v1/projects/my-proj/secrets/")
-	assert.Contains(t, wf, `printf '%s=%s\n' 'DB' "$(sm 'Defang_p_s_DBPASS')"`)
-	assert.Contains(t, wf, `printf '%s=%s\n' 'API' "$(sm 'Defang_p_s_APIKEY')"`)
+	assert.Contains(t, wf, `v=$(sm 'Defang_p_s_DBPASS') || { echo "defang: failed to fetch secret Defang_p_s_DBPASS" >&2; exit 1; }`)
+	assert.Contains(t, wf, `printf '%s=%s\n' 'DB' "$v"`)
+	assert.Contains(t, wf, `v=$(sm 'Defang_p_s_APIKEY') || { echo "defang: failed to fetch secret Defang_p_s_APIKEY" >&2; exit 1; }`)
+	assert.Contains(t, wf, `printf '%s=%s\n' 'API' "$v"`)
 	assert.Contains(t, wf, "} > /run/defang/svc.env")
+	// fetch failures must fail ExecStartPre, never write an empty value
+	assert.Contains(t, wf, "set -euo pipefail")
+	assert.Contains(t, wf, `[ -n "$tok" ]`)
+	assert.Contains(t, wf, "curl -fsS")
 
 	// no refs -> no output
 	wf2, pre2, flag2 := secretFetchScript("p", "svc", nil)
@@ -294,7 +300,8 @@ func TestGetCloudInitConfigSecrets(t *testing.T) {
 	assert.Contains(t, cloudInit, "ExecStartPre=/opt/defang/api-secrets.sh")
 	assert.Contains(t, cloudInit, "--env-file /run/defang/api.env")
 	assert.Contains(t, cloudInit, "https://secretmanager.googleapis.com/v1/projects/gcp-proj/secrets/")
-	assert.Contains(t, cloudInit, `printf '%s=%s\n' 'SECRET_ENV' "$(sm 'Defang_proj_stack_SECRET_ENV')"`)
+	assert.Contains(t, cloudInit, `v=$(sm 'Defang_proj_stack_SECRET_ENV')`)
+	assert.Contains(t, cloudInit, `printf '%s=%s\n' 'SECRET_ENV' "$v"`)
 	// plain value inlined, secret value NOT inlined
 	assert.Contains(t, cloudInit, `-e "PLAIN=x"`)
 	assert.NotContains(t, cloudInit, `-e "SECRET_ENV`)

--- a/provider/defanggcp/gcp/compute_test.go
+++ b/provider/defanggcp/gcp/compute_test.go
@@ -250,9 +250,11 @@ func TestSecretFetchScript(t *testing.T) {
 	assert.Contains(t, wf, `permissions: "0700"`)
 	assert.Contains(t, wf, "metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")
 	assert.Contains(t, wf, "https://secretmanager.googleapis.com/v1/projects/my-proj/secrets/")
-	assert.Contains(t, wf, `v=$(sm 'Defang_p_s_DBPASS') || { echo "defang: failed to fetch secret Defang_p_s_DBPASS" >&2; exit 1; }`)
+	assert.Contains(t, wf,
+		`v=$(sm 'Defang_p_s_DBPASS') || { echo "defang: failed to fetch secret Defang_p_s_DBPASS" >&2; exit 1; }`)
 	assert.Contains(t, wf, `printf '%s=%s\n' 'DB' "$v"`)
-	assert.Contains(t, wf, `v=$(sm 'Defang_p_s_APIKEY') || { echo "defang: failed to fetch secret Defang_p_s_APIKEY" >&2; exit 1; }`)
+	assert.Contains(t, wf,
+		`v=$(sm 'Defang_p_s_APIKEY') || { echo "defang: failed to fetch secret Defang_p_s_APIKEY" >&2; exit 1; }`)
 	assert.Contains(t, wf, `printf '%s=%s\n' 'API' "$v"`)
 	assert.Contains(t, wf, "} > /run/defang/svc.env")
 	// fetch failures must fail ExecStartPre, never write an empty value

--- a/provider/defanggcp/gcp/gcp.go
+++ b/provider/defanggcp/gcp/gcp.go
@@ -41,8 +41,10 @@ type SharedInfra struct {
 	Etag string
 }
 
-// EnableGcpAPIs enables the GCP APIs required by the project.
-func EnableGcpAPIs(ctx *pulumi.Context, gcpProject string, opts ...pulumi.ResourceOption) error {
+// EnableGcpAPIs enables the GCP APIs required by the project. Project is
+// deliberately left unset on each Service: it falls back to the provider's
+// configured project when omitted.
+func EnableGcpAPIs(ctx *pulumi.Context, opts ...pulumi.ResourceOption) error {
 	apis := []string{
 		"storage.googleapis.com",              // Cloud Storage API
 		"artifactregistry.googleapis.com",     // Artifact Registry API
@@ -63,7 +65,6 @@ func EnableGcpAPIs(ctx *pulumi.Context, gcpProject string, opts ...pulumi.Resour
 	opts = append(opts, pulumi.RetainOnDelete(true))
 	for _, api := range apis {
 		if _, err := projects.NewService(ctx, api, &projects.ServiceArgs{
-			Project: pulumi.String(gcpProject),
 			Service: pulumi.String(api),
 		}, opts...); err != nil {
 			return fmt.Errorf("failed to enable API %s: %w", api, err)
@@ -99,14 +100,18 @@ func BuildGlobalConfig(
 	region := GcpRegion(ctx)
 	gcpProject := config.GetProject(ctx)
 
-	vpc, err := compute.NewNetwork(ctx, projectName+"-vpc", &compute.NetworkArgs{
+	// Logical names below deliberately omit projectName, same as the firewalls and
+	// private-dns zone further down: Pulumi's default resource ID already prefixes
+	// it with <pulumi-project>-<stack>, which includes projectName, so repeating it
+	// here risked exceeding GCP's 63-char resource ID limit.
+	vpc, err := compute.NewNetwork(ctx, "vpc", &compute.NetworkArgs{
 		AutoCreateSubnetworks: pulumi.Bool(false),
 	}, append(opts, pulumi.RetainOnDelete(true))...)
 	if err != nil {
 		return nil, err
 	}
 
-	subnet, err := compute.NewSubnetwork(ctx, projectName+"-subnet", &compute.SubnetworkArgs{
+	subnet, err := compute.NewSubnetwork(ctx, "subnet", &compute.SubnetworkArgs{
 		IpCidrRange: pulumi.String("10.0.0.0/16"),
 		Region:      pulumi.String(region),
 		Network:     vpc.ID(),
@@ -115,7 +120,7 @@ func BuildGlobalConfig(
 		return nil, err
 	}
 
-	publicIP, err := compute.NewGlobalAddress(ctx, projectName+"-ip", &compute.GlobalAddressArgs{
+	publicIP, err := compute.NewGlobalAddress(ctx, "ip", &compute.GlobalAddressArgs{
 		AddressType: pulumi.String("EXTERNAL"),
 	}, opts...)
 	if err != nil {
@@ -123,7 +128,13 @@ func BuildGlobalConfig(
 	}
 
 	// Allow SSH ingress to all instances in the VPC (required for GCP Console SSH).
-	if _, err := compute.NewFirewall(ctx, projectName+"-allow-ssh", &compute.FirewallArgs{
+	// Logical name deliberately omits projectName: Pulumi's default resource ID
+	// already prefixes it with <pulumi-project>-<stack>, which includes
+	// projectName, so repeating it here risked exceeding GCP's 63-char resource
+	// ID limit (observed: "...-allow-icmp-<hash>" at 64 chars, one over, while
+	// the one-shorter "...-allow-ssh-<hash>" landed at exactly 63 and happened
+	// to still pass). Same fix as the wildcard-cert name below.
+	if _, err := compute.NewFirewall(ctx, "allow-ssh", &compute.FirewallArgs{
 		Network:      vpc.ID(),
 		SourceRanges: pulumi.StringArray{pulumi.String("0.0.0.0/0")},
 		Allows: compute.FirewallAllowArray{
@@ -138,7 +149,7 @@ func BuildGlobalConfig(
 	}
 
 	// Allow ICMP ping to all instances in the VPC.
-	if _, err := compute.NewFirewall(ctx, projectName+"-allow-icmp", &compute.FirewallArgs{
+	if _, err := compute.NewFirewall(ctx, "allow-icmp", &compute.FirewallArgs{
 		Network:      vpc.ID(),
 		SourceRanges: pulumi.StringArray{pulumi.String("0.0.0.0/0")},
 		Allows: compute.FirewallAllowArray{
@@ -151,7 +162,11 @@ func BuildGlobalConfig(
 		return nil, err
 	}
 
-	privateZone, err := dns.NewManagedZone(ctx, projectName+"-private-dns", &dns.ManagedZoneArgs{
+	// Logical name deliberately omits projectName, same as the firewalls above and
+	// public-dns below: Pulumi's default resource ID already prefixes it with
+	// <pulumi-project>-<stack>, which includes projectName, so repeating it here
+	// risked exceeding GCP's 63-char resource ID limit.
+	privateZone, err := dns.NewManagedZone(ctx, "private-dns", &dns.ManagedZoneArgs{
 		Description: pulumi.String(fmt.Sprintf("Private DNS zone for %v", projectName)),
 		DnsName:     pulumi.String("google.internal."),
 		Visibility:  pulumi.String("private"),
@@ -217,7 +232,7 @@ func buildOptionalInfra(
 	}
 
 	if needsVpcPeering(services) {
-		serviceConn, err := createVPCPeeringInfra(ctx, projectName, cfg.VpcId, opts...)
+		serviceConn, err := createVPCPeeringInfra(ctx, cfg.VpcId, opts...)
 		if err != nil {
 			return err
 		}

--- a/provider/defanggcp/gcp/gcp.go
+++ b/provider/defanggcp/gcp/gcp.go
@@ -215,7 +215,7 @@ func buildOptionalInfra(
 	}
 
 	if externalRegistries := collectExternalRegistries(services); len(externalRegistries) > 0 {
-		repos, err := createRemoteRepos(ctx, externalRegistries, opts...)
+		repos, err := createRemoteRepos(ctx, projectName, externalRegistries, opts...)
 		if err != nil {
 			return err
 		}

--- a/provider/defanggcp/gcp/image.go
+++ b/provider/defanggcp/gcp/image.go
@@ -2,6 +2,7 @@ package gcp
 
 import (
 	"crypto/sha1" //nolint:gosec
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -40,16 +41,32 @@ func isCloudRunSupportedRegistry(registry string) bool {
 
 var nonLowerAlphaNumericOrDashRe = regexp.MustCompile(`[^a-z0-9-]`)
 
+const (
+	artifactRegistryRepositoryIDMaxLength  = 63
+	artifactRegistryRepositoryIDHashLength = 8
+)
+
 // sanitizeRepoName produces a valid Artifact Registry repository ID:
-// lowercase alphanumeric + hyphens, max 63 characters.
+// lowercase alphanumeric + hyphens, max 63 characters. Long names are simply
+// truncated; two names that share a 63-char prefix can collide, but that's an
+// acceptable tradeoff for keeping this straightforward.
 func sanitizeRepoName(name string) string {
+	original := name
 	name = strings.ToLower(name)
 	name = nonLowerAlphaNumericOrDashRe.ReplaceAllLiteralString(name, "-")
 	name = strings.Trim(name, "-")
-	if len(name) > 63 {
-		name = name[:63] // FIXME: this could lead to collisions
+	if name == "" {
+		return "repo-" + repositoryIDHash(original)
 	}
-	return strings.TrimRight(name, "-")
+	if len(name) > artifactRegistryRepositoryIDMaxLength {
+		name = strings.TrimRight(name[:artifactRegistryRepositoryIDMaxLength], "-")
+	}
+	return name
+}
+
+func repositoryIDHash(name string) string {
+	digest := sha256.Sum256([]byte(name))
+	return hex.EncodeToString(digest[:])[:artifactRegistryRepositoryIDHashLength]
 }
 
 // gcpBuildResource is the Pulumi resource state for the defang-gcp:defanggcp:Build custom resource.

--- a/provider/defanggcp/gcp/image_test.go
+++ b/provider/defanggcp/gcp/image_test.go
@@ -103,7 +103,7 @@ func TestIsCloudRunSupportedRegistry(t *testing.T) {
 		{"us-central1-docker.pkg.dev", true},
 		{"europe-west1-docker.pkg.dev", true},
 		{"quay.io", false},
-		{"ghcr.io", false},
+		{ghcrRegistry, false},
 		{"registry.example.com", false},
 		{"my-registry.io", false},
 	}
@@ -125,17 +125,26 @@ func TestSanitizeRepoName(t *testing.T) {
 		{"UPPER.CASE.IO", "upper-case-io"},
 		{"-leading-dash", "leading-dash"},
 		{"trailing-dash-", "trailing-dash"},
-		// 64-char input should be trimmed to 63
-		{
-			"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
-			"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
 			assert.Equal(t, tt.want, sanitizeRepoName(tt.input))
 		})
 	}
+}
+
+func TestSanitizeRepoNameShortensByTruncating(t *testing.T) {
+	long := strings.Repeat("a", artifactRegistryRepositoryIDMaxLength) + "1"
+
+	id := sanitizeRepoName(long)
+
+	require.Len(t, id, artifactRegistryRepositoryIDMaxLength)
+	assert.Equal(t, id, sanitizeRepoName(long), "repository IDs must be deterministic")
+	assert.Equal(t, strings.Repeat("a", artifactRegistryRepositoryIDMaxLength), id)
+}
+
+func TestSanitizeRepoNameNeverReturnsEmpty(t *testing.T) {
+	assert.Regexp(t, `^repo-[0-9a-f]{8}$`, sanitizeRepoName("..."))
 }
 
 func TestGetServiceImage(t *testing.T) {
@@ -191,11 +200,11 @@ func TestGetServiceImage(t *testing.T) {
 			wantImage: "us-central1-docker.pkg.dev/my-gcp-project/quay-io/prometheus/node-exporter:v1.8.0",
 		},
 		{
-			name:  "ghcr.io image rewritten to artifact registry",
-			svc:   compose.ServiceConfig{Image: pulumi.String("ghcr.io/owner/image:sha-abc123")},
+			name:  ghcrRegistry + " image rewritten to artifact registry",
+			svc:   compose.ServiceConfig{Image: pulumi.String(ghcrRegistry + "/owner/image:sha-abc123")},
 			infra: fakeInfra,
 			repos: map[string]*artifactregistry.Repository{
-				"ghcr.io": {RepositoryId: pulumi.String("ghcr-io").ToStringOutput()},
+				ghcrRegistry: {RepositoryId: pulumi.String("ghcr-io").ToStringOutput()},
 			},
 			wantImage: "us-central1-docker.pkg.dev/my-gcp-project/ghcr-io/owner/image:sha-abc123",
 		},

--- a/provider/defanggcp/gcp/vpc_peering.go
+++ b/provider/defanggcp/gcp/vpc_peering.go
@@ -21,11 +21,14 @@ func needsVpcPeering(services map[string]compose.ServiceConfig) bool {
 // connection for Cloud SQL private IP access.
 func createVPCPeeringInfra(
 	ctx *pulumi.Context,
-	projectName string,
 	vpcId pulumi.StringOutput,
 	opts ...pulumi.ResourceOption,
 ) (*servicenetworking.Connection, error) {
-	privateIpAlloc, err := compute.NewGlobalAddress(ctx, projectName+"-peering-ip", &compute.GlobalAddressArgs{
+	// Logical names below deliberately omit projectName: Pulumi's default resource
+	// ID already prefixes it with <pulumi-project>-<stack>, which includes
+	// projectName, so repeating it here risked exceeding GCP's 63-char resource
+	// ID limit.
+	privateIpAlloc, err := compute.NewGlobalAddress(ctx, "peering-ip", &compute.GlobalAddressArgs{
 		Purpose:      pulumi.String("VPC_PEERING"),
 		AddressType:  pulumi.String("INTERNAL"),
 		PrefixLength: pulumi.Int(16),
@@ -35,7 +38,7 @@ func createVPCPeeringInfra(
 		return nil, err
 	}
 
-	serviceConn, err := servicenetworking.NewConnection(ctx, projectName+"-svc-conn",
+	serviceConn, err := servicenetworking.NewConnection(ctx, "svc-conn",
 		&servicenetworking.ConnectionArgs{
 			Network:               vpcId,
 			Service:               pulumi.String("servicenetworking.googleapis.com"),

--- a/provider/defanggcp/project.go
+++ b/provider/defanggcp/project.go
@@ -101,7 +101,7 @@ func buildProject(
 	}
 	config.Etag = args.Etag
 
-	if err := providergcp.EnableGcpAPIs(ctx, config.GcpProject, childOpts...); err != nil {
+	if err := providergcp.EnableGcpAPIs(ctx, childOpts...); err != nil {
 		return nil, err
 	}
 
@@ -122,7 +122,7 @@ func buildProject(
 		_, err := projects.NewService(ctx, projectName+"-defang-llm", &projects.ServiceArgs{
 			Project: pulumi.StringPtr(config.GcpProject),
 			Service: pulumi.String("aiplatform.googleapis.com"),
-		}, pulumi.RetainOnDelete(true)) // Do not try disabling on compose down
+		}, append(childOpts, pulumi.RetainOnDelete(true))...) // Do not try disabling on compose down
 		if err != nil {
 			return nil, err
 		}

--- a/provider/defanggcp/service.go
+++ b/provider/defanggcp/service.go
@@ -314,7 +314,7 @@ func createService(
 			PolicyDeps: policyDeps,
 		}
 		ceResult, ceErr := providergcp.CreateComputeEngine(
-			ctx, serviceName, image, svc, ceArgs, infra, parentOpt,
+			ctx, configProvider, serviceName, image, svc, ceArgs, infra, parentOpt,
 		)
 		if ceErr != nil {
 			return fmt.Errorf("creating Compute Engine service %s: %w", serviceName, ceErr)

--- a/tests/aws/project_test.go
+++ b/tests/aws/project_test.go
@@ -194,7 +194,7 @@ func TestConstructAwsProjectAllResourcesAreChildren(t *testing.T) {
 				"worker": testutil.ServiceWithImage("myapp:worker"),
 				"builder": property.New(property.NewMap(map[string]property.Value{
 					"build": property.New(property.NewMap(map[string]property.Value{
-						"context": property.New("./app"),
+						"context": property.New("s3://bucket/uploads/digest.tar.gz"),
 					})),
 				})),
 				"db": property.New(property.NewMap(map[string]property.Value{

--- a/tests/gcp/image_test.go
+++ b/tests/gcp/image_test.go
@@ -23,7 +23,10 @@ import (
 	"github.com/DefangLabs/pulumi-defang/tests/testutil"
 )
 
-const gcpARRepositoryType = "gcp:artifactregistry/repository:Repository"
+const (
+	gcpARRepositoryType = "gcp:artifactregistry/repository:Repository"
+	remoteRepoPrefix    = "defang-name-stack-"
+)
 
 // isRemoteRepo returns true if the AR repository record represents a
 // REMOTE_REPOSITORY (pull-through cache), not a regular push repository.
@@ -67,8 +70,8 @@ func TestExternalRegistryRemoteRepoHasCorrectConfig(t *testing.T) {
 
 	repo := findTypeWhere(*records, gcpARRepositoryType, isRemoteRepo)
 	require.NotNil(t, repo, "expected an AR remote repo")
-	assert.Equal(t, "ghcr-io", repo.inputs.Get("repositoryId").AsString(),
-		"repo ID should be sanitized registry name")
+	assert.Equal(t, remoteRepoPrefix+"ghcr-io", repo.inputs.Get("repositoryId").AsString(),
+		"repo ID should include the project and stack-scoped naming prefix")
 	assert.Equal(t, "REMOTE_REPOSITORY", repo.inputs.Get("mode").AsString())
 
 	uri := repo.inputs.
@@ -148,10 +151,10 @@ func TestMultipleExternalRegistriesCreateSeparateRemoteRepos(t *testing.T) {
 		"two services from different external registries should create two remote repos")
 
 	ghcrRepo := findTypeWhere(*records, gcpARRepositoryType, func(m property.Map) bool {
-		return isRemoteRepo(m) && m.Get("repositoryId").AsString() == "ghcr-io"
+		return isRemoteRepo(m) && m.Get("repositoryId").AsString() == remoteRepoPrefix+"ghcr-io"
 	})
 	quayRepo := findTypeWhere(*records, gcpARRepositoryType, func(m property.Map) bool {
-		return isRemoteRepo(m) && m.Get("repositoryId").AsString() == "quay-io"
+		return isRemoteRepo(m) && m.Get("repositoryId").AsString() == remoteRepoPrefix+"quay-io"
 	})
 	assert.NotNil(t, ghcrRepo, "expected remote repo for ghcr.io")
 	assert.NotNil(t, quayRepo, "expected remote repo for quay.io")


### PR DESCRIPTION
**Do not merge — CI image vehicle only.**

This branch stacks three real PRs together purely so `test.yml` publishes `ghcr.io/defanglabs/cd:pr-423` for the `defang-mvp` `new-provider-sanity` smoketest (see DefangLabs/defang-mvp#3181):

- #467 — GCP Compute Engine: native secrets for env via boot-fetch (pulumi-defang#358)
- #469 — GCP: scope Artifact Registry repository IDs per project/stack (fixes #457)
- #470 — AWS: extract the tar.gz build context CodeBuild won't auto-unzip

All the actual review and merge activity happens on those three PRs. This branch will be closed (or just left to rot) once the smoketest run it's feeding is done — it is not a merge vehicle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added default GCP autonaming patterns for compute and networking resources.
  * Added support for scoped, customizable Artifact Registry repository names.
  * Improved GCP Compute Engine secret handling using secure runtime retrieval.

* **Bug Fixes**
  * AWS CodeBuild now supports multiple S3 URL formats and extracts `.tar.gz` and `.tgz` sources correctly.
  * Improved GCP load-balancer naming consistency and prevented naming collisions.
  * Repository names and generated image URLs are now reliably truncated and sanitized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->