### PR TITLE
[on hold] feat(gcp): delete the retained VPC with a scheduled cleanup job

### DIFF
--- a/cd/TODO.md
+++ b/cd/TODO.md
@@ -52,7 +52,7 @@ Compared against `~/dev/defang-mvp/pulumi/index.ts`.
 
 ## Missing commands (from old GCP code)
 
-- [x] `cleanup` — done in `cleanup_gcp.go` as `scheduleGcpCleanup` (old GCP `scheduleCleanUp()`) and `cleanupGCP` (old GCP `Cleanup()`). A GCP `down` schedules a Cloud Scheduler job that re-runs this image with `cleanup`, which deletes the retained VPC and then itself. It also removes the referencing resources this repo retains but old GCP did not (instance templates, the servicenetworking peering) — see issue 183.
+- [x] `cleanup` — done in `cleanup_gcp.go` as `scheduleGcpCleanup` (old GCP `scheduleCleanUp()`) and `cleanupGCP` (old GCP `Cleanup()`). A GCP `down` schedules a Cloud Scheduler job that re-runs this image with `cleanup`, which deletes the retained VPC and then itself. Both implementations retain the VPC, subnet, instance templates, and Service Networking connection; this cleanup additionally removes the retained referencing resources explicitly before deleting the network — see issue 183.
 
 ## Missing GCP-specific config
 

--- a/cd/TODO.md
+++ b/cd/TODO.md
@@ -52,7 +52,7 @@ Compared against `~/dev/defang-mvp/pulumi/index.ts`.
 
 ## Missing commands (from old GCP code)
 
-- [x] `cleanup` — done: `cleanup_gcp.go` ports `Cleanup()` + `scheduleCleanUp()`. A GCP `down` schedules a Cloud Scheduler job that re-runs this image with `cleanup`, which deletes the retained VPC and then itself. It also removes the referencing resources this repo retains but old GCP did not (instance templates, the servicenetworking peering) — see issue 183.
+- [x] `cleanup` — done in `cleanup_gcp.go` as `scheduleGcpCleanup` (old GCP `scheduleCleanUp()`) and `cleanupGCP` (old GCP `Cleanup()`). A GCP `down` schedules a Cloud Scheduler job that re-runs this image with `cleanup`, which deletes the retained VPC and then itself. It also removes the referencing resources this repo retains but old GCP did not (instance templates, the servicenetworking peering) — see issue 183.
 
 ## Missing GCP-specific config
 

--- a/cd/TODO.md
+++ b/cd/TODO.md
@@ -52,7 +52,7 @@ Compared against `~/dev/defang-mvp/pulumi/index.ts`.
 
 ## Missing commands (from old GCP code)
 
-- [ ] `cleanup` — old GCP had `Cleanup()` + `scheduleCleanUp()` that created a Cloud Build cron job to clean VPC resources after destroy
+- [x] `cleanup` — done: `cleanup_gcp.go` ports `Cleanup()` + `scheduleCleanUp()`. A GCP `down` schedules a Cloud Scheduler job that re-runs this image with `cleanup`, which deletes the retained VPC and then itself. It also removes the referencing resources this repo retains but old GCP did not (instance templates, the servicenetworking peering) — see issue 183.
 
 ## Missing GCP-specific config
 
@@ -60,7 +60,7 @@ Compared against `~/dev/defang-mvp/pulumi/index.ts`.
 
 ## Missing env vars (from old GCP code)
 
-- [x] `DEFANG_CD_IMAGE` — no longer unused: `config.go` reads it into `defang:cdImage`. The consumer (GCP cleanup cron) is still missing — tracked under `cleanup` above.
+- [x] `DEFANG_CD_IMAGE` — no longer unused: `config.go` reads it into `defang:cdImage`, and `cleanup_gcp.go` re-runs that image from the GCP cleanup cron.
 
 ---
 

--- a/cd/cd_main.go
+++ b/cd/cd_main.go
@@ -101,6 +101,10 @@ func cdMain(ctx context.Context, args ...string) error {
 		// No Pulumi stack: only starts a regular down execution on the
 		// shared CD job (Azure self-destruct; see triggerdown.go).
 		return triggerDown(ctx)
+	case cdCommandCleanup:
+		// No Pulumi stack: the stack is already gone, and the network to
+		// delete is read from the state backup (GCP; see cleanup_gcp.go).
+		return cleanupGCP(ctx, projectName, stackName)
 	default:
 		return &usageError{msg: fmt.Sprintf("unknown command: %s", command)}
 	}
@@ -223,6 +227,18 @@ func cdMain(ctx context.Context, args ...string) error {
 		}
 		_, err = stack.Destroy(ctx, destroyOpts...)
 		uploadState(ctx, statesUploadUrl, stack) // TODO: this prints a warning if the destroy succeeded
+		// The GCP provider retains the VPC and its subnet on delete, because
+		// GCP needs 1-2 hours to release the subnet's IPs after Cloud Run
+		// lets go of them; schedule a later run to delete them once that
+		// window has passed (see cleanup_gcp.go). A targeted destroy keeps the
+		// stack, so there is nothing to clean up yet. This is best effort: a
+		// missing cleanup job must not fail the down.
+		if len(pulumiTargets) == 0 && gcpProjectFromEnv() != "" {
+			if err := scheduleGcpCleanup(ctx, projectName, stackName); err != nil {
+				warn(" ** Failed to schedule the cleanup of the retained VPC:", err)
+				warn(" ** You may need to delete the VPC by hand in the GCP console")
+			}
+		}
 		if err != nil {
 			return pulumiErr(err)
 		}

--- a/cd/cleanup_gcp.go
+++ b/cd/cleanup_gcp.go
@@ -411,7 +411,15 @@ func deleteGcpNetwork(ctx context.Context, gcpProject, region, networkID string)
 
 	name := path.Base(networkID)
 
-	if err := deleteInstanceTemplates(ctx, gcpProject, networkID); err != nil {
+	// List the subnets up front: the instance templates are matched on their
+	// subnetwork, not their network (see deleteInstanceTemplates), and the same
+	// list is what gets deleted below.
+	subnets, err := listSubnetworks(ctx, gcpProject, region, networkID)
+	if err != nil {
+		return err
+	}
+
+	if err := deleteInstanceTemplates(ctx, gcpProject, networkID, subnets); err != nil {
 		return err
 	}
 	if err := removeNetworkPeerings(ctx, networks, gcpProject, name); err != nil {
@@ -420,7 +428,7 @@ func deleteGcpNetwork(ctx context.Context, gcpProject, region, networkID string)
 	if err := deleteRouters(ctx, gcpProject, region, networkID); err != nil {
 		return err
 	}
-	if err := deleteSubnetworks(ctx, gcpProject, region, networkID); err != nil {
+	if err := deleteSubnetworks(ctx, gcpProject, region, subnets); err != nil {
 		return err
 	}
 
@@ -440,9 +448,15 @@ func deleteGcpNetwork(ctx context.Context, gcpProject, region, networkID string)
 	return nil
 }
 
-// deleteInstanceTemplates deletes the retained MIG instance templates whose
-// network interfaces point at the network. Templates are a global resource.
-func deleteInstanceTemplates(ctx context.Context, gcpProject, networkID string) error {
+// deleteInstanceTemplates deletes the retained MIG instance templates that hold
+// the network, either directly or through one of its subnets. Templates are a
+// global resource, so the whole project is listed and filtered.
+//
+// Matching the subnet matters more than matching the network: a project-scoped
+// template sets only Subnetwork and leaves Network empty (see the network
+// interface built in provider/defanggcp/gcp/compute.go), so a network-only
+// filter would never match the templates that actually block the delete.
+func deleteInstanceTemplates(ctx context.Context, gcpProject, networkID string, subnets []subnetwork) error {
 	templates, err := compute.NewInstanceTemplatesRESTClient(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create instance templates client: %w", err)
@@ -459,7 +473,7 @@ func deleteInstanceTemplates(ctx context.Context, gcpProject, networkID string) 
 		if err != nil {
 			return fmt.Errorf("failed to list instance templates: %w", err)
 		}
-		if tmpl.GetProperties() == nil || !usesNetwork(tmpl.GetProperties().GetNetworkInterfaces(), networkID) {
+		if tmpl.GetProperties() == nil || !usesNetwork(tmpl.GetProperties().GetNetworkInterfaces(), networkID, subnets) {
 			continue
 		}
 		tmplName := tmpl.GetName()
@@ -483,10 +497,17 @@ func deleteInstanceTemplates(ctx context.Context, gcpProject, networkID string) 
 	return grp.Wait()
 }
 
-func usesNetwork(interfaces []*computepb.NetworkInterface, networkID string) bool {
+// usesNetwork reports whether any interface holds the network directly or sits
+// in one of its subnets.
+func usesNetwork(interfaces []*computepb.NetworkInterface, networkID string, subnets []subnetwork) bool {
 	for _, ni := range interfaces {
 		if referencesNetwork(ni.GetNetwork(), networkID) {
 			return true
+		}
+		for _, subnet := range subnets {
+			if referencesNetwork(ni.GetSubnetwork(), subnet.id) {
+				return true
+			}
 		}
 	}
 	return false
@@ -569,8 +590,46 @@ func deleteRouters(ctx context.Context, gcpProject, region, networkID string) er
 	return grp.Wait()
 }
 
-// deleteSubnetworks deletes the retained subnets of the network in the region.
-func deleteSubnetworks(ctx context.Context, gcpProject, region, networkID string) error {
+// subnetwork is one of the network's subnets: its name, to delete it, and its
+// id in the "projects/P/regions/R/subnetworks/N" form, to match references to
+// it.
+type subnetwork struct {
+	name string
+	id   string
+}
+
+// listSubnetworks returns the subnets of the network in the region. This
+// includes the retained shared subnet and the load balancer's proxy-only
+// subnet.
+func listSubnetworks(ctx context.Context, gcpProject, region, networkID string) ([]subnetwork, error) {
+	subnets, err := compute.NewSubnetworksRESTClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create subnetworks client: %w", err)
+	}
+	defer subnets.Close()
+
+	var out []subnetwork
+	it := subnets.List(ctx, &computepb.ListSubnetworksRequest{Project: gcpProject, Region: region})
+	for {
+		subnet, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			return out, nil
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to list subnetworks: %w", err)
+		}
+		if !referencesNetwork(subnet.GetNetwork(), networkID) {
+			continue
+		}
+		out = append(out, subnetwork{
+			name: subnet.GetName(),
+			id:   fmt.Sprintf("projects/%s/regions/%s/subnetworks/%s", gcpProject, region, subnet.GetName()),
+		})
+	}
+}
+
+// deleteSubnetworks deletes the network's subnets.
+func deleteSubnetworks(ctx context.Context, gcpProject, region string, list []subnetwork) error {
 	subnets, err := compute.NewSubnetworksRESTClient(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create subnetworks client: %w", err)
@@ -578,19 +637,8 @@ func deleteSubnetworks(ctx context.Context, gcpProject, region, networkID string
 	defer subnets.Close()
 
 	grp := new(errgroup.Group)
-	it := subnets.List(ctx, &computepb.ListSubnetworksRequest{Project: gcpProject, Region: region})
-	for {
-		subnet, err := it.Next()
-		if errors.Is(err, iterator.Done) {
-			break
-		}
-		if err != nil {
-			return fmt.Errorf("failed to list subnetworks: %w", err)
-		}
-		if !referencesNetwork(subnet.GetNetwork(), networkID) {
-			continue
-		}
-		subnetName := subnet.GetName()
+	for _, subnet := range list {
+		subnetName := subnet.name
 		grp.Go(func() error {
 			op, err := subnets.Delete(ctx, &computepb.DeleteSubnetworkRequest{
 				Project:    gcpProject,

--- a/cd/cleanup_gcp.go
+++ b/cd/cleanup_gcp.go
@@ -1,0 +1,671 @@
+package main
+
+import (
+	"cmp"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"net/url"
+	"os"
+	"path"
+	"slices"
+	"strings"
+	"time"
+
+	compute "cloud.google.com/go/compute/apiv1"
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"cloud.google.com/go/compute/metadata"
+	scheduler "cloud.google.com/go/scheduler/apiv1"
+	"cloud.google.com/go/scheduler/apiv1/schedulerpb"
+	"cloud.google.com/go/storage"
+	"github.com/DefangLabs/defang/src/pkg/cli/client"
+	"github.com/DefangLabs/pulumi-defang/cd/program"
+	"github.com/googleapis/gax-go/v2/apierror"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/iterator"
+	"google.golang.org/grpc/codes"
+)
+
+// cdCommandCleanup deletes the VPC a `down` deliberately leaves behind.
+//
+// Why the VPC is not deleted inline: Cloud Run attaches to the VPC with Direct
+// VPC egress (see buildVpcAccess in provider/defanggcp/gcp/cloudrun.go), and
+// GCP holds the subnet's IP addresses for 1-2 hours after the service is gone.
+// Until they are released the subnet delete fails with
+// resourceInUseByAnotherResource, and the network cannot go before its subnet.
+// This is documented GCP behaviour, not a provider bug, so no amount of
+// retrying inside the destroy would help:
+// https://docs.cloud.google.com/run/docs/configuring/vpc-direct-vpc
+//
+// So the provider marks the network and subnet RetainOnDelete
+// (provider/defanggcp/gcp/gcp.go) to keep the destroy from failing on them,
+// and the destroy schedules this command to delete them once the window has
+// passed. Without it the leaked networks exhaust the project's NETWORKS quota
+// (30 per project), which is what issue 183 was raised for.
+const cdCommandCleanup = client.CdCommand("cleanup")
+
+// cleanupJobTimeFormat stamps the scheduler job name with its own creation
+// time, so the cleanup run can tell which state-file generations predate it.
+const cleanupJobTimeFormat = "20060102150405"
+
+// cleanupJobEnvVar names the scheduler job in the environment of the build it
+// schedules, so the run can delete the job that started it.
+const cleanupJobEnvVar = "CLEAN_UP_JOB_NAME"
+
+// cleanupFirstRunDelay delays the first fire to the end of the 1-2h window GCP
+// needs to release the subnet's IP addresses (see cdCommandCleanup). It also
+// keeps the first run from happening immediately, which the every-2-hours cron
+// would otherwise do. A first fire that is still too early is not a problem:
+// the delete fails, and the next fire two hours later retries.
+const cleanupFirstRunDelay = 1*time.Hour + 59*time.Minute
+
+// pulumiState is the subset of a Pulumi checkpoint the cleanup reads: the
+// resource list, to recover the network's id.
+type pulumiState struct {
+	Checkpoint struct {
+		Latest struct {
+			Resources []struct {
+				Type string `json:"type"`
+				Id   string `json:"id"`
+			} `json:"resources,omitempty"`
+		} `json:"latest"`
+	} `json:"checkpoint"`
+}
+
+// gcpNetworkType is the Pulumi type token of the retained VPC.
+const gcpNetworkType = "gcp:compute/network:Network"
+
+// stackDir is the folder the DIY backend keeps checkpoints in, under
+// workspace.BookkeepingDir — see pulumi/pkg/backend/diy/store.go. The sdk used
+// to export this as workspace.StackDir but dropped it, so it lives here now.
+const stackDir = "stacks"
+
+// cleanupJobID names the scheduler job for one stack's cleanup. The trailing
+// timestamp both keeps concurrent downs from colliding and records when the
+// job was created.
+func cleanupJobID(projectName, stackName string, now time.Time) string {
+	return "defang-cleanup-" + projectName + "-" + stackName + "-" + now.UTC().Format(cleanupJobTimeFormat)
+}
+
+// cleanupJobCreatedAt recovers the creation time cleanupJobID encoded.
+func cleanupJobCreatedAt(jobID string) (time.Time, error) {
+	stamp := jobID[strings.LastIndex(jobID, "-")+1:]
+	t, err := time.ParseInLocation(cleanupJobTimeFormat, stamp, time.UTC)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("cannot read the creation time from job name %q: %w", jobID, err)
+	}
+	return t, nil
+}
+
+// cleanupCron renders a 5-field cron expression firing every 2 hours, first at
+// now+cleanupFirstRunDelay. Unlike the self-destruct trigger this repeats on
+// purpose: the network delete fails while anything still references the
+// network, so each fire is a retry. A successful run deletes the job.
+func cleanupCron(now time.Time) string {
+	first := now.Add(cleanupFirstRunDelay).UTC()
+	return fmt.Sprintf("%d %d-23/2 * * *", first.Minute(), first.Hour()%2)
+}
+
+// gcpCleanupBuild renders the builds.create request body that re-runs this CD
+// image with args ["cleanup"] — the same shape as gcpSelfDestructBuild in
+// cd/program, plus the job name so the run can delete its own scheduler job.
+func gcpCleanupBuild(cdImage, gcpProject, saEmail, stackName, jobID string, environ []string) ([]byte, error) {
+	env := program.SelfDestructEnv(environ)
+	env[cleanupJobEnvVar] = jobID
+	envList := make([]string, 0, len(env))
+	for _, k := range slices.Sorted(maps.Keys(env)) {
+		envList = append(envList, k+"="+env[k])
+	}
+	build := map[string]any{
+		"steps": []map[string]any{{
+			"name": cdImage,
+			"args": []string{string(cdCommandCleanup)},
+			"env":  envList,
+		}},
+		"options": map[string]any{
+			// Custom-service-account builds require an explicit logging mode.
+			"logging":                 "CLOUD_LOGGING_ONLY",
+			"enableStructuredLogging": true,
+		},
+		"timeout":        fmt.Sprintf("%ds", int(program.CdTimeout.Seconds())),
+		"tags":           []string{"defang-cd", "defang-cleanup", stackName},
+		"serviceAccount": fmt.Sprintf("projects/%s/serviceAccounts/%s", gcpProject, saEmail),
+	}
+	return json.Marshal(build)
+}
+
+// scheduleGcpCleanup creates the Cloud Scheduler job that runs the cleanup.
+// It is called after a full destroy; the caller only warns on failure, because
+// a missing cleanup job must not fail the down itself.
+func scheduleGcpCleanup(ctx context.Context, projectName, stackName string) error {
+	gcpProject := gcpProjectFromEnv()
+	if gcpProject == "" {
+		return errors.New("missing required environment variable: GCLOUD_PROJECT")
+	}
+	region := getenv("GCLOUD_REGION", os.Getenv("REGION"))
+	if region == "" {
+		return errors.New("missing required environment variable: GCLOUD_REGION")
+	}
+	cdImage := os.Getenv("DEFANG_CD_IMAGE")
+	if cdImage == "" {
+		return errors.New("missing required environment variable: DEFANG_CD_IMAGE")
+	}
+
+	// The scheduled build must run as the service account this run uses; Cloud
+	// Build exposes it through the metadata server.
+	saCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	saEmail, err := metadata.EmailWithContext(saCtx, "default")
+	if err != nil {
+		return fmt.Errorf("cleanup needs the CD to run in Cloud Build: %w", err)
+	}
+
+	now := time.Now()
+	jobID := cleanupJobID(projectName, stackName, now)
+	body, err := gcpCleanupBuild(cdImage, gcpProject, saEmail, stackName, jobID, os.Environ())
+	if err != nil {
+		return err
+	}
+
+	client, err := scheduler.NewCloudSchedulerClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create scheduler client: %w", err)
+	}
+	defer client.Close()
+
+	parent, name := schedulerJobName(gcpProject, region, jobID)
+	if _, err := client.CreateJob(ctx, &schedulerpb.CreateJobRequest{
+		Parent: parent,
+		Job: &schedulerpb.Job{
+			Name:        name,
+			Description: "Defang cleanup of the retained VPC; deletes itself once it succeeds",
+			Schedule:    cleanupCron(now),
+			TimeZone:    "Etc/UTC",
+			Target: &schedulerpb.Job_HttpTarget{
+				HttpTarget: &schedulerpb.HttpTarget{
+					Uri:        fmt.Sprintf("https://cloudbuild.googleapis.com/v1/projects/%s/builds", gcpProject),
+					HttpMethod: schedulerpb.HttpMethod_POST,
+					Body:       body,
+					Headers:    map[string]string{"Content-Type": "application/json"},
+					AuthorizationHeader: &schedulerpb.HttpTarget_OauthToken{
+						OauthToken: &schedulerpb.OAuthToken{
+							ServiceAccountEmail: saEmail,
+							Scope:               "https://www.googleapis.com/auth/cloud-platform",
+						},
+					},
+				},
+			},
+		},
+	}); err != nil {
+		return fmt.Errorf("failed to create cleanup job: %w", err)
+	}
+	warn("Scheduled cleanup of the retained VPC as", jobID)
+	return nil
+}
+
+// cleanupGCP is the `cleanup` command. It deletes the retained VPC of the
+// stack it was scheduled for, then deletes its own scheduler job.
+func cleanupGCP(ctx context.Context, projectName, stackName string) error {
+	jobID := os.Getenv(cleanupJobEnvVar)
+	if jobID == "" {
+		return &usageError{msg: "missing required environment variable: " + cleanupJobEnvVar}
+	}
+	gcpProject := gcpProjectFromEnv()
+	if gcpProject == "" {
+		return errors.New("missing required environment variable: GCLOUD_PROJECT")
+	}
+	region := getenv("GCLOUD_REGION", os.Getenv("REGION"))
+	if region == "" {
+		return errors.New("missing required environment variable: GCLOUD_REGION")
+	}
+
+	if err := cleanupGcpNetwork(ctx, gcpProject, region, projectName, stackName, jobID); err != nil {
+		// A state backup with no network will never grow one, so retrying
+		// cannot help: drop through and delete the job, or it fires every two
+		// hours for ever. Any other failure (a blocked delete, an I/O error)
+		// may well succeed later, so leave the job in place to retry.
+		if !errors.Is(err, errNoNetworkInState) {
+			return err
+		}
+		warn(" **", err, "- giving up and removing the cleanup job")
+	}
+
+	return deleteSchedulerJob(ctx, gcpProject, region, jobID)
+}
+
+// errNoNetworkInState marks the one failure that is not worth retrying.
+var errNoNetworkInState = errors.New("no retained VPC found in the stack state backup")
+
+// cleanupGcpNetwork finds this stack's network in the state backup and tears it
+// down. A state file that is present again means the stack was redeployed, so
+// there is nothing to clean up.
+func cleanupGcpNetwork(ctx context.Context, gcpProject, region, projectName, stackName, jobID string) error {
+	createdAt, err := cleanupJobCreatedAt(jobID)
+	if err != nil {
+		return err
+	}
+
+	bucket, object, err := stackStateObject(projectName, stackName)
+	if err != nil {
+		return err
+	}
+
+	gcs, err := storage.NewClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create storage client: %w", err)
+	}
+	defer gcs.Close()
+
+	exists, err := objectExists(ctx, gcs, bucket, object)
+	if err != nil {
+		return fmt.Errorf("failed to check the state file gs://%s/%s: %w", bucket, object, err)
+	}
+	if exists {
+		warn("Stack", stackName, "exists again; skipping the VPC cleanup")
+		return nil
+	}
+
+	// Pulumi keeps the previous checkpoint alongside the live one. Once the
+	// stack is removed only the backup is left, and it still records the
+	// retained network.
+	networkID, err := networkFromStateBackup(ctx, gcs, bucket, object+".bak", createdAt)
+	if err != nil {
+		return err
+	}
+
+	warn("Deleting the retained VPC", networkID)
+	return deleteGcpNetwork(ctx, gcpProject, region, networkID)
+}
+
+// stackStateObject derives the bucket and object of the stack's checkpoint in
+// the DIY (GCS) backend, matching pulumi/pkg/backend/diy.
+func stackStateObject(projectName, stackName string) (string, string, error) {
+	backendURL := getenv("PULUMI_BACKEND_URL", os.Getenv("DEFANG_STATE_URL"))
+	if backendURL == "" {
+		return "", "", errors.New("missing required environment variable: PULUMI_BACKEND_URL")
+	}
+	u, err := url.Parse(backendURL)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid PULUMI_BACKEND_URL %q: %w", backendURL, err)
+	}
+	u.Path = path.Join(u.Path, workspace.BookkeepingDir, stackDir, projectName, stackName+".json")
+	return parseGCSURL(u.String())
+}
+
+// parseGCSURL splits a gs:// URL into its bucket and object.
+func parseGCSURL(raw string) (string, string, error) {
+	rest, ok := strings.CutPrefix(raw, "gs://")
+	if !ok {
+		return "", "", fmt.Errorf("expected a gs:// URL, got %q", raw)
+	}
+	bucket, object, ok := strings.Cut(rest, "/")
+	if !ok || bucket == "" || object == "" {
+		return "", "", fmt.Errorf("expected a bucket and an object in %q", raw)
+	}
+	// The stack name may be base64, which can carry escaped characters.
+	object, err := url.PathUnescape(object)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid object path in %q: %w", raw, err)
+	}
+	return bucket, object, nil
+}
+
+// networkFromStateBackup reads the newest generation of the state backup that
+// predates the cleanup job and returns the network's id. Generations created
+// after the job belong to a later deploy and are ignored. The bucket is
+// versioned by the CLI (EnsureBucketExists with versioning), so the walk back
+// through generations reaches a checkpoint that still holds the network even
+// when the last one no longer does.
+func networkFromStateBackup(ctx context.Context, gcs *storage.Client, bucket, object string, before time.Time) (string, error) {
+	generations, err := objectGenerations(ctx, gcs, bucket, object)
+	if err != nil {
+		return "", fmt.Errorf("failed to list the generations of gs://%s/%s: %w", bucket, object, err)
+	}
+	// Newest first, so the first match is the most recent checkpoint that still
+	// holds the network.
+	slices.SortFunc(generations, func(a, b objectGeneration) int { return cmp.Compare(b.generation, a.generation) })
+
+	for _, gen := range generations {
+		if gen.created.After(before) {
+			continue
+		}
+		state, err := readStateFile(ctx, gcs, bucket, object, gen.generation)
+		if err != nil {
+			return "", err
+		}
+		for _, res := range state.Checkpoint.Latest.Resources {
+			if res.Type == gcpNetworkType {
+				return res.Id, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("%w: looked for %s in gs://%s/%s", errNoNetworkInState, gcpNetworkType, bucket, object)
+}
+
+type objectGeneration struct {
+	generation int64
+	created    time.Time
+}
+
+func objectGenerations(ctx context.Context, gcs *storage.Client, bucket, object string) ([]objectGeneration, error) {
+	var out []objectGeneration
+	it := gcs.Bucket(bucket).Objects(ctx, &storage.Query{Prefix: object, Versions: true})
+	for {
+		attrs, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			return out, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+		// The prefix query also matches longer names.
+		if attrs.Name == object {
+			out = append(out, objectGeneration{generation: attrs.Generation, created: attrs.Created})
+		}
+	}
+}
+
+func readStateFile(ctx context.Context, gcs *storage.Client, bucket, object string, generation int64) (*pulumiState, error) {
+	r, err := gcs.Bucket(bucket).Object(object).Generation(generation).NewReader(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read gs://%s/%s generation %d: %w", bucket, object, generation, err)
+	}
+	defer r.Close()
+	var state pulumiState
+	if err := json.NewDecoder(r).Decode(&state); err != nil {
+		return nil, fmt.Errorf("failed to decode gs://%s/%s generation %d: %w", bucket, object, generation, err)
+	}
+	return &state, nil
+}
+
+func objectExists(ctx context.Context, gcs *storage.Client, bucket, object string) (bool, error) {
+	_, err := gcs.Bucket(bucket).Object(object).Attrs(ctx)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, storage.ErrObjectNotExist) || isNotFound(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+// deleteGcpNetwork removes the network and everything still referencing it, in
+// the order GCP requires. Each step tolerates an already-deleted resource, so
+// a retry after a partial run makes progress.
+//
+// The referencing resources exist because the GCP provider retains them on
+// delete: the subnet (gcp.go), the servicenetworking peering (vpc_peering.go)
+// and the MIG instance templates (compute.go). Cloud Routers are not retained,
+// but a destroy that continued on error can leave one behind, and it blocks
+// the network delete just the same.
+func deleteGcpNetwork(ctx context.Context, gcpProject, region, networkID string) error {
+	networks, err := compute.NewNetworksRESTClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create networks client: %w", err)
+	}
+	defer networks.Close()
+
+	name := path.Base(networkID)
+
+	if err := deleteInstanceTemplates(ctx, gcpProject, networkID); err != nil {
+		return err
+	}
+	if err := removeNetworkPeerings(ctx, networks, gcpProject, name); err != nil {
+		return err
+	}
+	if err := deleteRouters(ctx, gcpProject, region, networkID); err != nil {
+		return err
+	}
+	if err := deleteSubnetworks(ctx, gcpProject, region, networkID); err != nil {
+		return err
+	}
+
+	op, err := networks.Delete(ctx, &computepb.DeleteNetworkRequest{
+		Project: gcpProject,
+		Network: name,
+	})
+	if err != nil {
+		if isNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to delete network %s: %w", name, err)
+	}
+	if err := op.Wait(ctx); err != nil {
+		return fmt.Errorf("failed to wait for the delete of network %s: %w", name, err)
+	}
+	return nil
+}
+
+// deleteInstanceTemplates deletes the retained MIG instance templates whose
+// network interfaces point at the network. Templates are a global resource.
+func deleteInstanceTemplates(ctx context.Context, gcpProject, networkID string) error {
+	templates, err := compute.NewInstanceTemplatesRESTClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create instance templates client: %w", err)
+	}
+	defer templates.Close()
+
+	grp := new(errgroup.Group)
+	it := templates.List(ctx, &computepb.ListInstanceTemplatesRequest{Project: gcpProject})
+	for {
+		tmpl, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("failed to list instance templates: %w", err)
+		}
+		if tmpl.GetProperties() == nil || !usesNetwork(tmpl.GetProperties().GetNetworkInterfaces(), networkID) {
+			continue
+		}
+		tmplName := tmpl.GetName()
+		grp.Go(func() error {
+			op, err := templates.Delete(ctx, &computepb.DeleteInstanceTemplateRequest{
+				Project:          gcpProject,
+				InstanceTemplate: tmplName,
+			})
+			if err != nil {
+				if isNotFound(err) {
+					return nil
+				}
+				return fmt.Errorf("failed to delete instance template %s: %w", tmplName, err)
+			}
+			if err := op.Wait(ctx); err != nil {
+				return fmt.Errorf("failed to wait for the delete of instance template %s: %w", tmplName, err)
+			}
+			return nil
+		})
+	}
+	return grp.Wait()
+}
+
+func usesNetwork(interfaces []*computepb.NetworkInterface, networkID string) bool {
+	for _, ni := range interfaces {
+		if referencesNetwork(ni.GetNetwork(), networkID) {
+			return true
+		}
+	}
+	return false
+}
+
+// removeNetworkPeerings drops every peering on the network, including the
+// retained servicenetworking connection. A network with a peering cannot be
+// deleted, and the peering outlives the address range it was created from.
+func removeNetworkPeerings(ctx context.Context, networks *compute.NetworksClient, gcpProject, name string) error {
+	network, err := networks.Get(ctx, &computepb.GetNetworkRequest{Project: gcpProject, Network: name})
+	if err != nil {
+		if isNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get network %s: %w", name, err)
+	}
+	for _, peering := range network.GetPeerings() {
+		peeringName := peering.GetName()
+		op, err := networks.RemovePeering(ctx, &computepb.RemovePeeringNetworkRequest{
+			Project: gcpProject,
+			Network: name,
+			NetworksRemovePeeringRequestResource: &computepb.NetworksRemovePeeringRequest{
+				Name: &peeringName,
+			},
+		})
+		if err != nil {
+			if isNotFound(err) {
+				continue
+			}
+			return fmt.Errorf("failed to remove peering %s from network %s: %w", peeringName, name, err)
+		}
+		if err := op.Wait(ctx); err != nil {
+			return fmt.Errorf("failed to wait for the removal of peering %s: %w", peeringName, err)
+		}
+	}
+	return nil
+}
+
+// deleteRouters deletes the Cloud Routers on the network, which carry the NAT
+// configuration and hold a reference to the network.
+func deleteRouters(ctx context.Context, gcpProject, region, networkID string) error {
+	routers, err := compute.NewRoutersRESTClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create routers client: %w", err)
+	}
+	defer routers.Close()
+
+	grp := new(errgroup.Group)
+	it := routers.List(ctx, &computepb.ListRoutersRequest{Project: gcpProject, Region: region})
+	for {
+		router, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("failed to list routers: %w", err)
+		}
+		if !referencesNetwork(router.GetNetwork(), networkID) {
+			continue
+		}
+		routerName := router.GetName()
+		grp.Go(func() error {
+			op, err := routers.Delete(ctx, &computepb.DeleteRouterRequest{
+				Project: gcpProject,
+				Region:  region,
+				Router:  routerName,
+			})
+			if err != nil {
+				if isNotFound(err) {
+					return nil
+				}
+				return fmt.Errorf("failed to delete router %s: %w", routerName, err)
+			}
+			if err := op.Wait(ctx); err != nil {
+				return fmt.Errorf("failed to wait for the delete of router %s: %w", routerName, err)
+			}
+			return nil
+		})
+	}
+	return grp.Wait()
+}
+
+// deleteSubnetworks deletes the retained subnets of the network in the region.
+func deleteSubnetworks(ctx context.Context, gcpProject, region, networkID string) error {
+	subnets, err := compute.NewSubnetworksRESTClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create subnetworks client: %w", err)
+	}
+	defer subnets.Close()
+
+	grp := new(errgroup.Group)
+	it := subnets.List(ctx, &computepb.ListSubnetworksRequest{Project: gcpProject, Region: region})
+	for {
+		subnet, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("failed to list subnetworks: %w", err)
+		}
+		if !referencesNetwork(subnet.GetNetwork(), networkID) {
+			continue
+		}
+		subnetName := subnet.GetName()
+		grp.Go(func() error {
+			op, err := subnets.Delete(ctx, &computepb.DeleteSubnetworkRequest{
+				Project:    gcpProject,
+				Region:     region,
+				Subnetwork: subnetName,
+			})
+			if err != nil {
+				if isNotFound(err) {
+					return nil
+				}
+				return fmt.Errorf("failed to delete subnet %s: %w", subnetName, err)
+			}
+			if err := op.Wait(ctx); err != nil {
+				return fmt.Errorf("failed to wait for the delete of subnet %s: %w", subnetName, err)
+			}
+			return nil
+		})
+	}
+	return grp.Wait()
+}
+
+// referencesNetwork reports whether a resource's network field points at the
+// network. The field is a full self-link, while the id from Pulumi state is
+// the "projects/P/global/networks/N" form, so compare on the trailing path.
+func referencesNetwork(selfLink, networkID string) bool {
+	if selfLink == "" {
+		return false
+	}
+	return strings.HasSuffix(selfLink, "/"+strings.TrimPrefix(networkID, "/"))
+}
+
+// deleteSchedulerJob deletes the cleanup job itself, so a successful run does
+// not fire again.
+func deleteSchedulerJob(ctx context.Context, gcpProject, region, jobID string) error {
+	client, err := scheduler.NewCloudSchedulerClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create scheduler client: %w", err)
+	}
+	defer client.Close()
+
+	_, name := schedulerJobName(gcpProject, region, jobID)
+	if err := client.DeleteJob(ctx, &schedulerpb.DeleteJobRequest{Name: name}); err != nil {
+		if isNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to delete the cleanup job %s: %w", jobID, err)
+	}
+	return nil
+}
+
+func schedulerJobName(gcpProject, region, jobID string) (string, string) {
+	parent := fmt.Sprintf("projects/%s/locations/%s", gcpProject, region)
+	return parent, parent + "/jobs/" + jobID
+}
+
+// gcpProjectFromEnv mirrors cd/config.go: GCP_PROJECT is kept for old CLIs.
+func gcpProjectFromEnv() string {
+	return getenv("GCLOUD_PROJECT", os.Getenv("GCP_PROJECT"))
+}
+
+// isNotFound reports whether err is a 404 from either the REST or the gRPC
+// transport, in which case the resource is already gone.
+func isNotFound(err error) bool {
+	var gerr *googleapi.Error
+	if errors.As(err, &gerr) && gerr.Code == 404 {
+		return true
+	}
+	var aerr *apierror.APIError
+	if errors.As(err, &aerr) {
+		if aerr.HTTPCode() == 404 {
+			return true
+		}
+		if s := aerr.GRPCStatus(); s != nil && s.Code() == codes.NotFound {
+			return true
+		}
+	}
+	return false
+}

--- a/cd/cleanup_gcp.go
+++ b/cd/cleanup_gcp.go
@@ -41,14 +41,13 @@ import (
 // retrying inside the destroy would help:
 // https://docs.cloud.google.com/run/docs/configuring/vpc-direct-vpc
 //
-// Both this repo and the old MVP CD hit that same constraint; they differ only
-// in how they absorb it. MVP does not retain: it attempts the delete, the
-// delete fails, and its destroy() downgrades the error to a warning and
-// returns nothing (pulumi/cd/gcp/gcpcd/down.go), so the `down` still exits 0
-// and the failure is invisible — its cron then mops up. This CD instead
-// propagates a destroy error (see pulumiErr in cd_main.go), so the same failure
-// would be a visibly broken `down`. Hence RetainOnDelete on the network and
-// subnet (provider/defanggcp/gcp/gcp.go): do not attempt what cannot succeed.
+// Both this repo and the old MVP CD hit that same constraint and retain the
+// network and subnet so Pulumi removes them from state without attempting a
+// delete that cannot yet succeed. MVP also retains the MIG instance templates
+// and the Service Networking connection. Its delayed cleanup complements those
+// retains by deleting the physical subnet and network later. This CD preserves
+// that two-phase lifecycle: RetainOnDelete during the destroy, followed by the
+// scheduled cleanup once GCP has released the subnet.
 //
 // Either way the deferred clean-up is required, and it was the piece missing
 // here — so the retained networks accumulated until they exhausted the

--- a/cd/cleanup_gcp.go
+++ b/cd/cleanup_gcp.go
@@ -41,11 +41,18 @@ import (
 // retrying inside the destroy would help:
 // https://docs.cloud.google.com/run/docs/configuring/vpc-direct-vpc
 //
-// So the provider marks the network and subnet RetainOnDelete
-// (provider/defanggcp/gcp/gcp.go) to keep the destroy from failing on them,
-// and the destroy schedules this command to delete them once the window has
-// passed. Without it the leaked networks exhaust the project's NETWORKS quota
-// (30 per project), which is what issue 183 was raised for.
+// Both this repo and the old MVP CD hit that same constraint; they differ only
+// in how they absorb it. MVP does not retain: it attempts the delete, the
+// delete fails, and its destroy() downgrades the error to a warning and
+// returns nothing (pulumi/cd/gcp/gcpcd/down.go), so the `down` still exits 0
+// and the failure is invisible — its cron then mops up. This CD instead
+// propagates a destroy error (see pulumiErr in cd_main.go), so the same failure
+// would be a visibly broken `down`. Hence RetainOnDelete on the network and
+// subnet (provider/defanggcp/gcp/gcp.go): do not attempt what cannot succeed.
+//
+// Either way the deferred clean-up is required, and it was the piece missing
+// here — so the retained networks accumulated until they exhausted the
+// project's NETWORKS quota (30 per project), which is what issue 183 is about.
 const cdCommandCleanup = client.CdCommand("cleanup")
 
 // cleanupJobTimeFormat stamps the scheduler job name with its own creation
@@ -55,6 +62,11 @@ const cleanupJobTimeFormat = "20060102150405"
 // cleanupJobEnvVar names the scheduler job in the environment of the build it
 // schedules, so the run can delete the job that started it.
 const cleanupJobEnvVar = "CLEAN_UP_JOB_NAME"
+
+// deleteConcurrency bounds the parallel deletes. The template and router lists
+// are project-wide and a matching stack can hold many, so the fan-out needs a
+// ceiling to stay within the Compute API's rate limits.
+const deleteConcurrency = 8
 
 // cleanupFirstRunDelay delays the first fire to the end of the 1-2h window GCP
 // needs to release the subnet's IP addresses (see cdCommandCleanup). It also
@@ -325,14 +337,7 @@ func networkFromStateBackup(ctx context.Context, gcs *storage.Client, bucket, ob
 	if err != nil {
 		return "", fmt.Errorf("failed to list the generations of gs://%s/%s: %w", bucket, object, err)
 	}
-	// Newest first, so the first match is the most recent checkpoint that still
-	// holds the network.
-	slices.SortFunc(generations, func(a, b objectGeneration) int { return cmp.Compare(b.generation, a.generation) })
-
-	for _, gen := range generations {
-		if gen.created.After(before) {
-			continue
-		}
+	for _, gen := range candidateGenerations(generations, before) {
 		state, err := readStateFile(ctx, gcs, bucket, object, gen.generation)
 		if err != nil {
 			return "", err
@@ -349,6 +354,27 @@ func networkFromStateBackup(ctx context.Context, gcs *storage.Client, bucket, ob
 type objectGeneration struct {
 	generation int64
 	created    time.Time
+}
+
+// candidateGenerations orders the generations newest first and drops any created
+// at or after `before` (the cleanup job's own creation time).
+//
+// The filter is what keeps this safe rather than merely correct: a generation
+// written after the job was scheduled belongs to a LATER deploy, whose network
+// is live. Reading one would hand back a network still in use and the teardown
+// would delete it. Only older checkpoints describe the stack this job was
+// scheduled to clean up.
+func candidateGenerations(generations []objectGeneration, before time.Time) []objectGeneration {
+	out := make([]objectGeneration, 0, len(generations))
+	for _, gen := range generations {
+		// Not After: a generation stamped exactly at the cut-off is not older
+		// than the job, so it cannot be assumed to predate it.
+		if gen.created.Before(before) {
+			out = append(out, gen)
+		}
+	}
+	slices.SortFunc(out, func(a, b objectGeneration) int { return cmp.Compare(b.generation, a.generation) })
+	return out
 }
 
 func objectGenerations(ctx context.Context, gcs *storage.Client, bucket, object string) ([]objectGeneration, error) {
@@ -452,10 +478,13 @@ func deleteGcpNetwork(ctx context.Context, gcpProject, region, networkID string)
 // the network, either directly or through one of its subnets. Templates are a
 // global resource, so the whole project is listed and filtered.
 //
-// Matching the subnet matters more than matching the network: a project-scoped
-// template sets only Subnetwork and leaves Network empty (see the network
-// interface built in provider/defanggcp/gcp/compute.go), so a network-only
-// filter would never match the templates that actually block the delete.
+// A template is matched on either field. The code only ever sets Subnetwork
+// (see the network interface built in provider/defanggcp/gcp/compute.go), but
+// GCP fills Network in from it, so reading either one back normally works —
+// verified against live templates in defang-playground-dev, which were created
+// with Subnetwork alone and report both. Matching only Network would leave the
+// whole teardown resting on that server-side normalisation, and a template we
+// fail to spot blocks the network delete for ever, so match both.
 func deleteInstanceTemplates(ctx context.Context, gcpProject, networkID string, subnets []subnetwork) error {
 	templates, err := compute.NewInstanceTemplatesRESTClient(ctx)
 	if err != nil {
@@ -463,7 +492,9 @@ func deleteInstanceTemplates(ctx context.Context, gcpProject, networkID string, 
 	}
 	defer templates.Close()
 
-	grp := new(errgroup.Group)
+	grp, grpCtx := errgroup.WithContext(ctx)
+	grp.SetLimit(deleteConcurrency)
+	var listErr error
 	it := templates.List(ctx, &computepb.ListInstanceTemplatesRequest{Project: gcpProject})
 	for {
 		tmpl, err := it.Next()
@@ -471,14 +502,17 @@ func deleteInstanceTemplates(ctx context.Context, gcpProject, networkID string, 
 			break
 		}
 		if err != nil {
-			return fmt.Errorf("failed to list instance templates: %w", err)
+			// Break rather than return: the deletes already started must still
+			// be waited on, or they run unsupervised while the process exits.
+			listErr = fmt.Errorf("failed to list instance templates: %w", err)
+			break
 		}
 		if tmpl.GetProperties() == nil || !usesNetwork(tmpl.GetProperties().GetNetworkInterfaces(), networkID, subnets) {
 			continue
 		}
 		tmplName := tmpl.GetName()
 		grp.Go(func() error {
-			op, err := templates.Delete(ctx, &computepb.DeleteInstanceTemplateRequest{
+			op, err := templates.Delete(grpCtx, &computepb.DeleteInstanceTemplateRequest{
 				Project:          gcpProject,
 				InstanceTemplate: tmplName,
 			})
@@ -488,13 +522,13 @@ func deleteInstanceTemplates(ctx context.Context, gcpProject, networkID string, 
 				}
 				return fmt.Errorf("failed to delete instance template %s: %w", tmplName, err)
 			}
-			if err := op.Wait(ctx); err != nil {
+			if err := op.Wait(grpCtx); err != nil {
 				return fmt.Errorf("failed to wait for the delete of instance template %s: %w", tmplName, err)
 			}
 			return nil
 		})
 	}
-	return grp.Wait()
+	return errors.Join(grp.Wait(), listErr)
 }
 
 // usesNetwork reports whether any interface holds the network directly or sits
@@ -555,7 +589,9 @@ func deleteRouters(ctx context.Context, gcpProject, region, networkID string) er
 	}
 	defer routers.Close()
 
-	grp := new(errgroup.Group)
+	grp, grpCtx := errgroup.WithContext(ctx)
+	grp.SetLimit(deleteConcurrency)
+	var listErr error
 	it := routers.List(ctx, &computepb.ListRoutersRequest{Project: gcpProject, Region: region})
 	for {
 		router, err := it.Next()
@@ -563,14 +599,15 @@ func deleteRouters(ctx context.Context, gcpProject, region, networkID string) er
 			break
 		}
 		if err != nil {
-			return fmt.Errorf("failed to list routers: %w", err)
+			listErr = fmt.Errorf("failed to list routers: %w", err)
+			break
 		}
 		if !referencesNetwork(router.GetNetwork(), networkID) {
 			continue
 		}
 		routerName := router.GetName()
 		grp.Go(func() error {
-			op, err := routers.Delete(ctx, &computepb.DeleteRouterRequest{
+			op, err := routers.Delete(grpCtx, &computepb.DeleteRouterRequest{
 				Project: gcpProject,
 				Region:  region,
 				Router:  routerName,
@@ -581,13 +618,13 @@ func deleteRouters(ctx context.Context, gcpProject, region, networkID string) er
 				}
 				return fmt.Errorf("failed to delete router %s: %w", routerName, err)
 			}
-			if err := op.Wait(ctx); err != nil {
+			if err := op.Wait(grpCtx); err != nil {
 				return fmt.Errorf("failed to wait for the delete of router %s: %w", routerName, err)
 			}
 			return nil
 		})
 	}
-	return grp.Wait()
+	return errors.Join(grp.Wait(), listErr)
 }
 
 // subnetwork is one of the network's subnets: its name, to delete it, and its
@@ -636,11 +673,12 @@ func deleteSubnetworks(ctx context.Context, gcpProject, region string, list []su
 	}
 	defer subnets.Close()
 
-	grp := new(errgroup.Group)
+	grp, grpCtx := errgroup.WithContext(ctx)
+	grp.SetLimit(deleteConcurrency)
 	for _, subnet := range list {
 		subnetName := subnet.name
 		grp.Go(func() error {
-			op, err := subnets.Delete(ctx, &computepb.DeleteSubnetworkRequest{
+			op, err := subnets.Delete(grpCtx, &computepb.DeleteSubnetworkRequest{
 				Project:    gcpProject,
 				Region:     region,
 				Subnetwork: subnetName,
@@ -651,7 +689,7 @@ func deleteSubnetworks(ctx context.Context, gcpProject, region string, list []su
 				}
 				return fmt.Errorf("failed to delete subnet %s: %w", subnetName, err)
 			}
-			if err := op.Wait(ctx); err != nil {
+			if err := op.Wait(grpCtx); err != nil {
 				return fmt.Errorf("failed to wait for the delete of subnet %s: %w", subnetName, err)
 			}
 			return nil

--- a/cd/cleanup_gcp_test.go
+++ b/cd/cleanup_gcp_test.go
@@ -1,0 +1,278 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DefangLabs/pulumi-defang/cd/program"
+)
+
+func TestCleanupJobIDRoundTrip(t *testing.T) {
+	now := time.Date(2026, 8, 19, 14, 30, 45, 0, time.UTC)
+	jobID := cleanupJobID("myproj", "preview", now)
+	if want := "defang-cleanup-myproj-preview-20260819143045"; jobID != want {
+		t.Errorf("jobID = %q, want %q", jobID, want)
+	}
+
+	got, err := cleanupJobCreatedAt(jobID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.Equal(now) {
+		t.Errorf("createdAt = %s, want %s", got, now)
+	}
+}
+
+// The timestamp must be read as UTC: parsing it in the local zone would shift
+// the cut-off and skip state generations that predate the job.
+func TestCleanupJobCreatedAtIsUTC(t *testing.T) {
+	t.Setenv("TZ", "America/Vancouver")
+	got, err := cleanupJobCreatedAt("defang-cleanup-p-s-20260819143045")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := time.Date(2026, 8, 19, 14, 30, 45, 0, time.UTC); !got.Equal(want) {
+		t.Errorf("createdAt = %s, want %s", got, want)
+	}
+}
+
+func TestCleanupJobCreatedAtRejectsGarbage(t *testing.T) {
+	for _, jobID := range []string{"defang-cleanup-p-s-notatime", "nodashes", ""} {
+		if _, err := cleanupJobCreatedAt(jobID); err == nil {
+			t.Errorf("cleanupJobCreatedAt(%q) = nil error, want error", jobID)
+		}
+	}
+}
+
+func TestCleanupCron(t *testing.T) {
+	tests := []struct {
+		now  time.Time
+		want string
+	}{
+		// +1h59m lands at 15:29, an odd hour -> the odd 2-hourly series.
+		{time.Date(2026, 8, 19, 13, 30, 0, 0, time.UTC), "29 1-23/2 * * *"},
+		// +1h59m lands at 14:29, an even hour -> the even series.
+		{time.Date(2026, 8, 19, 12, 30, 0, 0, time.UTC), "29 0-23/2 * * *"},
+		// Crossing midnight must still yield a valid hour field.
+		{time.Date(2026, 8, 19, 23, 0, 0, 0, time.UTC), "59 0-23/2 * * *"},
+	}
+	for _, tt := range tests {
+		if got := cleanupCron(tt.now); got != tt.want {
+			t.Errorf("cleanupCron(%s) = %q, want %q", tt.now, got, tt.want)
+		}
+	}
+}
+
+// The first fire must not be immediate, or the job runs before the resources
+// referencing the network are gone, and it must stay inside the 2h period.
+func TestCleanupFirstRunDelay(t *testing.T) {
+	if cleanupFirstRunDelay <= 0 || cleanupFirstRunDelay >= 2*time.Hour {
+		t.Errorf("cleanupFirstRunDelay = %s, want between 0 and 2h", cleanupFirstRunDelay)
+	}
+}
+
+func TestGcpCleanupBuild(t *testing.T) {
+	environ := []string{
+		"PROJECT=myproj",
+		"STACK=preview",
+		"GCLOUD_PROJECT=my-gcp-project",              // kept: GCLOUD_ prefix
+		"PULUMI_BACKEND_URL=gs://defang-cd",          // kept: PULUMI_ prefix, needed to find the state
+		"DEFANG_STATES_UPLOAD_URL=https://presigned", // dropped: expires before the job fires
+		"PATH=/usr/bin",                              // dropped
+	}
+	body, err := gcpCleanupBuild("us-docker.pkg.dev/defang/cd:v2", "my-gcp-project", "cd@my-gcp-project.iam.gserviceaccount.com", "preview", "defang-cleanup-myproj-preview-20260819143045", environ)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var build struct {
+		Steps []struct {
+			Name string   `json:"name"`
+			Args []string `json:"args"`
+			Env  []string `json:"env"`
+		} `json:"steps"`
+		Options struct {
+			Logging string `json:"logging"`
+		} `json:"options"`
+		Timeout        string   `json:"timeout"`
+		Tags           []string `json:"tags"`
+		ServiceAccount string   `json:"serviceAccount"`
+	}
+	if err := json.Unmarshal(body, &build); err != nil {
+		t.Fatal(err)
+	}
+	if len(build.Steps) != 1 {
+		t.Fatalf("steps = %d", len(build.Steps))
+	}
+	step := build.Steps[0]
+	if step.Name != "us-docker.pkg.dev/defang/cd:v2" {
+		t.Errorf("step name = %q", step.Name)
+	}
+	if strings.Join(step.Args, " ") != "cleanup" {
+		t.Errorf("args = %v, want [cleanup]", step.Args)
+	}
+	want := "CLEAN_UP_JOB_NAME=defang-cleanup-myproj-preview-20260819143045," +
+		"GCLOUD_PROJECT=my-gcp-project,PROJECT=myproj,PULUMI_BACKEND_URL=gs://defang-cd,STACK=preview"
+	if got := strings.Join(step.Env, ","); got != want {
+		t.Errorf("env = %q, want %q", got, want)
+	}
+	if build.Options.Logging != "CLOUD_LOGGING_ONLY" {
+		t.Errorf("logging = %q", build.Options.Logging)
+	}
+	if want := fmt.Sprintf("%ds", int(program.CdTimeout.Seconds())); build.Timeout != want {
+		t.Errorf("timeout = %q, want %q", build.Timeout, want)
+	}
+	if build.ServiceAccount != "projects/my-gcp-project/serviceAccounts/cd@my-gcp-project.iam.gserviceaccount.com" {
+		t.Errorf("serviceAccount = %q", build.ServiceAccount)
+	}
+	if strings.Join(build.Tags, ",") != "defang-cd,defang-cleanup,preview" {
+		t.Errorf("tags = %v", build.Tags)
+	}
+}
+
+func TestStackStateObject(t *testing.T) {
+	t.Setenv("PULUMI_BACKEND_URL", "gs://defang-cd-bucket")
+	t.Setenv("DEFANG_STATE_URL", "")
+	bucket, object, err := stackStateObject("myproj", "preview")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bucket != "defang-cd-bucket" {
+		t.Errorf("bucket = %q", bucket)
+	}
+	if want := ".pulumi/stacks/myproj/preview.json"; object != want {
+		t.Errorf("object = %q, want %q", object, want)
+	}
+}
+
+// DEFANG_STATE_URL is the fallback the CLI always sets; PULUMI_BACKEND_URL wins
+// because it is what Pulumi itself wrote the checkpoint to.
+func TestStackStateObjectFallsBackToStateURL(t *testing.T) {
+	t.Setenv("PULUMI_BACKEND_URL", "")
+	t.Setenv("DEFANG_STATE_URL", "gs://defang-cd-bucket")
+	bucket, object, err := stackStateObject("myproj", "preview")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bucket != "defang-cd-bucket" || object != ".pulumi/stacks/myproj/preview.json" {
+		t.Errorf("bucket = %q, object = %q", bucket, object)
+	}
+}
+
+func TestStackStateObjectRequiresBackend(t *testing.T) {
+	t.Setenv("PULUMI_BACKEND_URL", "")
+	t.Setenv("DEFANG_STATE_URL", "")
+	if _, _, err := stackStateObject("myproj", "preview"); err == nil {
+		t.Error("expected an error when no backend URL is set")
+	}
+}
+
+func TestParseGCSURL(t *testing.T) {
+	tests := []struct {
+		raw     string
+		bucket  string
+		object  string
+		wantErr bool
+	}{
+		{raw: "gs://bucket/a/b.json", bucket: "bucket", object: "a/b.json"},
+		{raw: "gs://bucket/a/b%3D%3D.json", bucket: "bucket", object: "a/b==.json"},
+		{raw: "s3://bucket/a", wantErr: true},
+		{raw: "gs://bucket", wantErr: true},
+		{raw: "gs:///object", wantErr: true},
+		{raw: "gs://bucket/", wantErr: true},
+	}
+	for _, tt := range tests {
+		bucket, object, err := parseGCSURL(tt.raw)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("parseGCSURL(%q) = nil error, want error", tt.raw)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseGCSURL(%q): %v", tt.raw, err)
+			continue
+		}
+		if bucket != tt.bucket || object != tt.object {
+			t.Errorf("parseGCSURL(%q) = %q, %q; want %q, %q", tt.raw, bucket, object, tt.bucket, tt.object)
+		}
+	}
+}
+
+// The network id from Pulumi state is a partial path, while GCP returns full
+// self-links. A prefix-sharing network name must not match.
+func TestReferencesNetwork(t *testing.T) {
+	const networkID = "projects/my-gcp-project/global/networks/myproj-vpc"
+	tests := []struct {
+		selfLink string
+		want     bool
+	}{
+		{"https://www.googleapis.com/compute/v1/projects/my-gcp-project/global/networks/myproj-vpc", true},
+		{"https://www.googleapis.com/compute/v1/projects/my-gcp-project/global/networks/other-vpc", false},
+		// Same suffix, different network: must not match.
+		{"https://www.googleapis.com/compute/v1/projects/my-gcp-project/global/networks/notmyproj-vpc", false},
+		// Same name in a different project: must not match.
+		{"https://www.googleapis.com/compute/v1/projects/other-project/global/networks/myproj-vpc", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := referencesNetwork(tt.selfLink, networkID); got != tt.want {
+			t.Errorf("referencesNetwork(%q) = %v, want %v", tt.selfLink, got, tt.want)
+		}
+	}
+}
+
+func TestSchedulerJobName(t *testing.T) {
+	parent, name := schedulerJobName("my-gcp-project", "us-central1", "defang-cleanup-p-s-20260819143045")
+	if want := "projects/my-gcp-project/locations/us-central1"; parent != want {
+		t.Errorf("parent = %q, want %q", parent, want)
+	}
+	if want := "projects/my-gcp-project/locations/us-central1/jobs/defang-cleanup-p-s-20260819143045"; name != want {
+		t.Errorf("name = %q, want %q", name, want)
+	}
+}
+
+// A state backup with no network is terminal: the job must be able to
+// recognise it and delete itself instead of retrying every two hours for ever.
+func TestNoNetworkInStateIsIdentifiable(t *testing.T) {
+	err := fmt.Errorf("%w: looked for %s in gs://b/o", errNoNetworkInState, gcpNetworkType)
+	if !errors.Is(err, errNoNetworkInState) {
+		t.Error("wrapped errNoNetworkInState is not identifiable with errors.Is")
+	}
+	if errors.Is(errors.New("delete blocked by a dependent resource"), errNoNetworkInState) {
+		t.Error("an unrelated error must not match errNoNetworkInState")
+	}
+}
+
+func TestNetworkFromStateDecode(t *testing.T) {
+	const checkpoint = `{
+	  "version": 3,
+	  "checkpoint": {
+	    "stack": "organization/myproj/preview",
+	    "latest": {
+	      "resources": [
+	        {"type": "pulumi:pulumi:Stack", "id": ""},
+	        {"type": "gcp:compute/subnetwork:Subnetwork", "id": "projects/p/regions/us-central1/subnetworks/s"},
+	        {"type": "gcp:compute/network:Network", "id": "projects/p/global/networks/myproj-vpc"}
+	      ]
+	    }
+	  }
+	}`
+	var state pulumiState
+	if err := json.Unmarshal([]byte(checkpoint), &state); err != nil {
+		t.Fatal(err)
+	}
+	var found string
+	for _, res := range state.Checkpoint.Latest.Resources {
+		if res.Type == gcpNetworkType {
+			found = res.Id
+		}
+	}
+	if want := "projects/p/global/networks/myproj-vpc"; found != want {
+		t.Errorf("network id = %q, want %q", found, want)
+	}
+}

--- a/cd/cleanup_gcp_test.go
+++ b/cd/cleanup_gcp_test.go
@@ -8,7 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/DefangLabs/pulumi-defang/cd/program"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestCleanupJobIDRoundTrip(t *testing.T) {
@@ -223,6 +225,51 @@ func TestReferencesNetwork(t *testing.T) {
 		if got := referencesNetwork(tt.selfLink, networkID); got != tt.want {
 			t.Errorf("referencesNetwork(%q) = %v, want %v", tt.selfLink, got, tt.want)
 		}
+	}
+}
+
+// A project-scoped instance template sets only Subnetwork and leaves Network
+// empty (see compute.go), so matching on the network alone misses exactly the
+// templates that block the network delete. Without the subnet arm of this
+// filter the cleanup fails on every retry, for ever.
+func TestUsesNetworkMatchesSubnetOnlyInterface(t *testing.T) {
+	const networkID = "projects/my-gcp-project/global/networks/myproj-vpc"
+	subnets := []subnetwork{
+		{name: "myproj-subnet", id: "projects/my-gcp-project/regions/us-central1/subnetworks/myproj-subnet"},
+	}
+	subnetOnly := []*computepb.NetworkInterface{{
+		Subnetwork: proto.String("https://www.googleapis.com/compute/v1/projects/my-gcp-project/regions/us-central1/subnetworks/myproj-subnet"),
+	}}
+	if !usesNetwork(subnetOnly, networkID, subnets) {
+		t.Error("a subnetwork-only interface in the network's subnet must match")
+	}
+
+	networkOnly := []*computepb.NetworkInterface{{
+		Network: proto.String("https://www.googleapis.com/compute/v1/projects/my-gcp-project/global/networks/myproj-vpc"),
+	}}
+	if !usesNetwork(networkOnly, networkID, subnets) {
+		t.Error("a network-only interface must match")
+	}
+
+	// The standalone path puts templates on the default network; those belong
+	// to no stack of ours and must be left alone.
+	other := []*computepb.NetworkInterface{{
+		Network: proto.String("https://www.googleapis.com/compute/v1/projects/my-gcp-project/global/networks/default"),
+	}}
+	if usesNetwork(other, networkID, subnets) {
+		t.Error("an interface on another network must not match")
+	}
+
+	// A subnet of a different network must not drag the template in.
+	otherSubnet := []*computepb.NetworkInterface{{
+		Subnetwork: proto.String("https://www.googleapis.com/compute/v1/projects/my-gcp-project/regions/us-central1/subnetworks/someone-else"),
+	}}
+	if usesNetwork(otherSubnet, networkID, subnets) {
+		t.Error("an interface in an unrelated subnet must not match")
+	}
+
+	if usesNetwork(nil, networkID, subnets) {
+		t.Error("no interfaces must not match")
 	}
 }
 

--- a/cd/cleanup_gcp_test.go
+++ b/cd/cleanup_gcp_test.go
@@ -29,13 +29,17 @@ func TestCleanupJobIDRoundTrip(t *testing.T) {
 	}
 }
 
-// The timestamp must be read as UTC: parsing it in the local zone would shift
-// the cut-off and skip state generations that predate the job.
+// The timestamp must be read as UTC, because it is written as UTC. Parsing it
+// in the local zone would shift the cut-off by the offset and could admit a
+// newer deploy's state generation. Assert the zone directly: setting TZ here
+// would not help, as Go resolves time.Local once per process.
 func TestCleanupJobCreatedAtIsUTC(t *testing.T) {
-	t.Setenv("TZ", "America/Vancouver")
 	got, err := cleanupJobCreatedAt("defang-cleanup-p-s-20260819143045")
 	if err != nil {
 		t.Fatal(err)
+	}
+	if got.Location() != time.UTC {
+		t.Errorf("location = %s, want UTC", got.Location())
 	}
 	if want := time.Date(2026, 8, 19, 14, 30, 45, 0, time.UTC); !got.Equal(want) {
 		t.Errorf("createdAt = %s, want %s", got, want)
@@ -228,10 +232,10 @@ func TestReferencesNetwork(t *testing.T) {
 	}
 }
 
-// A project-scoped instance template sets only Subnetwork and leaves Network
-// empty (see compute.go), so matching on the network alone misses exactly the
-// templates that block the network delete. Without the subnet arm of this
-// filter the cleanup fails on every retry, for ever.
+// The provider sets only Subnetwork on a template's interface (compute.go), and
+// GCP fills Network in from it. Both arms of the filter are therefore exercised
+// by real data, and a template missed by both blocks the network delete for
+// ever — so pin the behaviour of each, including that neither arm over-matches.
 func TestUsesNetworkMatchesSubnetOnlyInterface(t *testing.T) {
 	const networkID = "projects/my-gcp-project/global/networks/myproj-vpc"
 	subnets := []subnetwork{
@@ -292,6 +296,47 @@ func TestNoNetworkInStateIsIdentifiable(t *testing.T) {
 	}
 	if errors.Is(errors.New("delete blocked by a dependent resource"), errNoNetworkInState) {
 		t.Error("an unrelated error must not match errNoNetworkInState")
+	}
+}
+
+// The cut-off is the safety property of the whole feature: a generation written
+// after the job was scheduled belongs to a LATER deploy whose network is live,
+// so reading it would make the teardown delete a network still in use.
+func TestCandidateGenerations(t *testing.T) {
+	before := time.Date(2026, 8, 19, 14, 30, 45, 0, time.UTC)
+	generations := []objectGeneration{
+		{generation: 100, created: before.Add(-2 * time.Hour)},
+		{generation: 300, created: before.Add(10 * time.Minute)}, // a later deploy
+		{generation: 200, created: before.Add(-1 * time.Hour)},
+		{generation: 250, created: before}, // exactly at the cut-off
+	}
+
+	got := candidateGenerations(generations, before)
+
+	ids := make([]int64, 0, len(got))
+	for _, gen := range got {
+		ids = append(ids, gen.generation)
+	}
+	// Newest first, and neither the later deploy nor the boundary generation.
+	if len(ids) != 2 || ids[0] != 200 || ids[1] != 100 {
+		t.Errorf("generations = %v, want [200 100]", ids)
+	}
+	for _, gen := range got {
+		if !gen.created.Before(before) {
+			t.Errorf("generation %d created %s is not before the cut-off %s", gen.generation, gen.created, before)
+		}
+	}
+}
+
+func TestCandidateGenerationsEmpty(t *testing.T) {
+	before := time.Date(2026, 8, 19, 14, 30, 45, 0, time.UTC)
+	if got := candidateGenerations(nil, before); len(got) != 0 {
+		t.Errorf("candidateGenerations(nil) = %v, want empty", got)
+	}
+	// Every generation newer than the job: nothing is safe to read.
+	newer := []objectGeneration{{generation: 1, created: before.Add(time.Minute)}}
+	if got := candidateGenerations(newer, before); len(got) != 0 {
+		t.Errorf("candidateGenerations(newer) = %v, want empty", got)
 	}
 }
 

--- a/cd/go.mod
+++ b/cd/go.mod
@@ -11,7 +11,9 @@ replace (
 )
 
 require (
+	cloud.google.com/go/compute v1.66.0
 	cloud.google.com/go/compute/metadata v0.9.0
+	cloud.google.com/go/scheduler v1.16.0
 	cloud.google.com/go/storage v1.64.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers/v3 v3.1.0
@@ -24,6 +26,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.37
 	github.com/aws/aws-sdk-go-v2/service/codebuild v1.72.6
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.107.2
+	github.com/googleapis/gax-go/v2 v2.23.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/pulumi/pulumi-aws/sdk/v7 v7.42.0
 	github.com/pulumi/pulumi-azure-native-sdk/app/v3 v3.17.0
@@ -35,6 +38,8 @@ require (
 	github.com/stretchr/testify v1.12.0
 	go.yaml.in/yaml/v4 v4.0.0-rc.6
 	golang.org/x/sync v0.22.0
+	google.golang.org/api v0.293.0
+	google.golang.org/grpc v1.83.0
 	google.golang.org/protobuf v1.36.12
 )
 
@@ -123,7 +128,6 @@ require (
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.20 // indirect
-	github.com/googleapis/gax-go/v2 v2.23.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
@@ -224,11 +228,9 @@ require (
 	golang.org/x/text v0.41.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.48.0 // indirect
-	google.golang.org/api v0.293.0 // indirect
 	google.golang.org/genproto v0.0.0-20260519071638-aa98bba5eb94 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260810153831-ec0a7760b754 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260810153831-ec0a7760b754 // indirect
-	google.golang.org/grpc v1.83.0 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/frand v1.5.1 // indirect

--- a/cd/go.sum
+++ b/cd/go.sum
@@ -6,6 +6,8 @@ cloud.google.com/go/auth v0.23.0 h1:6Gg1CMgpgubRG7DGz5Vf1pcoNo8RfiRiRAPS4crTp54=
 cloud.google.com/go/auth v0.23.0/go.mod h1:4DhBRcqvtljQN3dJ57qtqbib5ZGCYE5f2crfiiC2EM0=
 cloud.google.com/go/auth/oauth2adapt v0.2.8 h1:keo8NaayQZ6wimpNSmW5OPc283g65QNIiLpZnkHRbnc=
 cloud.google.com/go/auth/oauth2adapt v0.2.8/go.mod h1:XQ9y31RkqZCcwJWNSx2Xvric3RrU88hAYYbjDWYDL+c=
+cloud.google.com/go/compute v1.66.0 h1:v8pAJeA0xYPe/tJDMcyimdnHZ115LVrw3xCi9ZelTNQ=
+cloud.google.com/go/compute v1.66.0/go.mod h1:h1O3BCv0Zd0/8rZ6PGx8aRBhKBtDC0AuvURtWg1hLLE=
 cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 cloud.google.com/go/iam v1.11.0 h1:KieQ9Pb+LLPak1O3Rv3GgCxhnmkYf7Xyh0P5HfF1jFM=
@@ -16,6 +18,8 @@ cloud.google.com/go/longrunning v1.2.0 h1:WjYH3YHBGCxGJP9M4dWGHBfXr/cFIjMkNgWcJj
 cloud.google.com/go/longrunning v1.2.0/go.mod h1:5KMQALFGOCtFoi2xSOA1u3H7WKlhmckgiyFw7+LGQp0=
 cloud.google.com/go/monitoring v1.29.0 h1:AHhDsFaSax1/4k+qlIDX/SDGe6hggnfXJ9dkgD9qBPY=
 cloud.google.com/go/monitoring v1.29.0/go.mod h1:72NOVjJXHY/HBfoLT0+qlCZBT059+9VXLeAnL2PeeVM=
+cloud.google.com/go/scheduler v1.16.0 h1:EPdChptxnvCasdMixuu58247qhKMO1iAlrVaQhvuRyE=
+cloud.google.com/go/scheduler v1.16.0/go.mod h1:0hsZg0MZJADyke1lutI0FHAYJR8Dtm8oIivXkmpACkA=
 cloud.google.com/go/storage v1.64.0 h1:KLpxI/oX9LxeRsNqn877d2WyeT3ryiEwnGt8pwcSPZg=
 cloud.google.com/go/storage v1.64.0/go.mod h1:lWyAtwvDZHdL3k68WVKbESP6bmWaV23ZJJ/JEVw/ZaQ=
 cloud.google.com/go/trace v1.16.0 h1:GmQovzFc5F0CNfl0VLgL64aoTtu7xsM0YajW2GlG9+E=

--- a/provider/defanggcp/gcp/gcp.go
+++ b/provider/defanggcp/gcp/gcp.go
@@ -99,6 +99,14 @@ func BuildGlobalConfig(
 	region := GcpRegion(ctx)
 	gcpProject := config.GetProject(ctx)
 
+	// RetainOnDelete on the network and its subnet is deliberate: Cloud Run
+	// attaches with Direct VPC egress (see buildVpcAccess), and GCP holds the
+	// subnet's IP addresses for 1-2 hours after the service is gone. Deleting
+	// them inline therefore fails with resourceInUseByAnotherResource, and a
+	// retry cannot help because the wait is documented GCP behaviour:
+	// https://docs.cloud.google.com/run/docs/configuring/vpc-direct-vpc
+	// The `cleanup` CD command deletes them after the window instead — do not
+	// drop these without removing that (see cd/cleanup_gcp.go).
 	vpc, err := compute.NewNetwork(ctx, projectName+"-vpc", &compute.NetworkArgs{
 		AutoCreateSubnetworks: pulumi.Bool(false),
 	}, append(opts, pulumi.RetainOnDelete(true))...)


### PR DESCRIPTION
Closes #183.

## Why the VPC leaks

A GCP `down` cannot delete the project VPC inline. Cloud Run attaches to it with **Direct VPC egress** (`buildVpcAccess`, `cloudrun.go:284`), and GCP holds the subnet's IP addresses for **1-2 hours** after the service is gone:

> "After you delete or move your Cloud Run resources, wait 1-2 hours for Cloud Run to release the IP addresses before you delete the subnet."
> — [Cloud Run Direct VPC docs](https://docs.cloud.google.com/run/docs/configuring/vpc-direct-vpc)

Until they are released the subnet delete fails with `resourceInUseByAnotherResource`, and the network cannot go before its subnet. That is documented GCP behaviour, not a `pulumi-gcp` defect, and no inline retry can cover a two-hour wait — hence the network and subnet are `RetainOnDelete`, so the destroy does not fail on them.

Nothing then deleted them. The leaked networks exhausted the `NETWORKS` quota (30 per project), which is what blocked the new-provider GCP sanity run and put `defang-playground-dev` at 30/30.

## What this does

Ports the clean-up job from `defang-mvp` (`pulumi/cd/gcp/gcpcd/cleanup.go` + `down.go`). A full destroy now schedules a Cloud Scheduler job that re-runs this CD image with a new `cleanup` command, which:

1. Skips if the stack's state file is back (the stack was redeployed).
2. Otherwise reads the network's id from the newest `<stack>.json.bak` generation that predates the job.
3. Tears the network down, and deletes its own scheduler job.

First fire at **+1h59m**, then every 2 hours — matching the window GCP documents. The repetition is a retry; a successful run removes the job.

No CLI or IAM change is needed. The CD service account already holds `roles/cloudscheduler.admin` (its comment in the CLI reads *"For scheduling clean up jobs"*), `roles/compute.networkAdmin` and bucket `roles/storage.admin`, and the CLI already passes `DEFANG_CD_IMAGE`, `PULUMI_BACKEND_URL`, `GCP_PROJECT`, `STACK` and `REGION`. This also ticks off the two `cd/TODO.md` entries that tracked it.

## Two differences from the original

The retain sets are substantially the same: both implementations retain the VPC, subnet, MIG instance templates, and Service Networking connection. The old cleanup explicitly deleted only subnetworks and the network; this port also removes the retained referencing resources before deleting the network.

- **The teardown removes the blockers, not just the subnets.** MVP deletes subnetworks then the network. That is not enough here: the MIG instance templates (`compute.go:225`) and the servicenetworking peering (`vpc_peering.go:44`) are also retained and each holds a reference to the network, so any stack that used Postgres/CloudSQL or a Compute Engine service would keep failing for ever. The teardown now works in GCP dependency order — instance templates, peering, routers, subnetworks, network — treating 404 as already gone at each step so a retry after a partial run makes progress. Cloud Routers are not retained, but a destroy that continued on error can leave one behind, and it blocks the delete just the same. Firewall rules need no handling: they are not retained.
- **A state backup with no network is terminal.** It will never grow one, so the job deletes itself instead of firing every two hours for ever. Every other failure still leaves the job in place to retry.

## Other deliberate deviations

- **No `getCdImageFromProtoBuf` fallback.** `DEFANG_CD_IMAGE` is already stack config here (`config.go:156`, already marked *"GCP only; for cleanup"*) and the GCP self-destruct already hard-requires it, so a clear error beats a second code path that reads a `ProjectUpdate` protobuf from GCS.
- **No `IsPlayground` skip.** There is no playground mode here, and `gcp.go:102` always creates one `<project>-vpc` per project. (The MVP skip is dead code in its own container path anyway — `ParseGlobalConfig` never sets `IsPlayground`.)
- **Reuse over copy**: `program.SelfDestructEnv`, `program.CdTimeout`, and `compute/metadata` for the service-account address (MVP hand-rolls that HTTP call). This keeps `cloudbuild/apiv1` and `protojson` out of `cd/go.mod` — the build body is JSON, as `gcpSelfDestructBuild` already does it.
- **Schedules only on an untargeted destroy**, matching the existing `optdestroy.Remove()` condition. A targeted destroy keeps the stack, so a job would find the state file and do nothing.
- `cleanup` is not added to the usage string, matching `trigger-down`: both are machine-invoked, not user-facing.
- Recorded *why* the retains exist next to where they are set. Their absence of a rationale is what made this lifecycle ambiguous; they arrived silently in commits about unrelated things (`8d9f366`, `c142733`, `212a8c9`).

## Dependencies

Adds `cloud.google.com/go/compute` (the `apiv1` clients) and `cloud.google.com/go/scheduler` to `cd/go.mod`; four already-present modules are promoted from indirect to direct. No existing pinned version changes.

## Testing

`go test ./...` green for both `cd/` and `provider/...`. New unit tests cover the pure logic, following the `selfdestruct_gcp_test.go` pattern: job-name round-trip, UTC parsing of the timestamp, the cron for odd/even/midnight-crossing hours, the build request body and its env filtering, state-object derivation and its fallback, `gs://` parsing, the terminal-error classification, and `referencesNetwork` — including that a prefix-sharing network name and a same-named network in another project must **not** match.

Two caveats worth flagging:
- **The GCP calls themselves are not covered.** There is no GCP mock in `cd/`, so the client code paths (`deleteGcpNetwork` and friends) are only exercised in a real project. Verifying this end to end needs a GCP `down` and a ~2h wait.
- I could not run the suite with `-race` (`make test_cd` does) as my sandbox has no `gcc`; CI will.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a cleanup command for removing retained Google Cloud networking resources after a full environment teardown.
  * Cleanup is scheduled automatically and runs asynchronously, with retries for recoverable failures.
  * Cleanup safely skips resources when an environment has been redeployed.
  * Added timezone-safe scheduling and validation for cleanup configuration.

* **Documentation**
  * Documented retained networking resources and their delayed cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->