### PR TITLE
fix(tests): synchronize mock-monitor captures in AWS project tests

### DIFF
--- a/tests/aws/project_test.go
+++ b/tests/aws/project_test.go
@@ -12,6 +12,7 @@ package aws
 
 import (
 	"encoding/json"
+	"sync"
 	"testing"
 
 	p "github.com/pulumi/pulumi-go-provider"
@@ -42,10 +43,14 @@ func TestConstructAwsProject(t *testing.T) {
 // network_mode: "service:<name>" is folded into the parent's task definition
 // as an additional container instead of being deployed as its own ECS service.
 func TestConstructAwsProjectFoldsSidecars(t *testing.T) {
+	// NewResourceF runs concurrently (one goroutine per resource registration),
+	// so captures must be synchronized.
+	var mu sync.Mutex
 	var taskDefs []property.Map
 	ecsServices := 0
 	mock := &integration.MockResourceMonitor{
 		NewResourceF: func(args integration.MockResourceArgs) (string, property.Map, error) {
+			mu.Lock()
 			switch string(args.TypeToken) {
 			case "aws:ecs/taskDefinition:TaskDefinition":
 				taskDefs = append(taskDefs, args.Inputs)
@@ -53,6 +58,7 @@ func TestConstructAwsProjectFoldsSidecars(t *testing.T) {
 				ecsServices++
 			default:
 			}
+			mu.Unlock()
 			return args.Name, args.Inputs, nil
 		},
 	}
@@ -229,11 +235,16 @@ func TestConstructAwsProjectRejectsForeignPolicies(t *testing.T) {
 }
 
 func TestConstructAwsProjectPoliciesNormalized(t *testing.T) {
+	// NewResourceF runs concurrently; the unsynchronized append here used to
+	// drop attachments occasionally, failing this test flakily in CI.
+	var mu sync.Mutex
 	var attachments []property.Map
 	mock := &integration.MockResourceMonitor{
 		NewResourceF: func(args integration.MockResourceArgs) (string, property.Map, error) {
 			if string(args.TypeToken) == "aws:iam/rolePolicyAttachment:RolePolicyAttachment" {
+				mu.Lock()
 				attachments = append(attachments, args.Inputs)
+				mu.Unlock()
 			}
 			return args.Name, args.Inputs, nil
 		},
@@ -268,11 +279,14 @@ func TestConstructAwsProjectPoliciesNormalized(t *testing.T) {
 }
 
 func TestConstructAwsProjectDuplicatePoliciesDeduped(t *testing.T) {
+	var mu sync.Mutex
 	var attachments []property.Map
 	mock := &integration.MockResourceMonitor{
 		NewResourceF: func(args integration.MockResourceArgs) (string, property.Map, error) {
 			if string(args.TypeToken) == "aws:iam/rolePolicyAttachment:RolePolicyAttachment" {
+				mu.Lock()
 				attachments = append(attachments, args.Inputs)
+				mu.Unlock()
 			}
 			return args.Name, args.Inputs, nil
 		},


### PR DESCRIPTION
Fixes the `test` failure on main ([run 32191173619](https://github.com/DefangLabs/pulumi-defang/actions/runs/32191173619)): `TestConstructAwsProjectPoliciesNormalized` asserted that the captured role-policy attachments contain `AmazonS3ReadOnlyAccess`, but the slice only held 2 of the 3 attachments.

## Root cause

`NewResourceF` on the mock resource monitor is invoked concurrently — one goroutine per resource registration. Three mocks in `tests/aws/project_test.go` appended to a captured slice (or bumped a counter) without synchronization, so a concurrent append could lose an element. The `tests/` suite runs **without** `-race` in CI (only `cd/` uses it), so this surfaced as a rare flake instead of a detector report. It is unrelated to PR 421, which merely triggered the run.

Reproduced locally: `go test -race -run TestConstructAwsProjectPolicies -short ./aws/...` reports the race immediately on main.

## Fix

Guard the three capturing mocks with a `sync.Mutex` — the same pattern `tests/testutil/parent_check.go` and `tests/gcp/project_test.go` already use. The single-value captures in `ecs_service_test.go` / `gcp/service_test.go` are left alone: each has exactly one matching resource, so there is no concurrent write.

Verified: `go test -race -count=5 -short ./aws/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J163J63iUG83y1yS1dz4JT