### PR TITLE
cd: drop the TTL minimum, the CLI enforces it now

### DIFF
--- a/cd/program/selfdestruct_aws.go
+++ b/cd/program/selfdestruct_aws.go
@@ -104,8 +104,11 @@ func createAWSSelfDestruct(pctx *pulumi.Context, cf *compose.Project, ttl time.D
 
 	_, err = scheduler.NewSchedule(pctx, "self-destruct", &scheduler.ScheduleArgs{
 		Description: pulumi.Sprintf("defang self-destruct for %s/%s", cf.Name, pctx.Stack()),
-		// One-time schedule, evaluated in UTC (the provider default); a fire
-		// time in the past is rejected at create, which minTTL prevents.
+		// One-time schedule, evaluated in UTC (the provider default). AWS
+		// rejects a fire time in the past at create — the CLI's minTTL floor
+		// keeps that from happening for real deploys, but a short TTL from a
+		// test or manual CD invocation can still hit it if this resource
+		// isn't created until after fireAt has passed.
 		ScheduleExpression: pulumi.String(fmt.Sprintf("at(%s)", fireAt.UTC().Format("2006-01-02T15:04:05"))),
 		FlexibleTimeWindow: scheduler.ScheduleFlexibleTimeWindowArgs{
 			Mode: pulumi.String("OFF"),

--- a/cd/program/ttl.go
+++ b/cd/program/ttl.go
@@ -16,14 +16,6 @@ import (
 // DefangLabs/defang issue 2213 for aligning that with this value.)
 const CdTimeout = time.Hour
 
-// minTTL is the shortest supported time-to-live. The trigger's clock starts
-// when the deploy creates it, but resources can take 10+ minutes to finish
-// provisioning after that — a short TTL could tear the stack down while (or
-// right after) it comes up. It also keeps the fire time safely in the future:
-// cron-based triggers (Azure, GCP) silently postpone a passed occurrence by a
-// whole year.
-const minTTL = time.Hour
-
 // maxTTL guards against typo'd far-future dates.
 const maxTTL = 10 * 365 * 24 * time.Hour
 
@@ -33,6 +25,13 @@ const maxTTL = 10 * 365 * 24 * time.Hour
 // "7d12h"), parsed by the same timeutils.ParseDuration the CLI validates
 // the value with, so the two sides cannot drift. The CLI's ParseTTL already
 // trims and lowercases before setting DEFANG_TTL, so this doesn't repeat it.
+//
+// There is deliberately no minimum here (the CLI's ParseTTL enforces a 1h
+// floor for real deployments — see byoc.ParseTTL in the defang CLI repo) so a
+// test or manual CD invocation that bypasses the CLI can use a short TTL
+// (seconds or minutes) to verify the self-destruct trigger actually fires,
+// without waiting an hour. A stack driven by the real CLI never sees
+// anything shorter than the CLI's floor.
 func parseTTL(value string) (time.Duration, error) {
 	switch value {
 	case "", "never", "0":
@@ -43,8 +42,8 @@ func parseTTL(value string) (time.Duration, error) {
 	if err != nil {
 		return 0, fmt.Errorf("invalid ttl %q: %w", value, err)
 	}
-	if d < minTTL || d > maxTTL {
-		return 0, fmt.Errorf("ttl %q must be between %s and %s", value, minTTL, maxTTL)
+	if d <= 0 || d > maxTTL {
+		return 0, fmt.Errorf("ttl %q must be between 0 and %s", value, maxTTL)
 	}
 	return d, nil
 }

--- a/cd/program/ttl_test.go
+++ b/cd/program/ttl_test.go
@@ -20,13 +20,14 @@ func TestParseTTL(t *testing.T) {
 		{"1h30m", 90 * time.Minute, false},
 		{"7d", 7 * 24 * time.Hour, false},
 		{"7d12h", 7*24*time.Hour + 12*time.Hour, false},
-		{"1h", time.Hour, false}, // exactly the minimum
-		{"59m", 0, true},         // below the minimum
-		{"5m", 0, true},          // below the minimum
-		{"-1h", 0, true},         // negative
-		{"-1d48h", 0, true},      // negative day prefix
-		{"213504d", 0, true},     // would overflow time.Duration
-		{"3651d", 0, true},       // above the maximum
+		{"1h", time.Hour, false},         // no CD-side minimum; the CLI enforces one
+		{"59m", 59 * time.Minute, false}, // no CD-side minimum
+		{"5m", 5 * time.Minute, false},   // no CD-side minimum
+		{"1s", time.Second, false},       // no CD-side minimum
+		{"-1h", 0, true},                 // negative
+		{"-1d48h", 0, true},              // negative day prefix
+		{"213504d", 0, true},             // would overflow time.Duration
+		{"3651d", 0, true},               // above the maximum
 		{"tomorrow", 0, true},
 		{"12", 0, true},   // bare number (only "0" is special)
 		{"d", 0, true},    // no digits


### PR DESCRIPTION
## Summary
- Removes the CD-side `minTTL` (1h) floor from \`cd/program/ttl.go\`'s \`parseTTL\`. \`maxTTL\` (10y, typo guard) is unchanged.
- The CLI now enforces the 1h floor (DefangLabs/defang PR 2219), so real deployments through the CLI are unaffected — they still can't set a TTL below 1h.
- Lets a test or manual CD invocation (bypassing the CLI's ParseTTL) use a short TTL to verify the self-destruct trigger actually fires, instead of waiting an hour.
- Updates the AWS self-destruct comment: a too-short TTL can still hit AWS's "fire time in the past" rejection at create if the trigger resource isn't created until after `fireAt` — that's now a real (and correct) failure mode for a too-aggressive test TTL, not something `minTTL` prevents anymore. Azure/GCP use cron triggers instead, which silently defer to next year rather than erroring (see `selfDestructCron`'s existing doc comment) — worth keeping in mind when picking a short test TTL on those clouds.

Companion change: DefangLabs/defang src/pkg/cli/client/byoc/ttl.go — https://github.com/DefangLabs/defang/pull/2219

## Test plan
- [x] `go test ./cd/program/...` passes with updated cases (`59m`/`5m`/`1s` now valid; only negative/zero/overflow/above-max still reject)
- [x] `go build ./...` and `go vet ./...` clean in `cd/`
- [x] `golangci-lint run ./program/...` shows no new findings (confirmed via `git stash` diff against the pre-change baseline)
- [ ] `-race` variant (`make test_cd`) not run in this sandbox — no gcc/cgo available; ran `go test` without `-race` instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Short positive TTL values are now accepted when creating resources.
  * TTL validation continues to reject zero, negative, and excessively long durations.
  * Improved handling and documentation for AWS scheduling when resource creation is delayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->