### PR TITLE
fix(gcp): drop redundant projectName from private-dns zone name

### DIFF
--- a/provider/defanggcp/gcp/gcp.go
+++ b/provider/defanggcp/gcp/gcp.go
@@ -157,7 +157,11 @@ func BuildGlobalConfig(
 		return nil, err
 	}
 
-	privateZone, err := dns.NewManagedZone(ctx, projectName+"-private-dns", &dns.ManagedZoneArgs{
+	// Logical name deliberately omits projectName, same as the firewalls above and
+	// public-dns below: Pulumi's default resource ID already prefixes it with
+	// <pulumi-project>-<stack>, which includes projectName, so repeating it here
+	// risked exceeding GCP's 63-char resource ID limit.
+	privateZone, err := dns.NewManagedZone(ctx, "private-dns", &dns.ManagedZoneArgs{
 		Description: pulumi.String(fmt.Sprintf("Private DNS zone for %v", projectName)),
 		DnsName:     pulumi.String("google.internal."),
 		Visibility:  pulumi.String("private"),


### PR DESCRIPTION
## Summary

`BuildGlobalConfig` names the private DNS managed zone `projectName+"-private-dns"`. Pulumi's default resource ID already prefixes the logical name with `<pulumi-project>-<stack>`, which includes `projectName` — so repeating it here double-embeds the project name into the generated GCP resource name, same bug class as #455.

Confirmed live via `defang-mvp#3181`'s `new-provider-sanity` smoketest (dispatched while validating #358):

```
gcp:dns:ManagedZone (html-css-js-private-dns):
  error: googleapi: Error 400: Invalid value for 'entity.managedZone.name':
  'defang-html-css-js-newprovidergcp-html-css-js-private-dns-badcf6f', invalid
```

That name is 67 chars; GCP's DNS managed zone name limit is 63. The deploy fails at this resource before any service starts.

## Fix

Drop the redundant `projectName` prefix from the logical name — same pattern already used for `allow-ssh`/`allow-icmp` (#455) and already followed by `public-dns` a few lines down in the same file, which is why only the private zone hit this.

## Test plan
- [x] `go build ./provider/...`
- [x] `go test ./provider/defanggcp/...`
- [x] `golangci-lint run ./provider/defanggcp/...` — no new issues (pre-existing `goconst` warnings elsewhere in the package, untouched by this change)
- [ ] Re-run `new-provider-sanity.yml` (defang-mvp#3181) once this is picked up into a CD image, to confirm the GCP leg gets past shared-infra creation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the private DNS managed zone naming to use the consistent logical name `private-dns`.
  * Ensured the name complies with GCP resource ID length constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->