### PR TITLE
fix(gcp): stop the VPC firewall rules from exceeding GCP's 63-char name limit

### DIFF
--- a/provider/defanggcp/gcp/gcp.go
+++ b/provider/defanggcp/gcp/gcp.go
@@ -123,7 +123,13 @@ func BuildGlobalConfig(
 	}
 
 	// Allow SSH ingress to all instances in the VPC (required for GCP Console SSH).
-	if _, err := compute.NewFirewall(ctx, projectName+"-allow-ssh", &compute.FirewallArgs{
+	// Logical name deliberately omits projectName: Pulumi's default resource ID
+	// already prefixes it with <pulumi-project>-<stack>, which includes
+	// projectName, so repeating it here risked exceeding GCP's 63-char resource
+	// ID limit (observed: "...-allow-icmp-<hash>" at 64 chars, one over, while
+	// the one-shorter "...-allow-ssh-<hash>" landed at exactly 63 and happened
+	// to still pass). Same fix as the wildcard-cert name below.
+	if _, err := compute.NewFirewall(ctx, "allow-ssh", &compute.FirewallArgs{
 		Network:      vpc.ID(),
 		SourceRanges: pulumi.StringArray{pulumi.String("0.0.0.0/0")},
 		Allows: compute.FirewallAllowArray{
@@ -138,7 +144,7 @@ func BuildGlobalConfig(
 	}
 
 	// Allow ICMP ping to all instances in the VPC.
-	if _, err := compute.NewFirewall(ctx, projectName+"-allow-icmp", &compute.FirewallArgs{
+	if _, err := compute.NewFirewall(ctx, "allow-icmp", &compute.FirewallArgs{
 		Network:      vpc.ID(),
 		SourceRanges: pulumi.StringArray{pulumi.String("0.0.0.0/0")},
 		Allows: compute.FirewallAllowArray{

--- a/tests/gcp/project_test.go
+++ b/tests/gcp/project_test.go
@@ -136,6 +136,10 @@ func TestConstructProjectAlwaysCreatesVPCFirewalls(t *testing.T) {
 	})
 	require.NotNil(t, ssh, "expected an SSH firewall rule")
 	assert.Equal(t, "INGRESS", ssh.inputs.Get("direction").AsString())
+	// Logical name must not re-embed the project name: Pulumi's default resource
+	// ID already prefixes <pulumi-project>-<stack>, which includes it, and
+	// doing so again pushed the physical name over GCP's 63-char limit.
+	assert.Equal(t, "allow-ssh", ssh.name)
 
 	// ICMP firewall rule
 	icmp := findTypeWhere(*records, "gcp:compute/firewall:Firewall", func(m property.Map) bool {
@@ -144,6 +148,7 @@ func TestConstructProjectAlwaysCreatesVPCFirewalls(t *testing.T) {
 	})
 	require.NotNil(t, icmp, "expected an ICMP firewall rule")
 	assert.Equal(t, "INGRESS", icmp.inputs.Get("direction").AsString())
+	assert.Equal(t, "allow-icmp", icmp.name)
 }
 
 func TestConstructProjectAlwaysCreatesPrivateDNSZone(t *testing.T) {


### PR DESCRIPTION
## Summary
This is the root cause of the "unexplained" GCP failures in DefangLabs/defang-mvp#3181's `new-provider-sanity` workflow — every run so far, going back before pulumi-defang#358, hit a generic wrapper error:
```
failed to poll build operation: rpc error: code = Unknown desc = Build failed; check build logs for details
```
`gcloud builds log <BUILD_ID> --project defang-playground-dev` (the CLI's Cloud Build log tail excludes `labels.build_step="MAIN"`, hiding this) shows the real error, consistently across all three runs I checked:
```
gcp:compute/firewall:Firewall resource 'html-css-js-allow-icmp' has a problem: "name" ("defang-html-css-js-newprovidergcp-html-css-js-allow-icmp-2ffa9f1") doesn't match regexp "^(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)$"
```

## Root cause
`compute.NewFirewall(ctx, projectName+"-allow-icmp", ...)` gives the resource a Pulumi *logical* name that redundantly re-embeds `projectName`. Pulumi's default physical resource ID already prefixes `<pulumi-project>-<stack>-<logical-name>-<hash>`, and the stack name here already contains the compose project name (`html-css-js-newprovidergcp`). Repeating it produces a 64-character name — one over GCP's 63-char limit — while the one-character-shorter `-allow-ssh` variant happens to land at exactly 63 and pass. Confirmed by exact length count on all three observed failures (64 chars every time for `-icmp`, 63 for `-ssh`).

This isn't smoketest-specific: any real customer with a sufficiently long project + stack name combination would hit the exact same failure on the AWS... er, GCP new provider today.

There's already an established fix for this exact class of bug a few lines down in the same file (the `wildcard-cert` resource, with the comment "Use a short name without the FQDN to stay within GCP's 63-char resource ID limit") — this PR just extends that pattern to the two firewalls.

## Change
Drop the redundant `projectName+"-"` prefix from both firewalls' Pulumi logical names (`allow-ssh`, `allow-icmp`). Uniqueness across concurrent stacks in the same GCP project is unaffected — that still comes from Pulumi's own `<project>-<stack>-` autoname prefix.

## Test plan
- [x] `go test ./tests/gcp/...` passes; strengthened `TestConstructProjectAlwaysCreatesVPCFirewalls` to assert the exact logical name (verified it fails on the old `projectName+"-allow-*"` form)
- [x] `golangci-lint run ./provider/defanggcp/...` and `./tests/gcp/...` — no new findings
- [ ] Re-dispatch `new-provider-sanity.yml` with this fix baked into a `pr-423`-style image to confirm the GCP leg gets past firewall creation (next blocker after that, if any, is the `storage.buckets.create` 403 on `defang-cd@defang-playground-dev.iam.gserviceaccount.com` — looks like a separate IAM grant gap in that project, not a code issue, but flagging here too)