### PR TITLE
fix(aws): give ECR repos a lifecycle policy so they stop growing forever

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 A Pulumi multi-cloud provider that deploys Docker Compose applications to AWS, GCP, and Azure. Written in Go, it generates SDKs for TypeScript, Python, Go, and .NET from provider schemas.
 
+## Cross-Provider Parity
+
+This repo has three providers (AWS, GCP, Azure) that are meant to behave the same way. When investigating a bug or a feature request against one provider, **always check whether the other two have the same gap or need the same feature** — don't assume it's AWS-only (or GCP/Azure-only) just because that's where it was reported. A missing lifecycle policy, a missing digest pin, a missing config knob — these tend to be a shape of problem, not a one-provider problem.
+
+When a fix or feature applies to more than one provider, **implement it for all applicable providers in the same PR** rather than filing follow-ups per provider, unless the other providers' fix is genuinely a separate design decision (e.g. it needs its own tradeoff sign-off, or a cloud API constraint forces a materially different approach there). Doing all providers together means:
+- the three implementations get built to look alike, instead of drifting apart because they were written months apart by different context
+- shared logic (constants, policy shapes, anything not cloud-API-specific) gets pulled into `provider/common` immediately, while all three call sites are in front of you, instead of waiting for a third occurrence to justify the extraction
+- a reviewer sees the whole shape of the change at once, instead of three PRs that each look like a narrow one-off
+
+This doesn't mean blocking a real, ready fix on speculative parity work — if one provider's equivalent needs a genuinely separate decision (cost tradeoff, missing platform feature, needs product sign-off), split it out explicitly and say why, the same way you'd flag any other out-of-scope finding.
+
 ## Build Commands
 
 ```bash

--- a/provider/common/registry_retention.go
+++ b/provider/common/registry_retention.go
@@ -1,0 +1,31 @@
+package common
+
+// Registry image-retention policy shared across providers' build repositories.
+// None of the three providers' registry resources expire anything by default
+// (AWS ecr.Repository, GCP artifactregistry.Repository, Azure ContainerRegistry
+// all keep every pushed image forever), so every project accumulates storage
+// without bound. Measured on the Defang org 2026-08-11: 2.13 TB of ECR storage
+// alone ($216/month), 90% of it expirable. See DefangLabs/defang-global#112.
+const (
+	// KeepBuildImages bounds a per-project build repo. Each provider's build
+	// path pushes every build to (effectively) one mutable tag rather than
+	// deploying by digest, so the live image is always the newest one and a
+	// count rule can never expire it — the count is a cap on churn from
+	// superseded builds, not an in-use-image guard. A count is preferred over
+	// an age rule so a rarely-rebuilt project keeps its image indefinitely
+	// (elsewhere in the Defang org, live tasks reference images up to 742 days
+	// old).
+	KeepBuildImages = 20
+
+	// KeepCacheImages bounds each pull-through/remote cache repo. Mirrored
+	// images can always be re-fetched from upstream, so this can be small.
+	KeepCacheImages = 10
+
+	// ExpireUntaggedDays clears superseded build layers quickly, without
+	// waiting for KeepBuildImages to churn them out. Applied to build repos
+	// only: a cache repo's mirrored images arrive untagged by design (pulled
+	// by digest), so an untagged rule there would empty the whole cache and
+	// put every deploy back on the upstream registry's rate limits
+	// (DefangLabs/defang-mvp#2487).
+	ExpireUntaggedDays = 1
+)

--- a/provider/defangaws/aws/ecr.go
+++ b/provider/defangaws/aws/ecr.go
@@ -29,6 +29,19 @@ func createECRRepo(
 		return nil, fmt.Errorf("creating ECR repository: %w", err)
 	}
 
+	// Without this the repository keeps every image ever pushed: the raw ECR
+	// resource has no default lifecycle policy of any kind.
+	policy, err := buildLifecyclePolicy(keepBuildImages)
+	if err != nil {
+		return nil, fmt.Errorf("building ECR lifecycle policy: %w", err)
+	}
+	if _, err := ecr.NewLifecyclePolicy(ctx, name+"-lifecycle", &ecr.LifecyclePolicyArgs{
+		Repository: repo.Name,
+		Policy:     pulumi.String(policy),
+	}, common.MergeOptions(opts, pulumi.Parent(repo))...); err != nil {
+		return nil, fmt.Errorf("creating ECR lifecycle policy: %w", err)
+	}
+
 	return &ecrResult{
 		repository: repo,
 		repoURL:    pulumix.Output[string](repo.RepositoryUrl),
@@ -69,6 +82,23 @@ func createEcrPullThroughCache(
 	)...)
 	if err != nil {
 		return nil, fmt.Errorf("creating ECR pull-through cache rule %q: %w", name, err)
+	}
+
+	// ECR creates the cache repositories itself on the first pull, so there is no
+	// repository resource here to attach a lifecycle policy to and the repos it
+	// creates have none. A creation template is the only mechanism that reaches
+	// them (DefangLabs/defang-mvp#1056).
+	cachePolicy, err := cacheLifecyclePolicy(keepCacheImages)
+	if err != nil {
+		return nil, fmt.Errorf("building ECR cache lifecycle policy: %w", err)
+	}
+	if _, err := ecr.NewRepositoryCreationTemplate(ctx, name+"-cache-template", &ecr.RepositoryCreationTemplateArgs{
+		Prefix:          rule.EcrRepositoryPrefix,
+		AppliedFors:     pulumi.StringArray{pulumi.String("PULL_THROUGH_CACHE")},
+		Description:     pulumi.Sprintf("Retention for %s pull-through cache repos", name),
+		LifecyclePolicy: pulumi.String(cachePolicy),
+	}, common.MergeOptions(opts, pulumi.Parent(rule))...); err != nil {
+		return nil, fmt.Errorf("creating ECR repository creation template %q: %w", name, err)
 	}
 
 	// Build the full ECR mirror URL prefix: {registryId}.dkr.ecr.{region}.amazonaws.com/{prefix}

--- a/provider/defangaws/aws/ecr.go
+++ b/provider/defangaws/aws/ecr.go
@@ -31,7 +31,7 @@ func createECRRepo(
 
 	// Without this the repository keeps every image ever pushed: the raw ECR
 	// resource has no default lifecycle policy of any kind.
-	policy, err := buildLifecyclePolicy(keepBuildImages)
+	policy, err := buildLifecyclePolicy(common.KeepBuildImages)
 	if err != nil {
 		return nil, fmt.Errorf("building ECR lifecycle policy: %w", err)
 	}
@@ -88,7 +88,7 @@ func createEcrPullThroughCache(
 	// repository resource here to attach a lifecycle policy to and the repos it
 	// creates have none. A creation template is the only mechanism that reaches
 	// them (DefangLabs/defang-mvp#1056).
-	cachePolicy, err := cacheLifecyclePolicy(keepCacheImages)
+	cachePolicy, err := cacheLifecyclePolicy(common.KeepCacheImages)
 	if err != nil {
 		return nil, fmt.Errorf("building ECR cache lifecycle policy: %w", err)
 	}

--- a/provider/defangaws/aws/ecr_policy.go
+++ b/provider/defangaws/aws/ecr_policy.go
@@ -1,0 +1,91 @@
+package aws
+
+import "encoding/json"
+
+// ECR retention. Without a lifecycle policy an ECR repository keeps every image
+// forever: unlike awsx, the raw ecr.Repository resource applies no default at
+// all, not even for untagged images. Measured on the Defang org 2026-08-11:
+// 2.13 TB of ECR storage ($216/month) of which 90% was expirable, and one
+// repository (prod1/kaniko-build) held 11,351 images.
+// See DefangLabs/defang-global#112.
+const (
+	// keepBuildImages bounds a per-project build repo. Chosen as a count rather
+	// than an age because a service that has not been rebuilt in a year still
+	// runs its old image and must be able to pull it again on a task restart —
+	// in the Defang org, live tasks reference images up to 742 days old.
+	keepBuildImages = 20
+
+	// keepCacheImages bounds each pull-through cache repo. Mirrored images can
+	// always be fetched again from upstream, so this can be small.
+	keepCacheImages = 10
+
+	// expireUntaggedDays clears superseded build layers quickly. Only applied to
+	// build repos: see cacheLifecyclePolicy for why caches must not have it.
+	expireUntaggedDays = 1
+)
+
+type lifecycleSelection struct {
+	TagStatus   string `json:"tagStatus"`
+	CountType   string `json:"countType"`
+	CountUnit   string `json:"countUnit,omitempty"`
+	CountNumber int    `json:"countNumber"`
+}
+
+type lifecycleRule struct {
+	RulePriority int                `json:"rulePriority"`
+	Description  string             `json:"description"`
+	Selection    lifecycleSelection `json:"selection"`
+	Action       struct {
+		Type string `json:"type"`
+	} `json:"action"`
+}
+
+type lifecyclePolicy struct {
+	Rules []lifecycleRule `json:"rules"`
+}
+
+func expireRule(priority int, description string, selection lifecycleSelection) lifecycleRule {
+	rule := lifecycleRule{
+		RulePriority: priority,
+		Description:  description,
+		Selection:    selection,
+	}
+	rule.Action.Type = "expire"
+	return rule
+}
+
+// buildLifecyclePolicy is the policy for a repository that holds images we build.
+func buildLifecyclePolicy(keepImages int) (string, error) {
+	policy := lifecyclePolicy{Rules: []lifecycleRule{
+		expireRule(1, "expire untagged images", lifecycleSelection{
+			TagStatus:   "untagged",
+			CountType:   "sinceImagePushed",
+			CountUnit:   "days",
+			CountNumber: expireUntaggedDays,
+		}),
+		expireRule(2, "keep the newest images", lifecycleSelection{
+			TagStatus:   "any",
+			CountType:   "imageCountMoreThan",
+			CountNumber: keepImages,
+		}),
+	}}
+	out, err := json.Marshal(policy)
+	return string(out), err
+}
+
+// cacheLifecyclePolicy is the policy for repositories that ECR creates for a
+// pull-through cache. It has exactly one rule and no untagged rule on purpose:
+// images pulled by digest arrive untagged, so an untagged rule empties the whole
+// cache. An empty cache still works, but it puts every deploy back on the
+// upstream registry and its rate limits (DefangLabs/defang-mvp#2487).
+func cacheLifecyclePolicy(keepImages int) (string, error) {
+	policy := lifecyclePolicy{Rules: []lifecycleRule{
+		expireRule(1, "keep the newest mirrored images", lifecycleSelection{
+			TagStatus:   "any",
+			CountType:   "imageCountMoreThan",
+			CountNumber: keepImages,
+		}),
+	}}
+	out, err := json.Marshal(policy)
+	return string(out), err
+}

--- a/provider/defangaws/aws/ecr_policy.go
+++ b/provider/defangaws/aws/ecr_policy.go
@@ -9,10 +9,14 @@ import "encoding/json"
 // repository (prod1/kaniko-build) held 11,351 images.
 // See DefangLabs/defang-global#112.
 const (
-	// keepBuildImages bounds a per-project build repo. Chosen as a count rather
-	// than an age because a service that has not been rebuilt in a year still
-	// runs its old image and must be able to pull it again on a task restart —
-	// in the Defang org, live tasks reference images up to 742 days old.
+	// keepBuildImages bounds a per-project build repo. In this provider the
+	// repo holds a single mutable :latest tag (codebuild.go pushes every
+	// service's build there; nothing is deployed by digest), so the live image
+	// is always the newest and a count rule can never expire it — the count is
+	// a cap on sub-24h untagged churn, not an in-use-image guard. A count is
+	// still preferred over an age rule so a rarely-rebuilt project keeps its
+	// tagged image indefinitely (elsewhere in the Defang org, live tasks
+	// reference images up to 742 days old).
 	keepBuildImages = 20
 
 	// keepCacheImages bounds each pull-through cache repo. Mirrored images can

--- a/provider/defangaws/aws/ecr_policy.go
+++ b/provider/defangaws/aws/ecr_policy.go
@@ -1,32 +1,24 @@
 package aws
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/DefangLabs/pulumi-defang/provider/common"
+)
 
 // ECR retention. Without a lifecycle policy an ECR repository keeps every image
 // forever: unlike awsx, the raw ecr.Repository resource applies no default at
 // all, not even for untagged images. Measured on the Defang org 2026-08-11:
 // 2.13 TB of ECR storage ($216/month) of which 90% was expirable, and one
 // repository (prod1/kaniko-build) held 11,351 images.
-// See DefangLabs/defang-global#112.
-const (
-	// keepBuildImages bounds a per-project build repo. In this provider the
-	// repo holds a single mutable :latest tag (codebuild.go pushes every
-	// service's build there; nothing is deployed by digest), so the live image
-	// is always the newest and a count rule can never expire it — the count is
-	// a cap on sub-24h untagged churn, not an in-use-image guard. A count is
-	// still preferred over an age rule so a rarely-rebuilt project keeps its
-	// tagged image indefinitely (elsewhere in the Defang org, live tasks
-	// reference images up to 742 days old).
-	keepBuildImages = 20
-
-	// keepCacheImages bounds each pull-through cache repo. Mirrored images can
-	// always be fetched again from upstream, so this can be small.
-	keepCacheImages = 10
-
-	// expireUntaggedDays clears superseded build layers quickly. Only applied to
-	// build repos: see cacheLifecyclePolicy for why caches must not have it.
-	expireUntaggedDays = 1
-)
+// See DefangLabs/defang-global#112. The retention shape (common.KeepBuildImages,
+// common.KeepCacheImages, common.ExpireUntaggedDays) is shared with the GCP and
+// Azure equivalents — this provider's specific note: the repo holds a single
+// mutable :latest tag (codebuild.go pushes every service's build there; nothing
+// is deployed by digest), so the live image is always the newest and a count
+// rule can never expire it — the count is a cap on sub-24h untagged churn, not
+// an in-use-image guard (elsewhere in the Defang org, live tasks reference
+// images up to 742 days old).
 
 type lifecycleSelection struct {
 	TagStatus   string `json:"tagStatus"`
@@ -65,7 +57,7 @@ func buildLifecyclePolicy(keepImages int) (string, error) {
 			TagStatus:   "untagged",
 			CountType:   "sinceImagePushed",
 			CountUnit:   "days",
-			CountNumber: expireUntaggedDays,
+			CountNumber: common.ExpireUntaggedDays,
 		}),
 		expireRule(2, "keep the newest images", lifecycleSelection{
 			TagStatus:   "any",

--- a/provider/defangaws/aws/ecr_policy_test.go
+++ b/provider/defangaws/aws/ecr_policy_test.go
@@ -1,0 +1,83 @@
+package aws
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func parsePolicy(t *testing.T, doc string) lifecyclePolicy {
+	t.Helper()
+	var parsed lifecyclePolicy
+	require.NoError(t, json.Unmarshal([]byte(doc), &parsed))
+	return parsed
+}
+
+func buildPolicy(t *testing.T, keep int) string {
+	t.Helper()
+	doc, err := buildLifecyclePolicy(keep)
+	require.NoError(t, err)
+	return doc
+}
+
+func cachePolicy(t *testing.T, keep int) string {
+	t.Helper()
+	doc, err := cacheLifecyclePolicy(keep)
+	require.NoError(t, err)
+	return doc
+}
+
+func TestBuildLifecyclePolicy(t *testing.T) {
+	policy := parsePolicy(t, buildPolicy(t, keepBuildImages))
+	require.Len(t, policy.Rules, 2)
+
+	untagged := policy.Rules[0]
+	assert.Equal(t, 1, untagged.RulePriority)
+	assert.Equal(t, "untagged", untagged.Selection.TagStatus)
+	assert.Equal(t, "sinceImagePushed", untagged.Selection.CountType)
+	assert.Equal(t, "days", untagged.Selection.CountUnit)
+	assert.Equal(t, "expire", untagged.Action.Type)
+
+	// Bounding the count is the whole point: without it the repo grows forever.
+	keep := policy.Rules[1]
+	assert.Equal(t, 2, keep.RulePriority)
+	assert.Equal(t, "any", keep.Selection.TagStatus)
+	assert.Equal(t, "imageCountMoreThan", keep.Selection.CountType)
+	assert.Equal(t, keepBuildImages, keep.Selection.CountNumber)
+	// Age would delete images that live-but-not-recently-rebuilt services need.
+	assert.Empty(t, keep.Selection.CountUnit)
+}
+
+func TestCacheLifecyclePolicyHasNoUntaggedRule(t *testing.T) {
+	policy := parsePolicy(t, cachePolicy(t, keepCacheImages))
+	require.Len(t, policy.Rules, 1, "a cache needs exactly one count rule")
+
+	rule := policy.Rules[0]
+	assert.Equal(t, "any", rule.Selection.TagStatus)
+	assert.Equal(t, keepCacheImages, rule.Selection.CountNumber)
+
+	// Images pulled by digest arrive untagged, so an untagged rule would empty
+	// the cache and push every deploy onto the upstream registry's rate limits.
+	for _, r := range policy.Rules {
+		assert.NotEqual(t, "untagged", r.Selection.TagStatus)
+	}
+}
+
+func TestLifecyclePoliciesAreValidJSON(t *testing.T) {
+	for name, doc := range map[string]string{
+		"build": buildPolicy(t, 5),
+		"cache": cachePolicy(t, 5),
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.True(t, json.Valid([]byte(doc)))
+			// ECR rejects a policy with an unknown or empty action type.
+			for _, r := range parsePolicy(t, doc).Rules {
+				assert.Equal(t, "expire", r.Action.Type)
+				assert.NotEmpty(t, r.Description)
+				assert.Positive(t, r.Selection.CountNumber)
+			}
+		})
+	}
+}

--- a/provider/defangaws/aws/ecr_policy_test.go
+++ b/provider/defangaws/aws/ecr_policy_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/DefangLabs/pulumi-defang/provider/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -30,7 +31,7 @@ func cachePolicy(t *testing.T, keep int) string {
 }
 
 func TestBuildLifecyclePolicy(t *testing.T) {
-	policy := parsePolicy(t, buildPolicy(t, keepBuildImages))
+	policy := parsePolicy(t, buildPolicy(t, common.KeepBuildImages))
 	require.Len(t, policy.Rules, 2)
 
 	untagged := policy.Rules[0]
@@ -45,18 +46,18 @@ func TestBuildLifecyclePolicy(t *testing.T) {
 	assert.Equal(t, 2, keep.RulePriority)
 	assert.Equal(t, "any", keep.Selection.TagStatus)
 	assert.Equal(t, "imageCountMoreThan", keep.Selection.CountType)
-	assert.Equal(t, keepBuildImages, keep.Selection.CountNumber)
+	assert.Equal(t, common.KeepBuildImages, keep.Selection.CountNumber)
 	// Age would delete images that live-but-not-recently-rebuilt services need.
 	assert.Empty(t, keep.Selection.CountUnit)
 }
 
 func TestCacheLifecyclePolicyHasNoUntaggedRule(t *testing.T) {
-	policy := parsePolicy(t, cachePolicy(t, keepCacheImages))
+	policy := parsePolicy(t, cachePolicy(t, common.KeepCacheImages))
 	require.Len(t, policy.Rules, 1, "a cache needs exactly one count rule")
 
 	rule := policy.Rules[0]
 	assert.Equal(t, "any", rule.Selection.TagStatus)
-	assert.Equal(t, keepCacheImages, rule.Selection.CountNumber)
+	assert.Equal(t, common.KeepCacheImages, rule.Selection.CountNumber)
 
 	// Images pulled by digest arrive untagged, so an untagged rule would empty
 	// the cache and push every deploy onto the upstream registry's rate limits.

--- a/provider/defangazure/azure/image.go
+++ b/provider/defangazure/azure/image.go
@@ -126,6 +126,15 @@ func CreateBuildInfra(
 		return nil, fmt.Errorf("creating AcrPull role assignment: %w", err)
 	}
 
+	// Basic/Standard SKUs (the default — see RegistrySku) have no native
+	// retention policy, unlike ECR/Artifact Registry; that's a Premium-only ACR
+	// feature. A scheduled purge task is the supported alternative.
+	if err := createRegistryPurgeTask(
+		ctx, registry, subID, infra.ResourceGroup.Name, SharedBuildRepo, opts...,
+	); err != nil {
+		return nil, fmt.Errorf("creating registry purge task: %w", err)
+	}
+
 	// Derive managedIdentityID from both the identity AND the role assignment so
 	// the Container App implicitly depends on the role assignment being active
 	// before it attempts to pull images from ACR.

--- a/provider/defangazure/azure/registry_purge.go
+++ b/provider/defangazure/azure/registry_purge.go
@@ -1,0 +1,133 @@
+package azure
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/DefangLabs/pulumi-defang/provider/common"
+	"github.com/pulumi/pulumi-azure-native-sdk/authorization/v3"
+	containerregistry "github.com/pulumi/pulumi-azure-native-sdk/containerregistry/v3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"gopkg.in/yaml.v3"
+)
+
+// acrDeleteRoleDefinitionID is the built-in Azure role that can delete
+// repositories, manifests and tags in a Container Registry — narrower than
+// the AcrPull role Container Apps use (acrPullRoleDefinitionID in image.go),
+// so a leaked pull credential can never delete anything.
+const acrDeleteRoleDefinitionID = "c2f4ef07-c644-48eb-af81-4b1b4947fb11"
+
+// acrCliImage is Microsoft's own purge tool, invoked as a task "cmd" step
+// (not a "build" step: there's nothing to build, and a cmd step's image
+// isn't tracked by a base-image-update trigger the way a build step's is).
+const acrCliImage = "mcr.microsoft.com/acr/acr-cli:0.19"
+
+type acrPurgeTaskStep struct {
+	Cmd                             string `yaml:"cmd"`
+	DisableWorkingDirectoryOverride bool   `yaml:"disableWorkingDirectoryOverride"`
+	Timeout                         int    `yaml:"timeout"`
+}
+
+type acrPurgeTaskSpec struct {
+	Version string             `yaml:"version"`
+	Steps   []acrPurgeTaskStep `yaml:"steps"`
+}
+
+// purgeTaskYAML is the ACR task recipe for a scheduled purge of repo, mirroring
+// the retention shape common.KeepBuildImages/common.ExpireUntaggedDays applied
+// on AWS (ecr_policy.go) and GCP (registry_policy.go): reclaim untagged
+// manifests quickly, then bound total count regardless of tag state.
+func purgeTaskYAML(repo string) (string, error) {
+	filter := repo + ":.*"
+	spec := acrPurgeTaskSpec{
+		Version: "v1.1.0",
+		Steps: []acrPurgeTaskStep{
+			{
+				Cmd: fmt.Sprintf("%s purge --filter %q --ago %dd --untagged",
+					acrCliImage, filter, common.ExpireUntaggedDays),
+				DisableWorkingDirectoryOverride: true,
+				Timeout:                         3600,
+			},
+			{
+				Cmd: fmt.Sprintf("%s purge --filter %q --ago 0d --keep %d",
+					acrCliImage, filter, common.KeepBuildImages),
+				DisableWorkingDirectoryOverride: true,
+				Timeout:                         3600,
+			},
+		},
+	}
+	out, err := yaml.Marshal(spec)
+	return string(out), err
+}
+
+// createRegistryPurgeTask creates a daily-scheduled ACR task that purges old
+// images from repo, plus the identity it needs to do so.
+//
+// ACR's native retention policy (Policies.RetentionPolicy on the Registry
+// resource) is a Premium-SKU-only feature; RegistrySku defaults to "Basic"
+// (recipe.go) and this provider does not require Premium. A scheduled purge
+// task is Microsoft's documented alternative on Basic/Standard, so that's
+// what this builds instead of a native policy.
+//
+// The task runs under its own system-assigned identity granted AcrDelete —
+// not the AcrPull identity CreateBuildInfra hands to Container Apps — so a
+// pull-scoped credential leak can never delete anything.
+func createRegistryPurgeTask(
+	ctx *pulumi.Context,
+	registry *containerregistry.Registry,
+	subID pulumi.StringOutput,
+	resourceGroupName pulumi.StringInput,
+	repo string,
+	opts ...pulumi.ResourceOption,
+) error {
+	taskYAML, err := purgeTaskYAML(repo)
+	if err != nil {
+		return fmt.Errorf("generating ACR purge task YAML: %w", err)
+	}
+
+	task, err := containerregistry.NewTask(ctx, "registry-purge", &containerregistry.TaskArgs{
+		ResourceGroupName: resourceGroupName,
+		RegistryName:      registry.Name,
+		Identity: &containerregistry.IdentityPropertiesArgs{
+			Type: containerregistry.ResourceIdentityTypePtr("SystemAssigned"),
+		},
+		Platform: &containerregistry.PlatformPropertiesArgs{
+			Os: pulumi.String("Linux"),
+		},
+		Step: containerregistry.EncodedTaskStepArgs{
+			Type:               pulumi.String("EncodedTask"),
+			EncodedTaskContent: pulumi.String(base64.StdEncoding.EncodeToString([]byte(taskYAML))),
+		},
+		AgentConfiguration: &containerregistry.AgentPropertiesArgs{
+			Cpu: pulumi.Int(2),
+		},
+		Timeout: pulumi.Int(3600),
+		Trigger: &containerregistry.TriggerPropertiesArgs{
+			TimerTriggers: containerregistry.TimerTriggerArray{
+				&containerregistry.TimerTriggerArgs{
+					Name:     pulumi.String("daily"),
+					Schedule: pulumi.String("0 3 * * *"),
+				},
+			},
+		},
+		Tags: ServiceTags("registry-purge"),
+	}, opts...)
+	if err != nil {
+		return fmt.Errorf("creating ACR purge task: %w", err)
+	}
+
+	roleDefID := pulumi.Sprintf(
+		"/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/%s",
+		subID, acrDeleteRoleDefinitionID,
+	)
+	if _, err := authorization.NewRoleAssignment(ctx, "acr-purge-delete", &authorization.RoleAssignmentArgs{
+		Scope:            registry.ID(),
+		RoleDefinitionId: roleDefID,
+		PrincipalId:      task.Identity.PrincipalId().Elem(),
+		PrincipalType:    pulumi.String("ServicePrincipal"),
+	}, opts...); err != nil {
+		return fmt.Errorf("creating AcrDelete role assignment for purge task: %w", err)
+	}
+
+	return nil
+}

--- a/provider/defangazure/azure/registry_purge_test.go
+++ b/provider/defangazure/azure/registry_purge_test.go
@@ -1,0 +1,38 @@
+package azure
+
+import (
+	"testing"
+
+	"github.com/DefangLabs/pulumi-defang/provider/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestPurgeTaskYAML(t *testing.T) {
+	doc, err := purgeTaskYAML(SharedBuildRepo)
+	require.NoError(t, err)
+
+	var spec acrPurgeTaskSpec
+	require.NoError(t, yaml.Unmarshal([]byte(doc), &spec))
+	require.Len(t, spec.Steps, 2)
+
+	untagged := spec.Steps[0]
+	assert.Contains(t, untagged.Cmd, `--filter "builds:.*"`)
+	assert.Contains(t, untagged.Cmd, "--untagged")
+	assert.Contains(t, untagged.Cmd, "--ago 1d")
+	assert.NotContains(t, untagged.Cmd, "--keep")
+
+	// Bounding the count is the whole point: without it the repo grows forever.
+	keepNewest := spec.Steps[1]
+	assert.NotContains(t, keepNewest.Cmd, "--untagged")
+	assert.Contains(t, keepNewest.Cmd, "--keep 20")
+
+	for _, step := range spec.Steps {
+		assert.Contains(t, step.Cmd, acrCliImage)
+		assert.True(t, step.DisableWorkingDirectoryOverride)
+		assert.Positive(t, step.Timeout)
+	}
+	assert.Equal(t, common.ExpireUntaggedDays, 1)
+	assert.Equal(t, common.KeepBuildImages, 20)
+}

--- a/provider/defanggcp/gcp/artifact_registry.go
+++ b/provider/defanggcp/gcp/artifact_registry.go
@@ -112,10 +112,11 @@ func createBuildInfra(
 
 	ar, err := artifactregistry.NewRepository(ctx, "repo", &artifactregistry.RepositoryArgs{
 		// RepositoryId is required by the GCP API; unlike AWS, GCP does not auto-generate resource IDs.
-		RepositoryId: pulumi.String(sanitizeRepoName(projectName)),
-		Location:     pulumi.String(region),
-		Description:  pulumi.String("Docker images for " + projectName),
-		Format:       pulumi.String("DOCKER"),
+		RepositoryId:    pulumi.String(sanitizeRepoName(projectName)),
+		Location:        pulumi.String(region),
+		Description:     pulumi.String("Docker images for " + projectName),
+		Format:          pulumi.String("DOCKER"),
+		CleanupPolicies: buildCleanupPolicies(),
 	}, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("creating artifact registry repository: %w", err)

--- a/provider/defanggcp/gcp/registry_policy.go
+++ b/provider/defanggcp/gcp/registry_policy.go
@@ -1,0 +1,49 @@
+package gcp
+
+import (
+	"fmt"
+
+	"github.com/DefangLabs/pulumi-defang/provider/common"
+	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/artifactregistry"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// buildCleanupPolicies is the Artifact Registry equivalent of the AWS build
+// repo's lifecycle policy (see provider/defangaws/aws/ecr_policy.go and
+// provider/common.KeepBuildImages): without it, a repository keeps every
+// version pushed to it forever.
+//
+// Artifact Registry evaluates cleanup policies differently from ECR: a
+// version matching ANY "KEEP" policy is protected even if it also matches a
+// "DELETE" policy, whereas ECR's rules each act independently. That means
+// keepNewest below fully protects the newest common.KeepBuildImages versions
+// from expireRest, so expireUntagged only ever fires on an orphaned untagged
+// version once it has already aged out of that window — a narrower window
+// than ECR's independent 1-day rule, but the same direction (safer, not more
+// aggressive), so it's an acceptable difference rather than a bug to chase.
+func buildCleanupPolicies() artifactregistry.RepositoryCleanupPolicyArray {
+	return artifactregistry.RepositoryCleanupPolicyArray{
+		&artifactregistry.RepositoryCleanupPolicyArgs{
+			Id:     pulumi.String("expire-untagged"),
+			Action: pulumi.String("DELETE"),
+			Condition: &artifactregistry.RepositoryCleanupPolicyConditionArgs{
+				TagState:  pulumi.String("UNTAGGED"),
+				OlderThan: pulumi.String(fmt.Sprintf("%dd", common.ExpireUntaggedDays)),
+			},
+		},
+		&artifactregistry.RepositoryCleanupPolicyArgs{
+			Id:     pulumi.String("keep-newest"),
+			Action: pulumi.String("KEEP"),
+			MostRecentVersions: &artifactregistry.RepositoryCleanupPolicyMostRecentVersionsArgs{
+				KeepCount: pulumi.Int(common.KeepBuildImages),
+			},
+		},
+		&artifactregistry.RepositoryCleanupPolicyArgs{
+			Id:     pulumi.String("expire-rest"),
+			Action: pulumi.String("DELETE"),
+			Condition: &artifactregistry.RepositoryCleanupPolicyConditionArgs{
+				TagState: pulumi.String("ANY"),
+			},
+		},
+	}
+}

--- a/provider/defanggcp/gcp/registry_policy_test.go
+++ b/provider/defanggcp/gcp/registry_policy_test.go
@@ -1,0 +1,49 @@
+package gcp
+
+import (
+	"testing"
+
+	"github.com/DefangLabs/pulumi-defang/provider/common"
+	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/artifactregistry"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildCleanupPolicies(t *testing.T) {
+	policies := buildCleanupPolicies()
+	require.Len(t, policies, 3)
+
+	untagged, ok := policies[0].(*artifactregistry.RepositoryCleanupPolicyArgs)
+	require.True(t, ok)
+	assert.Equal(t, "expire-untagged", pulumiString(t, untagged.Id))
+	assert.Equal(t, "DELETE", pulumiString(t, untagged.Action))
+	cond, ok := untagged.Condition.(*artifactregistry.RepositoryCleanupPolicyConditionArgs)
+	require.True(t, ok)
+	assert.Equal(t, "UNTAGGED", pulumiString(t, cond.TagState))
+	assert.Equal(t, "1d", pulumiString(t, cond.OlderThan))
+
+	// Bounding the count is the whole point: without it the repo grows forever.
+	keepNewest, ok := policies[1].(*artifactregistry.RepositoryCleanupPolicyArgs)
+	require.True(t, ok)
+	assert.Equal(t, "KEEP", pulumiString(t, keepNewest.Action))
+	mostRecent, ok := keepNewest.MostRecentVersions.(*artifactregistry.RepositoryCleanupPolicyMostRecentVersionsArgs)
+	require.True(t, ok)
+	keepCount, ok := mostRecent.KeepCount.(pulumi.Int)
+	require.True(t, ok)
+	assert.Equal(t, common.KeepBuildImages, int(keepCount))
+
+	expireRest, ok := policies[2].(*artifactregistry.RepositoryCleanupPolicyArgs)
+	require.True(t, ok)
+	assert.Equal(t, "DELETE", pulumiString(t, expireRest.Action))
+	restCond, ok := expireRest.Condition.(*artifactregistry.RepositoryCleanupPolicyConditionArgs)
+	require.True(t, ok)
+	assert.Equal(t, "ANY", pulumiString(t, restCond.TagState))
+}
+
+func pulumiString(t *testing.T, v any) string {
+	t.Helper()
+	s, ok := v.(pulumi.String)
+	require.True(t, ok, "expected pulumi.String, got %T", v)
+	return string(s)
+}


### PR DESCRIPTION
> Migrated from [#379](https://github.com/DefangLabs/pulumi-defang/pull/379) so the source branch lives in the upstream repository. Earlier discussion and reviews remain on the original PR.Companion to DefangLabs/defang-mvp#3171, which fixes the same class of bug in the legacy Pulumi code. Both come out of the measurement in DefangLabs/defang-global#112 item 1.

## What was wrong

`createECRRepo` creates the repository and stops there. **The raw `ecr.Repository` resource applies no default lifecycle policy of any kind** — not even for untagged images — so `grep -rn LifecyclePolicy` over this repo returned nothing and every image a project ever builds is retained. Each new BYOC project starts another unbounded repository. This is strictly worse than the legacy path, where awsx at least applies an untagged-only default.

Pull-through caches are worse again: ECR creates those repositories itself on the first pull, so there is no Pulumi resource to attach a policy to and they end up with none at all.

Measured across the Defang org on 2026-08-11 (272 repos, 9 accounts):

| | |
|---|---|
| ECR storage | 2.13 TB, **$216/month**, flat at $7.11/day |
| Repos with no lifecycle policy | 252 of 272 |
| Expirable | **90%** |
| Largest single repo | 11,351 images, 2,411 GB apparent |

## What this changes

**Build repos** (`ecr.NewLifecyclePolicy` on the repository) — expire untagged after 1 day, then keep the newest 20 images.

Count, not age, and deliberately: live ECS tasks in that org reference images **up to 742 days old** (`library/grafana/loki`), plus `loki-conf` at 578 days and two project `kaniko-build` repos at 270 days with no rebuild since 2025-11-14. An age rule deletes those — the running task survives, but the next restart or scale-out cannot pull. A count rule is safe here because this provider's build repo is per-project, so one project's builds cannot push another's image out of the window.

**Pull-through cache repos** (`ecr.NewRepositoryCreationTemplate` with `appliedFors: ["PULL_THROUGH_CACHE"]`) — keep the newest 10, and **no untagged rule**. That omission is the important detail: in a cache almost every image is untagged, because it arrives by digest. I verified one — `defang-cd-ecr-public/defang-io/cd` holds 25 images, all 25 untagged (5 OCI indexes plus their 20 children). An untagged rule would empty the cache and put every deploy back on `public.ecr.aws` and its rate limits, i.e. DefangLabs/defang-mvp#2487 again.

The policy documents live in a new `ecr_policy.go` as pure functions so the rule shapes are unit-testable without standing up a stack.

## Follow-up worth filing separately

`createEcrPullThroughCache` derives its prefix from `AutonamingPrefix`, i.e. one cache namespace **per project**. The same upstream image therefore gets cached once per project inside a single account. Measured in the `lab` account: **55 distinct prefixes each holding their own copy of `aws-observability/aws-for-fluent-bit`**, and 37 each caching `defang-io/route53-sidecar` — about 1 TB apparent org-wide in duplicate copies. This PR bounds each copy; sharing the prefix per account would remove them, but that needs adopt-or-create semantics because the namespace is account-global, which is exactly why the current code scopes it per project (as its own comment explains). Happy to do that as a second PR if you want it.

## Testing

`CGO_ENABLED=0 go test ./provider/...` passes; 3 new test functions cover the rule shapes, including a regression guard that the cache policy never grows an untagged rule. `go vet` clean, `gofmt` clean. `golangci-lint` reports 40 pre-existing `goconst` findings elsewhere in `provider/defangaws/aws` and none in these files; `recipe.go` was already unformatted on `main` and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3WmpdY3zc555sNdkY9dzQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic lifecycle policies for build and pull-through cache container repositories.
  * Build repositories now remove untagged images after one day and retain the configured number of recent images.
  * Cache repositories retain only the configured number of recent images, helping control storage growth.

* **Bug Fixes**
  * Improved error handling when creating repository lifecycle policies and cache templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->