### PR TITLE
fix(cd): don't abort final upload on cancellation

### DIFF
--- a/cd/upload.go
+++ b/cd/upload.go
@@ -16,10 +16,26 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 )
 
+// finalUploadTimeout bounds the final events/state upload once it's detached
+// from the run's own ctx (see detachUploadContext) so a dead network can't
+// hang process exit forever.
+const finalUploadTimeout = 30 * time.Second
+
+// detachUploadContext strips ctx's cancellation. ctx is canceled by SIGINT/
+// SIGTERM/timeout (main.go) right as the final events/state upload starts,
+// which aborted the upload before anything was written. The final upload is
+// exactly the thing we still want to happen on cancellation, so give it its
+// own bounded timeout instead of inheriting the cancellation it's reacting to.
+func detachUploadContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), finalUploadTimeout)
+}
+
 func uploadEvents[T any](ctx context.Context, eventsUploadUrl string, engineEvents []T) {
 	if eventsUploadUrl == "" {
 		return
 	}
+	ctx, cancel := detachUploadContext(ctx)
+	defer cancel()
 	// We also upload empty events to signal the Portal that the deployment has
 	// completed, so log at least the count even if the upload fails.
 	Println("Sending", len(engineEvents), "deployment events to Portal...")
@@ -32,6 +48,8 @@ func uploadState(ctx context.Context, statesUploadUrl string, stack auto.Stack) 
 	if statesUploadUrl == "" {
 		return
 	}
+	ctx, cancel := detachUploadContext(ctx)
+	defer cancel()
 	Println("Sending deployment state to Portal...")
 	state, err := stack.Export(ctx)
 	if err != nil {

--- a/cd/upload_test.go
+++ b/cd/upload_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -83,6 +84,45 @@ func TestUploadEventsSendsPayload(t *testing.T) {
 	evts, ok := got["events"].([]any)
 	if !ok || len(evts) != 1 {
 		t.Errorf("expected 1 event, got %v", got)
+	}
+}
+
+func TestUploadEventsSurvivesCanceledContext(t *testing.T) {
+	// Regression test for https://github.com/DefangLabs/pulumi-defang/issues/103:
+	// SIGINT/SIGTERM/timeout cancel the run's ctx right before the final
+	// upload starts, which used to abort the upload before anything was sent.
+	var called atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called.Store(true)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // simulate SIGINT/SIGTERM/timeout firing before the final upload
+
+	uploadEvents(ctx, srv.URL, []events.EngineEvent{{}})
+
+	if !called.Load() {
+		t.Error("expected the upload to still be sent after ctx was canceled")
+	}
+}
+
+func TestDetachUploadContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if ctx.Err() == nil {
+		t.Fatal("test setup: parent ctx should be canceled")
+	}
+
+	detached, cancelDetached := detachUploadContext(ctx)
+	defer cancelDetached()
+
+	if err := detached.Err(); err != nil {
+		t.Errorf("expected detached context to not be canceled, got %v", err)
+	}
+	if _, ok := detached.Deadline(); !ok {
+		t.Error("expected detached context to carry its own deadline")
 	}
 }
 


### PR DESCRIPTION
Closes #103 

## Summary
- The run's `ctx` is canceled by SIGINT/SIGTERM/timeout right as the final events/state upload starts (`cd/main.go:32-40` → `cd/upload.go`), aborting the upload before anything is written.
- Detach the final `uploadEvents`/`uploadState` upload from that cancellation via `context.WithoutCancel` + its own bounded 30s timeout, so it can still complete after cancellation instead of failing immediately, while still not hanging exit forever if the network is dead.

This only fixes the cancellation half of the two contributing paths noted in https://github.com/DefangLabs/pulumi-defang/issues/103#issuecomment-4999060627. The other path (the `cancel` command itself collecting no events) is out of scope here.

## Test plan
- [x] `go build ./...` and `go vet ./...` (cd module)
- [x] `go test -race ./...` (cd module) — all green, including new regression tests
- [x] Added `TestUploadEventsSurvivesCanceledContext` and `TestDetachUploadContext` covering the fix