### PR TITLE
fix: give the shared load-balancer and DNS children collision-free names

### DIFF
--- a/provider/defangaws/aws/naming.go
+++ b/provider/defangaws/aws/naming.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
@@ -8,6 +10,10 @@ import (
 
 const autonamingSuffixLen = 5 // "-" + hex(4) from autonaming stack config
 const tgMaxNameLen = 32
+
+// tgNameHashLen is how much of a truncated service name is given over to a
+// hash of the whole of it.
+const tgNameHashLen = 6
 
 // targetGroupName builds a logical Pulumi resource name for a TargetGroup.
 // The physical name (with its 32-char AWS limit) is handled by autonaming config.
@@ -27,7 +33,12 @@ func targetGroupName(
 
 	maxService := tgMaxNameLen - autonamingSuffixLen - len(suffix)
 	if len(service) > maxService {
-		service = service[:maxService]
+		// Plain truncation made two long service names that share a prefix
+		// collide, and two target groups with one logical name is a duplicate
+		// URN that fails the whole deploy. Trade the tail for a hash of the
+		// full name; short names are untouched.
+		digest := sha256.Sum256([]byte(service))
+		service = service[:maxService-tgNameHashLen] + hex.EncodeToString(digest[:])[:tgNameHashLen]
 	}
 
 	return service + suffix

--- a/provider/defangaws/aws/naming_test.go
+++ b/provider/defangaws/aws/naming_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
@@ -55,4 +56,19 @@ func TestBuildVolumesFromQualifiesNames(t *testing.T) {
 	require.Len(t, vols, 1)
 	assert.Equal(t, "helper_kg7lqwrfnfxa", *vols[0].SourceContainer)
 	assert.True(t, *vols[0].ReadOnly)
+}
+
+// Two long service names that share a prefix must not collapse onto one target
+// group logical name: same type, same parent, one name is a duplicate URN.
+func TestTargetGroupNameLongPrefixesDoNotCollide(t *testing.T) {
+	prefix := strings.Repeat("service", 5)
+
+	first := targetGroupName(prefix+"-alpha", 3000, "", compose.PortListenerDefault)
+	second := targetGroupName(prefix+"-bravo", 3000, "", compose.PortListenerDefault)
+
+	require.LessOrEqual(t, len(first), tgMaxNameLen-autonamingSuffixLen)
+	require.LessOrEqual(t, len(second), tgMaxNameLen-autonamingSuffixLen)
+	assert.NotEqual(t, first, second)
+	assert.Equal(t, first, targetGroupName(prefix+"-alpha", 3000, "", compose.PortListenerDefault),
+		"target group names must be deterministic")
 }

--- a/provider/defangazure/azure/dns.go
+++ b/provider/defangazure/azure/dns.go
@@ -60,9 +60,10 @@ func CreateDNSZones(
 			return nil, fmt.Errorf("creating postgres private DNS zone: %w", err)
 		}
 
-		// "link" alone: the zone above parents it, in Pulumi and in Azure's own
-		// resource ID, so the name has nothing left to disambiguate.
-		_, err = privatedns.NewVirtualNetworkLink(ctx, "link", &privatedns.VirtualNetworkLinkArgs{
+		// Named for its zone, not "link": a Pulumi URN inherits its parent's
+		// TYPE but not its name, so two links called "link" under two
+		// PrivateZone parents would produce one URN and fail the deploy.
+		_, err = privatedns.NewVirtualNetworkLink(ctx, "postgres", &privatedns.VirtualNetworkLinkArgs{
 			ResourceGroupName:   infra.ResourceGroup.Name,
 			PrivateZoneName:     pgZone.Name,
 			Location:            pulumi.String("global"),
@@ -90,7 +91,7 @@ func CreateDNSZones(
 			return nil, fmt.Errorf("creating Redis private DNS zone: %w", err)
 		}
 
-		redisLink, err := privatedns.NewVirtualNetworkLink(ctx, "link", &privatedns.VirtualNetworkLinkArgs{
+		redisLink, err := privatedns.NewVirtualNetworkLink(ctx, "redis", &privatedns.VirtualNetworkLinkArgs{
 			ResourceGroupName:   infra.ResourceGroup.Name,
 			PrivateZoneName:     redisZone.Name,
 			Location:            pulumi.String("global"),

--- a/provider/defangazure/azure/dns.go
+++ b/provider/defangazure/azure/dns.go
@@ -7,6 +7,24 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
+// renamedFrom preserves the URN a resource had before this package stopped
+// naming project-shared DNS resources after a service. Azure is in production,
+// so every rename here carries its old name; an empty or unchanged old name
+// yields no alias.
+// The logical names of the project-shared DNS resources. Both a zone and its
+// link may carry the same one: they differ in type, so their URNs differ.
+const (
+	postgresName = "postgres"
+	redisName    = "redis"
+)
+
+func renamedFrom(oldName, newName string) []pulumi.ResourceOption {
+	if oldName == "" || oldName == newName {
+		return nil
+	}
+	return []pulumi.ResourceOption{pulumi.Aliases([]pulumi.Alias{{Name: pulumi.String(oldName)}})}
+}
+
 // DNSResult holds private DNS zones for a project.
 type DNSResult struct {
 	// PostgresZoneName is the private DNS zone used by PostgreSQL Flexible Servers
@@ -51,11 +69,11 @@ func CreateDNSZones(
 	if pgServiceName != "" {
 		// Postgres private DNS zone — name must end in ".private.postgres.database.azure.com".
 		pgZoneName := projectName + ".private.postgres.database.azure.com"
-		pgZone, err := privatedns.NewPrivateZone(ctx, "postgres", &privatedns.PrivateZoneArgs{
+		pgZone, err := privatedns.NewPrivateZone(ctx, postgresName, &privatedns.PrivateZoneArgs{
 			ResourceGroupName: infra.ResourceGroup.Name,
 			Location:          pulumi.String("global"),
 			PrivateZoneName:   pulumi.String(pgZoneName),
-		}, opts...)
+		}, append(opts, renamedFrom(pgServiceName, postgresName)...)...)
 		if err != nil {
 			return nil, fmt.Errorf("creating postgres private DNS zone: %w", err)
 		}
@@ -63,13 +81,13 @@ func CreateDNSZones(
 		// Named for its zone, not "link": a Pulumi URN inherits its parent's
 		// TYPE but not its name, so two links called "link" under two
 		// PrivateZone parents would produce one URN and fail the deploy.
-		_, err = privatedns.NewVirtualNetworkLink(ctx, "postgres", &privatedns.VirtualNetworkLinkArgs{
+		_, err = privatedns.NewVirtualNetworkLink(ctx, postgresName, &privatedns.VirtualNetworkLinkArgs{
 			ResourceGroupName:   infra.ResourceGroup.Name,
 			PrivateZoneName:     pgZone.Name,
 			Location:            pulumi.String("global"),
 			RegistrationEnabled: pulumi.Bool(false),
 			VirtualNetwork:      &privatedns.SubResourceArgs{Id: networking.VNet.ID().ToStringOutput()},
-		}, append(opts, pulumi.Parent(pgZone))...)
+		}, append(append(opts, pulumi.Parent(pgZone)), renamedFrom(pgServiceName, postgresName)...)...)
 		if err != nil {
 			return nil, fmt.Errorf("creating postgres DNS VNet link: %w", err)
 		}
@@ -82,22 +100,22 @@ func CreateDNSZones(
 		// Redis Enterprise private DNS zone — required for private endpoint DNS resolution.
 		// Azure resolves <cluster>.westus3.redis.azure.net → <cluster>.privatelink.redis.azure.net
 		// and this zone maps that to the private endpoint IP.
-		redisZone, err := privatedns.NewPrivateZone(ctx, "redis", &privatedns.PrivateZoneArgs{
+		redisZone, err := privatedns.NewPrivateZone(ctx, redisName, &privatedns.PrivateZoneArgs{
 			ResourceGroupName: infra.ResourceGroup.Name,
 			Location:          pulumi.String("global"),
 			PrivateZoneName:   pulumi.String("privatelink.redis.azure.net"),
-		}, opts...)
+		}, append(opts, renamedFrom(redisServiceName, redisName)...)...)
 		if err != nil {
 			return nil, fmt.Errorf("creating Redis private DNS zone: %w", err)
 		}
 
-		redisLink, err := privatedns.NewVirtualNetworkLink(ctx, "redis", &privatedns.VirtualNetworkLinkArgs{
+		redisLink, err := privatedns.NewVirtualNetworkLink(ctx, redisName, &privatedns.VirtualNetworkLinkArgs{
 			ResourceGroupName:   infra.ResourceGroup.Name,
 			PrivateZoneName:     redisZone.Name,
 			Location:            pulumi.String("global"),
 			RegistrationEnabled: pulumi.Bool(false),
 			VirtualNetwork:      &privatedns.SubResourceArgs{Id: networking.VNet.ID().ToStringOutput()},
-		}, append(opts, pulumi.Parent(redisZone))...)
+		}, append(append(opts, pulumi.Parent(redisZone)), renamedFrom(redisServiceName, redisName)...)...)
 		if err != nil {
 			return nil, fmt.Errorf("creating Redis DNS VNet link: %w", err)
 		}

--- a/provider/defangazure/azure/dns.go
+++ b/provider/defangazure/azure/dns.go
@@ -33,8 +33,12 @@ type DNSResult struct {
 //  1. A postgres zone ("<project>.private.postgres.database.azure.com") for Flexible Server integration.
 //  2. The Redis Enterprise privatelink zone for private endpoint resolution.
 //
-// pgServiceName and redisServiceName are the compose service names used as
-// Pulumi logical names; pass empty to skip that kind's zone entirely.
+// pgServiceName and redisServiceName only select which zones are needed; pass
+// empty to skip that kind's zone entirely. They are deliberately NOT used as
+// logical names: both zones are project-shared, the caller picks the first
+// alphabetical service of each kind, and naming a shared resource after one of
+// its users means adding an earlier-sorting service replaces the zone the rest
+// of the project is already resolving through.
 func CreateDNSZones(
 	ctx *pulumi.Context,
 	projectName, pgServiceName, redisServiceName string,
@@ -47,17 +51,18 @@ func CreateDNSZones(
 	if pgServiceName != "" {
 		// Postgres private DNS zone — name must end in ".private.postgres.database.azure.com".
 		pgZoneName := projectName + ".private.postgres.database.azure.com"
-		pgZone, err := privatedns.NewPrivateZone(ctx, pgServiceName, &privatedns.PrivateZoneArgs{
+		pgZone, err := privatedns.NewPrivateZone(ctx, "postgres", &privatedns.PrivateZoneArgs{
 			ResourceGroupName: infra.ResourceGroup.Name,
 			Location:          pulumi.String("global"),
 			PrivateZoneName:   pulumi.String(pgZoneName),
-			Tags:              ServiceTags(pgServiceName),
 		}, opts...)
 		if err != nil {
 			return nil, fmt.Errorf("creating postgres private DNS zone: %w", err)
 		}
 
-		_, err = privatedns.NewVirtualNetworkLink(ctx, pgServiceName, &privatedns.VirtualNetworkLinkArgs{
+		// "link" alone: the zone above parents it, in Pulumi and in Azure's own
+		// resource ID, so the name has nothing left to disambiguate.
+		_, err = privatedns.NewVirtualNetworkLink(ctx, "link", &privatedns.VirtualNetworkLinkArgs{
 			ResourceGroupName:   infra.ResourceGroup.Name,
 			PrivateZoneName:     pgZone.Name,
 			Location:            pulumi.String("global"),
@@ -76,17 +81,16 @@ func CreateDNSZones(
 		// Redis Enterprise private DNS zone — required for private endpoint DNS resolution.
 		// Azure resolves <cluster>.westus3.redis.azure.net → <cluster>.privatelink.redis.azure.net
 		// and this zone maps that to the private endpoint IP.
-		redisZone, err := privatedns.NewPrivateZone(ctx, redisServiceName, &privatedns.PrivateZoneArgs{
+		redisZone, err := privatedns.NewPrivateZone(ctx, "redis", &privatedns.PrivateZoneArgs{
 			ResourceGroupName: infra.ResourceGroup.Name,
 			Location:          pulumi.String("global"),
 			PrivateZoneName:   pulumi.String("privatelink.redis.azure.net"),
-			Tags:              ServiceTags(redisServiceName),
 		}, opts...)
 		if err != nil {
 			return nil, fmt.Errorf("creating Redis private DNS zone: %w", err)
 		}
 
-		redisLink, err := privatedns.NewVirtualNetworkLink(ctx, redisServiceName, &privatedns.VirtualNetworkLinkArgs{
+		redisLink, err := privatedns.NewVirtualNetworkLink(ctx, "link", &privatedns.VirtualNetworkLinkArgs{
 			ResourceGroupName:   infra.ResourceGroup.Name,
 			PrivateZoneName:     redisZone.Name,
 			Location:            pulumi.String("global"),

--- a/provider/defangazure/azure/dns_test.go
+++ b/provider/defangazure/azure/dns_test.go
@@ -11,14 +11,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type dnsResource struct {
+	typeToken string
+	name      string
+}
+
 type dnsNameMocks struct {
-	names []string
+	resources []dnsResource
 }
 
 func (m *dnsNameMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
 	switch args.TypeToken {
 	case "azure-native:privatedns:PrivateZone", "azure-native:privatedns:VirtualNetworkLink":
-		m.names = append(m.names, args.Name)
+		m.resources = append(m.resources, dnsResource{typeToken: args.TypeToken, name: args.Name})
 	}
 	return args.Name + "_id", args.Inputs, nil
 }
@@ -31,7 +36,7 @@ func (m *dnsNameMocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, err
 // project gains a service that sorts before the one the caller happened to
 // pick: that would replace the zone the rest of the project resolves through.
 func TestCreateDNSZonesNamesAreIndependentOfTheService(t *testing.T) {
-	createNames := func(pgService, redisService string) []string {
+	createNames := func(pgService, redisService string) []dnsResource {
 		mocks := &dnsNameMocks{}
 		err := pulumi.RunErr(func(ctx *pulumi.Context) error {
 			rg, err := resources.NewResourceGroup(ctx, "project", &resources.ResourceGroupArgs{})
@@ -49,12 +54,38 @@ func TestCreateDNSZonesNamesAreIndependentOfTheService(t *testing.T) {
 			return err
 		}, pulumi.WithMocks("project", "stack", mocks))
 		require.NoError(t, err)
-		sort.Strings(mocks.names)
-		return mocks.names
+		sort.Slice(mocks.resources, func(i, j int) bool {
+			if mocks.resources[i].typeToken != mocks.resources[j].typeToken {
+				return mocks.resources[i].typeToken < mocks.resources[j].typeToken
+			}
+			return mocks.resources[i].name < mocks.resources[j].name
+		})
+		return mocks.resources
 	}
 
-	// Two zones and one link each; the links share a name because each is
-	// parented to its own zone.
-	require.Equal(t, []string{"link", "link", "postgres", "redis"}, createNames("alpha-pg", "alpha-cache"))
-	require.Equal(t, createNames("alpha-pg", "alpha-cache"), createNames("zulu-pg", "zulu-cache"))
+	const (
+		zone = "azure-native:privatedns:PrivateZone"
+		link = "azure-native:privatedns:VirtualNetworkLink"
+		pg   = "postgres"
+		rd   = "redis"
+	)
+
+	first := createNames("alpha-pg", "alpha-cache")
+	require.Equal(t, []dnsResource{
+		{zone, pg}, {zone, rd}, {link, pg}, {link, rd},
+	}, first)
+
+	// Same identities for a project whose services sort differently.
+	require.Equal(t, first, createNames("zulu-pg", "zulu-cache"))
+
+	// A Pulumi URN inherits its parent's TYPE but not its name, so two
+	// resources of one type must not share a logical name even when their
+	// parents differ -- that is a duplicate URN and the deploy bails. Pulumi's
+	// mock runtime does not run the step generator, so nothing but this check
+	// would catch it here.
+	seen := map[dnsResource]bool{}
+	for _, r := range first {
+		require.False(t, seen[r], "duplicate logical name %q for type %s", r.name, r.typeToken)
+		seen[r] = true
+	}
 }

--- a/provider/defangazure/azure/dns_test.go
+++ b/provider/defangazure/azure/dns_test.go
@@ -18,12 +18,21 @@ type dnsResource struct {
 
 type dnsNameMocks struct {
 	resources []dnsResource
+	aliases   []dnsResource
 }
 
 func (m *dnsNameMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
 	switch args.TypeToken {
 	case "azure-native:privatedns:PrivateZone", "azure-native:privatedns:VirtualNetworkLink":
 		m.resources = append(m.resources, dnsResource{typeToken: args.TypeToken, name: args.Name})
+		for _, alias := range args.RegisterRPC.GetAliases() {
+			// The azure-native SDK attaches an alias per historical API version
+			// to every resource; those carry a type and no name. Only the ones
+			// this package adds name a previous logical name.
+			if spec := alias.GetSpec(); spec != nil && spec.GetName() != "" {
+				m.aliases = append(m.aliases, dnsResource{typeToken: args.TypeToken, name: spec.GetName()})
+			}
+		}
 	}
 	return args.Name + "_id", args.Inputs, nil
 }
@@ -88,4 +97,58 @@ func TestCreateDNSZonesNamesAreIndependentOfTheService(t *testing.T) {
 		require.False(t, seen[r], "duplicate logical name %q for type %s", r.name, r.typeToken)
 		seen[r] = true
 	}
+}
+
+// Azure runs in production, so the rename above must not drop the URNs the old
+// service-derived names created: each zone and link claims its old name as an
+// alias. Without them an `up` on a live project deletes the zone every server
+// and private endpoint resolves through.
+func TestCreateDNSZonesKeepTheOldServiceNamesAsAliases(t *testing.T) {
+	mocks := &dnsNameMocks{}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		rg, err := resources.NewResourceGroup(ctx, "project", &resources.ResourceGroupArgs{})
+		if err != nil {
+			return err
+		}
+		vnet, err := network.NewVirtualNetwork(ctx, "project", &network.VirtualNetworkArgs{
+			ResourceGroupName: rg.Name,
+		})
+		if err != nil {
+			return err
+		}
+		_, err = CreateDNSZones(ctx, "project", "db", "cache",
+			&SharedInfra{ResourceGroup: rg}, &NetworkingResult{VNet: vnet})
+		return err
+	}, pulumi.WithMocks("project", "stack", mocks))
+	require.NoError(t, err)
+
+	const zone = "azure-native:privatedns:PrivateZone"
+	const link = "azure-native:privatedns:VirtualNetworkLink"
+	require.ElementsMatch(t, []dnsResource{
+		{zone, "db"}, {link, "db"}, {zone, "cache"}, {link, "cache"},
+	}, mocks.aliases)
+}
+
+// A project whose service is already called "postgres" needs no alias: the old
+// name and the new one are the same URN.
+func TestCreateDNSZonesDeclareNoSelfAlias(t *testing.T) {
+	mocks := &dnsNameMocks{}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		rg, err := resources.NewResourceGroup(ctx, "project", &resources.ResourceGroupArgs{})
+		if err != nil {
+			return err
+		}
+		vnet, err := network.NewVirtualNetwork(ctx, "project", &network.VirtualNetworkArgs{
+			ResourceGroupName: rg.Name,
+		})
+		if err != nil {
+			return err
+		}
+		_, err = CreateDNSZones(ctx, "project", postgresName, redisName,
+			&SharedInfra{ResourceGroup: rg}, &NetworkingResult{VNet: vnet})
+		return err
+	}, pulumi.WithMocks("project", "stack", mocks))
+	require.NoError(t, err)
+
+	require.Empty(t, mocks.aliases)
 }

--- a/provider/defangazure/azure/dns_test.go
+++ b/provider/defangazure/azure/dns_test.go
@@ -1,0 +1,60 @@
+package azure
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/pulumi/pulumi-azure-native-sdk/network/v3"
+	"github.com/pulumi/pulumi-azure-native-sdk/resources/v3"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/require"
+)
+
+type dnsNameMocks struct {
+	names []string
+}
+
+func (m *dnsNameMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+	switch args.TypeToken {
+	case "azure-native:privatedns:PrivateZone", "azure-native:privatedns:VirtualNetworkLink":
+		m.names = append(m.names, args.Name)
+	}
+	return args.Name + "_id", args.Inputs, nil
+}
+
+func (m *dnsNameMocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
+	return args.Args, nil
+}
+
+// The zones are project-shared, so their identity must not move when the
+// project gains a service that sorts before the one the caller happened to
+// pick: that would replace the zone the rest of the project resolves through.
+func TestCreateDNSZonesNamesAreIndependentOfTheService(t *testing.T) {
+	createNames := func(pgService, redisService string) []string {
+		mocks := &dnsNameMocks{}
+		err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+			rg, err := resources.NewResourceGroup(ctx, "project", &resources.ResourceGroupArgs{})
+			if err != nil {
+				return err
+			}
+			vnet, err := network.NewVirtualNetwork(ctx, "project", &network.VirtualNetworkArgs{
+				ResourceGroupName: rg.Name,
+			})
+			if err != nil {
+				return err
+			}
+			_, err = CreateDNSZones(ctx, "project", pgService, redisService,
+				&SharedInfra{ResourceGroup: rg}, &NetworkingResult{VNet: vnet})
+			return err
+		}, pulumi.WithMocks("project", "stack", mocks))
+		require.NoError(t, err)
+		sort.Strings(mocks.names)
+		return mocks.names
+	}
+
+	// Two zones and one link each; the links share a name because each is
+	// parented to its own zone.
+	require.Equal(t, []string{"link", "link", "postgres", "redis"}, createNames("alpha-pg", "alpha-cache"))
+	require.Equal(t, createNames("alpha-pg", "alpha-cache"), createNames("zulu-pg", "zulu-cache"))
+}

--- a/provider/defanggcp/gcp/alb.go
+++ b/provider/defanggcp/gcp/alb.go
@@ -210,9 +210,14 @@ func createInternalLoadBalancer(
 				return err
 			}
 
+			// Named after the service, not "private-lb-cloudrun-backend": a
+			// constant is a duplicate URN as soon as a project has two private
+			// Cloud Run services. No role suffix -- this is the only
+			// RegionBackendService a Cloud Run service gets, and the branches
+			// below (single-port MIG, host mode) are mutually exclusive with it.
 			serviceBackend, err := compute.NewRegionBackendService(
 				ctx,
-				"private-lb-cloudrun-backend",
+				service.Name,
 				&compute.RegionBackendServiceArgs{
 					Region:              pulumi.String(config.Region),
 					Protocol:            pulumi.String("HTTPS"),
@@ -421,9 +426,11 @@ func createInternalLoadBalancer(
 					return err
 				}
 
-				hcPortStr := strconv.FormatUint(uint64(*tcpHealthCheckPort), 10)
+				// A host-mode service gets exactly one health check, so the port
+				// adds nothing -- and appended without a separator it made
+				// "worker" + "6379" indistinguishable from "worker6" + "379".
 				healthCheck, err := compute.NewHealthCheck(ctx,
-					service.Name+hcPortStr,
+					service.Name,
 					&compute.HealthCheckArgs{
 						CheckIntervalSec:   pulumi.Int(30),
 						TimeoutSec:         pulumi.Int(10),
@@ -685,13 +692,23 @@ func buildLBEntry(
 	return pulumi.IDOutput{}, nil, nil, nil
 }
 
+// publicLBName names a child of the external load balancer. The role marker is
+// not a type word: the internal load balancer creates resources of the same
+// types for the same service (a NEG, a health check), so without it the two
+// would claim one URN. Everything else the type token already says, and the
+// port is left out because an external entry only ever uses its first ingress
+// port.
+func publicLBName(serviceName string) string {
+	return serviceName + "-public"
+}
+
 func buildCloudRunLBEntry(
 	ctx *pulumi.Context,
 	entry LBServiceEntry,
 	region string,
 	opts ...pulumi.ResourceOption,
 ) (pulumi.IDOutput, *compute.URLMapPathMatcherArgs, *compute.URLMapHostRuleArgs, error) {
-	neg, err := compute.NewRegionNetworkEndpointGroup(ctx, entry.Name+"-neg",
+	neg, err := compute.NewRegionNetworkEndpointGroup(ctx, publicLBName(entry.Name),
 		&compute.RegionNetworkEndpointGroupArgs{
 			NetworkEndpointType: pulumi.String("SERVERLESS"),
 			Region:              pulumi.String(region),
@@ -703,7 +720,7 @@ func buildCloudRunLBEntry(
 		return pulumi.IDOutput{}, nil, nil, err
 	}
 
-	backend, err := compute.NewBackendService(ctx, entry.Name+"-backend",
+	backend, err := compute.NewBackendService(ctx, publicLBName(entry.Name),
 		&compute.BackendServiceArgs{
 			Protocol:            pulumi.String("HTTPS"),
 			LoadBalancingScheme: pulumi.String("EXTERNAL_MANAGED"),
@@ -741,8 +758,7 @@ func buildMIGLBEntry(
 		if !port.IsIngress() {
 			continue
 		}
-		portStr := strconv.Itoa(int(port.Target))
-		hc, err := compute.NewHealthCheck(ctx, entry.Name+"-"+portStr+"-public-lb-hc",
+		hc, err := compute.NewHealthCheck(ctx, publicLBName(entry.Name),
 			&compute.HealthCheckArgs{
 				CheckIntervalSec: pulumi.Int(5),
 				TimeoutSec:       pulumi.Int(5),
@@ -754,7 +770,7 @@ func buildMIGLBEntry(
 			return pulumi.IDOutput{}, nil, nil, err
 		}
 
-		backend, err := compute.NewBackendService(ctx, entry.Name+"-"+portStr+"-gce-backend",
+		backend, err := compute.NewBackendService(ctx, publicLBName(entry.Name),
 			&compute.BackendServiceArgs{
 				Protocol:            pulumi.String("HTTP"),
 				LoadBalancingScheme: pulumi.String("EXTERNAL_MANAGED"),

--- a/provider/defanggcp/gcp/alb_test.go
+++ b/provider/defanggcp/gcp/alb_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
+	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/cloudrunv2"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/compute"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -55,7 +56,7 @@ func TestCreateLoadBalancersMIGHostModeExternalBackendUsesRateAndPortName(t *tes
 	}, pulumi.WithMocks("proj", "stack", mocks))
 	require.NoError(t, err)
 
-	backend := requireResource(t, mocks.resources, "gcp:compute/backendService:BackendService", "api-3000-gce-backend")
+	backend := requireResource(t, mocks.resources, "gcp:compute/backendService:BackendService", "api-public")
 	requirePropertyString(t, backend.inputs, "portName", "port-tcp-3000")
 	backends := backend.inputs["backends"].ArrayValue()
 	require.Len(t, backends, 1)
@@ -81,7 +82,7 @@ func TestCreateLoadBalancersMIGSingleIngressLeavesBalancingModeUnset(t *testing.
 	}, pulumi.WithMocks("proj", "stack", mocks))
 	require.NoError(t, err)
 
-	backend := requireResource(t, mocks.resources, "gcp:compute/backendService:BackendService", "api-3000-gce-backend")
+	backend := requireResource(t, mocks.resources, "gcp:compute/backendService:BackendService", "api-public")
 	requirePropertyString(t, backend.inputs, "portName", "port-tcp-3000")
 	backendArgs := backend.inputs["backends"].ArrayValue()[0].ObjectValue()
 	require.False(t, backendArgs.HasValue("balancingMode"))
@@ -236,4 +237,37 @@ func requireResource(t *testing.T, resources []albResource, typ, name string) al
 	}
 	require.Failf(t, "missing resource", "type=%s name=%s resources=%v", typ, name, resources)
 	return albResource{}
+}
+
+// Two private Cloud Run services used to claim one URN: the internal backend
+// service was registered under the constant "private-lb-cloudrun-backend", so
+// the second registration was a duplicate and the deploy failed outright.
+func TestCreateLoadBalancersTwoPrivateCloudRunServices(t *testing.T) {
+	mocks := &albMocks{}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		entries := make([]LBServiceEntry, 0, 2)
+		for _, name := range []string{"api", "worker"} {
+			svc, err := cloudrunv2.NewService(ctx, name, &cloudrunv2.ServiceArgs{
+				Location: pulumi.String("us-central1"),
+				Template: &cloudrunv2.ServiceTemplateArgs{},
+			})
+			if err != nil {
+				return err
+			}
+			entries = append(entries, LBServiceEntry{
+				Name:            name,
+				CloudRunService: svc,
+				PrivateFqdn:     name + ".google.internal",
+				Config: compose.ServiceConfig{
+					Ports: []compose.ServicePortConfig{{Target: 3000, Mode: compose.PortModeIngress}},
+				},
+			})
+		}
+		return CreateLoadBalancers(ctx, "proj", entries, testInfra(ctx))
+	}, pulumi.WithMocks("proj", "stack", mocks))
+	require.NoError(t, err)
+
+	const backendType = "gcp:compute/regionBackendService:RegionBackendService"
+	requireResource(t, mocks.resources, backendType, "api")
+	requireResource(t, mocks.resources, backendType, "worker")
 }


### PR DESCRIPTION
Rewritten from scratch on your review. The previous version preserved every changed URN with a `pulumi.Aliases` entry and added naming helpers; both are gone. Since `defang-aws` and `defang-gcp` are still prerelease, the names are free to change now, so this changes them and keeps nothing for backward compatibility.

Most of the old diff also went away because `main` has since fixed it independently: the GCP host-mode firewalls got their `-hc` discriminator, the chunked backend/forwarding-rule names got their separators and lost their type suffixes, and the private DNS record sets lost their project prefix.

## Naming guidance this follows

Recorded here because it is the review you gave, and the next PR should not have to rediscover it:

1. **Keep logical names short.** The recipe already prefixes `${project}-${stack}` (which contains the project), so repeating either in a child name only eats into the cloud's length limit.
2. **But avoid conflicts wherever we create more than one of the same resource under the same parent.** A duplicate URN is not a cosmetic problem: Pulumi rejects it and the deploy fails. Where siblings of one type exist, the name carries the smallest discriminator that separates them, and nothing more.
3. **Avoid superfluous resource-type suffixes.** The type token already says `BackendService`, `HealthCheck`, `RecordSet`. `-backend`, `-hc`, `-neg` and friends add nothing — unless they are doing job 2, in which case they should say the *role*, not the type.
4. **Take the cloud's own namespacing into account** — for PHYSICAL names only. A resource that is a child of another does not need to be fully qualified there: an ECS service lives in its cluster, an Azure VNet link lives under its zone in the ARM resource ID. This does **not** extend to Pulumi identity: a URN inherits its parent's *type* and not its parent's *name*, so two children of two differently-named parents with one logical name are one URN. I got this wrong first and it cost this PR a bug (see below).

5. **Rename freely only where the package is prerelease.** `defang-aws` and `defang-gcp` are; **`defang-azure` is in production and runs the portal**, so every Azure rename carries a `pulumi.Alias` for the URN it replaces.

## The three collisions fixed

**GCP: a project with two private Cloud Run services never deployed.** The internal backend service was registered under the constant `"private-lb-cloudrun-backend"`, so the second service's registration was a duplicate URN. It is now named after its service — no role suffix, because it is the only `RegionBackendService` a Cloud Run service gets and the MIG branches are mutually exclusive with it. `TestCreateLoadBalancersTwoPrivateCloudRunServices` fails against the old constant.

**Azure: adding a service could replace a project-shared DNS zone.** `CreateDNSZones` named the shared Postgres zone, the shared Redis zone and their VNet links after the *first alphabetical* service of each kind (`project.go:78`). Deploy a project with `redis`, then add `cache`, and the zone the whole project resolves through gets a new URN. The zones are now `postgres` and `redis`, and each link is just `link` — its zone parents it in Pulumi and in Azure's resource ID, so the name has nothing left to disambiguate. Answering your review question directly: only **one** zone per kind per project is ever created, so this was never a duplicate-name bug — it was an identity-flip bug. The misleading `defang:service` tag on those shared zones is gone with it.

**AWS: two long service names could collapse onto one target group.** Truncation with no hash meant `<27 shared chars>-alpha` and `<27 shared chars>-bravo` produced the same logical name. On your question — no, this never threw an error; it is a latent duplicate URN, which is why the fix touches only the truncating path and leaves every short name byte-identical.

## The bug this PR introduced, and its fix

Naming both Azure VNet links `link` — on the grounds that each is `pulumi.Parent`-ed to its own zone — was wrong for the reason in rule 4. Both resolved to

```
...$azure-native:privatedns:PrivateZone$azure-native:privatedns:VirtualNetworkLink::link
```

so any project with both a Postgres and a Redis service would have failed with `Duplicate resource URN`. Each link is now named for its zone (`postgres`, `redis`), which is safe beside the same-named zone because the type differs. The naming test asserts `(type, name)` pairs are pairwise unique rather than merely stable — the original test passed the broken code, because `pulumi.WithMocks` never runs the step generator that rejects duplicates.

## Azure keeps its old URNs

Since `defang-azure` is live, both zones and both links claim their previous service-derived names through `renamedFrom()`. Without that, an `up` on a running project deletes the zone every Flexible Server and private endpoint resolves through and recreates it empty. A project whose service is already named `postgres` or `redis` gets no alias, since the old and new URNs coincide.

## Also applied

- The host-mode health check was `service.Name + hcPortStr` with no separator, which made `worker` + `6379` and `worker6` + `379` the same string. A host-mode service gets exactly one health check, so the port is simply dropped.
- The external load balancer's NEG, backend service and health check now share one `publicLBName()` marker (`<service>-public`) instead of `-neg` / `-backend` / `-<port>-public-lb-hc` / `-<port>-gce-backend`. The marker survives rule 3 because the *internal* load balancer creates a NEG and a health check for the same service: without it those two claim one URN. The port is dropped because an external entry only ever uses its first ingress port.

## Deliberately not changed

- **The ECS service's project qualifier** (`ECSServiceResourceName`, `<project>_<service>`) looks exactly like rule 1's forbidden qualification, and it is load-bearing anyway: the CLI parses the compose service back out of the ARN by taking the text between the first `_` and the last `-`, so the qualifier is what makes `DEPLOYMENT_COMPLETED` attributable. There is a contract test in `cd/ecs_events_contract_test.go`.
- **Explicit physical names** — Azure Container Apps, the GCP MIG's `BaseInstanceName`, Artifact Registry's `repositoryId` — are cloud constraints, not accidental opt-outs of autonaming. #530 shows why one of them must stay explicit: matching the legacy CD's ID is what keeps a migrated registry from being replaced.
- **Azure ACR and Postgres logical names** and the remaining GCP MIG concatenations from #459's list. They are long, not colliding, and each needs its own length audit; #459 stays open for them.

## Tests

- `TestCreateLoadBalancersTwoPrivateCloudRunServices` — the duplicate-URN regression, verified to fail against the old constant.
- `TestCreateDNSZonesNamesAreIndependentOfTheService` — the shared zones and links keep one identity across two different service sets, and no two of them share a `(type, name)` pair.
- `TestCreateDNSZonesKeepTheOldServiceNamesAsAliases` / `TestCreateDNSZonesDeclareNoSelfAlias` — the Azure renames carry their old URNs, and a project already using those names carries none.
- `TestTargetGroupNameLongPrefixesDoNotCollide` — two long prefixes stay distinct, bounded and deterministic.
- `CGO_ENABLED=0 go test ./provider/...` — green. `golangci-lint run --config=.golangci.yaml --new-from-rev=origin/main ./provider/...` — 0 issues.

Refs #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3WmpdY3zc555sNdkY9dzQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented collisions for long AWS target group names while preserving deterministic, length-compliant names.
  - Preserved existing Azure private DNS resources when PostgreSQL or Redis service names change.
  - Standardized Google Cloud load balancer resource naming across Cloud Run and MIG configurations.
  - Ensured multiple private Cloud Run services receive distinct backend resources without duplicate names.
  - Kept related resource names consistent across supported deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->