### PR TITLE
GCP Compute Engine: native secrets for env via boot-fetch (#164)

### DIFF
--- a/cd/config.go
+++ b/cd/config.go
@@ -71,6 +71,11 @@ func unmarshalRecipe(recipePulumiConfig string, config configMap) error {
 	return nil
 }
 
+// defaultAutonamingSuffix is the "${project}-${stack}-${name}-${hex(7)}" tail
+// shared by most autonaming pattern overrides below; a prefix (bare, or
+// lowercased) is prepended where one is still wanted.
+const defaultAutonamingSuffix = "${project}-${stack}-${name}-${hex(7)}"
+
 func setDefaultStackConfig(prefix string, config configMap) {
 	// defang:prefix holds the bare prefix (e.g. "Defang"); its consumers
 	// (common.Prefix, e.g. ProjectResourceGroupName) append their own "-"
@@ -82,7 +87,7 @@ func setDefaultStackConfig(prefix string, config configMap) {
 	}
 	lowerPrefix := strings.ToLower(prefix)
 	config["pulumi:autonaming"] = configValue{Value: map[string]any{
-		"pattern": prefix + "${project}-${stack}-${name}-${hex(7)}",
+		"pattern": prefix + defaultAutonamingSuffix,
 		"providers": map[string]any{
 			"aws": map[string]any{
 				"resources": map[string]any{
@@ -91,9 +96,9 @@ func setDefaultStackConfig(prefix string, config configMap) {
 					// ecs.Service is always scoped to an ecs.Cluster, so the cluster's
 					// full prefix already disambiguates it; no need to repeat it here.
 					"aws:ecs/service:Service":                 map[string]string{"pattern": "${name}-${hex(7)}"},
-					"aws:elasticache/subnetGroup:SubnetGroup": map[string]string{"pattern": lowerPrefix + "${project}-${stack}-${name}-${hex(7)}"}, // lowercase
-					"aws:ecr/repository:Repository":           map[string]string{"pattern": lowerPrefix + "${project}-${stack}-${name}-${hex(7)}"}, // lowercase
-					"aws:rds/subnetGroup:SubnetGroup":         map[string]string{"pattern": lowerPrefix + "${project}-${stack}-${name}-${hex(7)}"}, // lowercase
+					"aws:elasticache/subnetGroup:SubnetGroup": map[string]string{"pattern": lowerPrefix + defaultAutonamingSuffix}, // lowercase
+					"aws:ecr/repository:Repository":           map[string]string{"pattern": lowerPrefix + defaultAutonamingSuffix}, // lowercase
+					"aws:rds/subnetGroup:SubnetGroup":         map[string]string{"pattern": lowerPrefix + defaultAutonamingSuffix}, // lowercase
 				},
 			},
 			"azure-native": map[string]any{
@@ -123,7 +128,7 @@ func setDefaultStackConfig(prefix string, config configMap) {
 			// (lowercase only, max 63 chars). The default prefix may contain capitals
 			// (e.g. "Defang-"), so force the entire pattern to use the lowercased prefix.
 			"gcp": map[string]any{
-				"pattern": lowerPrefix + "${project}-${stack}-${name}-${hex(7)}", // TODO: sanitize project name
+				"pattern": lowerPrefix + defaultAutonamingSuffix, // TODO: sanitize project name
 				"resources": map[string]any{
 					// Service account ID must be between 6 and 30 characters.
 					// Service account ID must start with a lower case letter, followed by one or more lower case alphanumerical characters that can be separated by hyphens.
@@ -131,10 +136,36 @@ func setDefaultStackConfig(prefix string, config configMap) {
 					// Cloud Run service name max 49 chars (^[a-z][a-z0-9-]{0,47}[a-z0-9]$).
 					// Default prefix-project-stack pattern overflows on longer inputs;
 					// drop the prefix to mirror old cloudrunServiceName (49 char budget).
-					"gcp:cloudrunv2/service:Service": map[string]string{"pattern": "${project}-${stack}-${name}-${hex(7)}"}, // TODO: sanitize project name
+					"gcp:cloudrunv2/service:Service": map[string]string{"pattern": defaultAutonamingSuffix}, // TODO: sanitize project name
 					// Memorystore Redis instance ID max 40 chars (^[a-z][a-z0-9-]{0,38}[a-z0-9]$).
 					// Drop the prefix to mirror old redisInstanceName (40 char budget).
 					"gcp:redis/instance:Instance": map[string]string{"pattern": "${project}-${name}-${hex(7)}"}, // TODO: sanitize project name
+					// Compute Engine resource names (health check, firewall, MIG, instance
+					// template) are capped at 63 chars, same regex as above. Their logical
+					// ${name} already includes the compose service name (and for the health
+					// check/firewall, the port and a "-mig-hc" role suffix), so the full
+					// default pattern (prefix-project-stack-name-hex7) overflows well before
+					// arbitrary-length service names would on their own -- surfaced live via
+					// defang-mvp#3181 against pulumi-defang#358. Drop just the prefix, same
+					// rationale as CloudRunService above.
+					"gcp:compute/healthCheck:HealthCheck": map[string]string{
+						"pattern": defaultAutonamingSuffix,
+					},
+					"gcp:compute/firewall:Firewall": map[string]string{
+						"pattern": defaultAutonamingSuffix,
+					},
+					"gcp:compute/regionInstanceGroupManager:RegionInstanceGroupManager": map[string]string{
+						"pattern": defaultAutonamingSuffix,
+					},
+					"gcp:compute/instanceTemplate:InstanceTemplate": map[string]string{
+						"pattern": defaultAutonamingSuffix,
+					},
+					"gcp:compute/regionBackendService:RegionBackendService": map[string]string{
+						"pattern": defaultAutonamingSuffix,
+					},
+					"gcp:compute/forwardingRule:ForwardingRule": map[string]string{
+						"pattern": defaultAutonamingSuffix,
+					},
 				},
 			},
 		},

--- a/cd/config.go
+++ b/cd/config.go
@@ -143,8 +143,8 @@ func setDefaultStackConfig(prefix string, config configMap) {
 					// Compute Engine resource names (health check, firewall, MIG, instance
 					// template) are capped at 63 chars, same regex as above. Their logical
 					// ${name} already includes the compose service name (and for the health
-					// check/firewall, the port and a "-mig-hc" role suffix), so the full
-					// default pattern (prefix-project-stack-name-hex7) overflows well before
+					// check/firewall, the probed port), so the full default pattern
+					// (prefix-project-stack-name-hex7) overflows well before
 					// arbitrary-length service names would on their own -- surfaced live via
 					// defang-mvp#3181 against pulumi-defang#358. Drop just the prefix, same
 					// rationale as CloudRunService above.

--- a/cd/config_test.go
+++ b/cd/config_test.go
@@ -31,7 +31,7 @@ func Test_setDefaultStackConfig(t *testing.T) {
 	if !ok {
 		t.Fatal("pattern is not a string")
 	}
-	if pattern != "TestPrefix-${project}-${stack}-${name}-${hex(7)}" {
+	if pattern != "TestPrefix-"+defaultAutonamingSuffix {
 		t.Errorf("unexpected pattern: %s", pattern)
 	}
 
@@ -50,11 +50,44 @@ func Test_setDefaultStackConfigEmptyPrefix(t *testing.T) {
 	autonamingMap := autonaming.Value.(map[string]any)
 	pattern := autonamingMap["pattern"].(string)
 	// With empty prefix, pattern should not have a leading prefix-
-	if pattern != "${project}-${stack}-${name}-${hex(7)}" {
+	if pattern != defaultAutonamingSuffix {
 		t.Errorf("unexpected pattern with empty prefix: %s", pattern)
 	}
 	if got := config["defang:prefix"].Value; got != "" {
 		t.Errorf("unexpected defang:prefix with empty prefix: %q", got)
+	}
+}
+
+// Test_setDefaultStackConfigGCPComputeOverrides guards against the health
+// check naming bug surfaced live via defang-mvp#3181 against
+// pulumi-defang#358: the default "gcp" pattern's lowerPrefix only applies to
+// resources with no more specific override, and GCP Compute Engine resources
+// (health check, firewall, MIG, instance template) need the "Defang-" prefix
+// dropped entirely to stay within the 63-char limit -- see setDefaultStackConfig.
+func Test_setDefaultStackConfigGCPComputeOverrides(t *testing.T) {
+	config := configMap{}
+	setDefaultStackConfig("Defang", config)
+
+	autonamingMap := config["pulumi:autonaming"].Value.(map[string]any)
+	providers := autonamingMap["providers"].(map[string]any)
+	gcp := providers["gcp"].(map[string]any)
+	resources := gcp["resources"].(map[string]any)
+
+	for _, resourceType := range []string{
+		"gcp:compute/healthCheck:HealthCheck",
+		"gcp:compute/firewall:Firewall",
+		"gcp:compute/regionInstanceGroupManager:RegionInstanceGroupManager",
+		"gcp:compute/instanceTemplate:InstanceTemplate",
+		"gcp:compute/regionBackendService:RegionBackendService",
+		"gcp:compute/forwardingRule:ForwardingRule",
+	} {
+		override, ok := resources[resourceType].(map[string]string)
+		if !ok {
+			t.Fatalf("missing override for %s", resourceType)
+		}
+		if override["pattern"] != defaultAutonamingSuffix {
+			t.Errorf("%s: pattern = %q, want %q", resourceType, override["pattern"], defaultAutonamingSuffix)
+		}
 	}
 }
 

--- a/provider/defanggcp/gcp/alb.go
+++ b/provider/defanggcp/gcp/alb.go
@@ -160,10 +160,13 @@ func createInternalLoadBalancer(
 		// Logical names below deliberately omit projectName: Pulumi's default
 		// resource ID already prefixes it with <pulumi-project>-<stack>, which
 		// includes projectName, so repeating it here risked exceeding GCP's
-		// 63-char resource ID limit.
+		// 63-char resource ID limit. They also carry no role suffix: the type
+		// token (dns:RecordSet) already says what they are, and every branch
+		// below is mutually exclusive, so a service gets at most one private
+		// record set here.
 		switch {
 		case service.Config.Postgres != nil:
-			if _, err := dns.NewRecordSet(ctx, service.Name+"-private-db-dns", &dns.RecordSetArgs{
+			if _, err := dns.NewRecordSet(ctx, service.Name, &dns.RecordSetArgs{
 				Name:        pulumi.String(internalServiceDns(service.Name)),
 				Type:        pulumi.String("A"),
 				Ttl:         pulumi.Int(60),
@@ -174,7 +177,7 @@ func createInternalLoadBalancer(
 			}
 			continue
 		case service.Config.Redis != nil:
-			if _, err := dns.NewRecordSet(ctx, service.Name+"-private-redis-dns", &dns.RecordSetArgs{
+			if _, err := dns.NewRecordSet(ctx, service.Name, &dns.RecordSetArgs{
 				Name:        pulumi.String(internalServiceDns(service.Name)),
 				Type:        pulumi.String("A"),
 				Ttl:         pulumi.Int(60),
@@ -499,7 +502,7 @@ func createInternalLoadBalancer(
 					}
 				}
 
-				if _, err := dns.NewRecordSet(ctx, service.Name+"-private-lb-dns", &dns.RecordSetArgs{
+				if _, err := dns.NewRecordSet(ctx, service.Name, &dns.RecordSetArgs{
 					Name:        pulumi.String(internalServiceDns(service.Name)),
 					Type:        pulumi.String("A"),
 					Ttl:         pulumi.Int(60),
@@ -579,7 +582,7 @@ func createInternalLoadBalancer(
 			return err
 		}
 		for _, serviceName := range internalAlbServices {
-			if _, err := dns.NewRecordSet(ctx, serviceName+"-private-lb-dns", &dns.RecordSetArgs{
+			if _, err := dns.NewRecordSet(ctx, serviceName, &dns.RecordSetArgs{
 				Name:        pulumi.String(internalServiceDns(serviceName)),
 				Type:        pulumi.String("A"),
 				Ttl:         pulumi.Int(60),

--- a/provider/defanggcp/gcp/alb.go
+++ b/provider/defanggcp/gcp/alb.go
@@ -47,7 +47,7 @@ func CreateLoadBalancers(
 	config *SharedInfra,
 	opts ...pulumi.ResourceOption,
 ) error {
-	if err := createInternalLoadBalancer(ctx, projectName, config, services, opts...); err != nil {
+	if err := createInternalLoadBalancer(ctx, config, services, opts...); err != nil {
 		return err
 	}
 
@@ -118,7 +118,11 @@ func createExternalLoadBalancers(
 	}
 
 	if config.WildcardCertId != nil {
-		if _, err := certificatemanager.NewCertificateMapEntry(ctx, projectName+"-cert-map-entry",
+		// Logical name deliberately omits projectName, same as the VPC/firewalls in
+		// gcp.go: Pulumi's default resource ID already prefixes it with
+		// <pulumi-project>-<stack>, which includes projectName, so repeating it here
+		// risked exceeding GCP's 63-char resource ID limit.
+		if _, err := certificatemanager.NewCertificateMapEntry(ctx, "cert-map-entry",
 			&certificatemanager.CertificateMapEntryArgs{
 				Map:          certMap.Name,
 				Certificates: pulumi.StringArray{config.WildcardCertId},
@@ -128,22 +132,21 @@ func createExternalLoadBalancers(
 		}
 	}
 
-	urlMap, err := buildURLMap(ctx, projectName, ingressEntries, config.Region, opts...)
+	urlMap, err := buildURLMap(ctx, ingressEntries, config.Region, opts...)
 	if err != nil {
 		return err
 	}
 
-	if err := createHTTPSForwardingRule(ctx, projectName, config.PublicIP, urlMap, certMap, opts...); err != nil {
+	if err := createHTTPSForwardingRule(ctx, config.PublicIP, urlMap, certMap, opts...); err != nil {
 		return err
 	}
 
-	return createHTTPRedirectForwardingRule(ctx, projectName, config.PublicIP, opts...)
+	return createHTTPRedirectForwardingRule(ctx, config.PublicIP, opts...)
 }
 
 //nolint:funlen,maintidx
 func createInternalLoadBalancer(
 	ctx *pulumi.Context,
-	projectName string,
 	config *SharedInfra,
 	services []LBServiceEntry,
 	opts ...pulumi.ResourceOption,
@@ -154,9 +157,13 @@ func createInternalLoadBalancer(
 	var privatePathMatchers compute.RegionUrlMapPathMatcherArray
 	for _, service := range services {
 		// Managed services: always create private DNS regardless of ports.
+		// Logical names below deliberately omit projectName: Pulumi's default
+		// resource ID already prefixes it with <pulumi-project>-<stack>, which
+		// includes projectName, so repeating it here risked exceeding GCP's
+		// 63-char resource ID limit.
 		switch {
 		case service.Config.Postgres != nil:
-			if _, err := dns.NewRecordSet(ctx, projectName+"-"+service.Name+"-private-db-dns", &dns.RecordSetArgs{
+			if _, err := dns.NewRecordSet(ctx, service.Name+"-private-db-dns", &dns.RecordSetArgs{
 				Name:        pulumi.String(internalServiceDns(service.Name)),
 				Type:        pulumi.String("A"),
 				Ttl:         pulumi.Int(60),
@@ -167,7 +174,7 @@ func createInternalLoadBalancer(
 			}
 			continue
 		case service.Config.Redis != nil:
-			if _, err := dns.NewRecordSet(ctx, projectName+"-"+service.Name+"-private-redis-dns", &dns.RecordSetArgs{
+			if _, err := dns.NewRecordSet(ctx, service.Name+"-private-redis-dns", &dns.RecordSetArgs{
 				Name:        pulumi.String(internalServiceDns(service.Name)),
 				Type:        pulumi.String("A"),
 				Ttl:         pulumi.Int(60),
@@ -194,6 +201,7 @@ func createInternalLoadBalancer(
 						Service: pulumi.StringPtrInput(service.CloudRunService.Name),
 					},
 				},
+				opts...,
 			)
 			if err != nil {
 				return err
@@ -212,6 +220,7 @@ func createInternalLoadBalancer(
 						},
 					},
 				},
+				opts...,
 			)
 			if err != nil {
 				return err
@@ -264,6 +273,7 @@ func createInternalLoadBalancer(
 						},
 						Direction: pulumi.String("INGRESS"),
 					},
+					opts...,
 				)
 				if err != nil {
 					return err
@@ -279,7 +289,7 @@ func createInternalLoadBalancer(
 							RequestPath: pulumi.String(healthCheckPath),
 						},
 					},
-					pulumi.DependsOn([]pulumi.Resource{firewall}),
+					append(opts, pulumi.DependsOn([]pulumi.Resource{firewall}))...,
 				)
 				if err != nil {
 					return err
@@ -298,6 +308,7 @@ func createInternalLoadBalancer(
 						HealthChecks: healthCheck.ID(),
 						PortName:     pulumi.String(fmt.Sprintf("port-%v-%v", portProto, port.Target)), // Matching compute.go
 					},
+					opts...,
 				)
 				if err != nil {
 					return err
@@ -330,6 +341,7 @@ func createInternalLoadBalancer(
 						Region:      pulumi.String(config.Region),
 						Purpose:     pulumi.String("SHARED_LOADBALANCER_VIP"),
 					},
+					opts...,
 				)
 				if err != nil {
 					return err
@@ -371,13 +383,18 @@ func createInternalLoadBalancer(
 						},
 						Direction: pulumi.String("INGRESS"),
 					},
+					opts...,
 				)
 				if err != nil {
 					return err
 				}
 
+				// "-hc" distinguishes this from trafficFirewall above: both are
+				// gcp:compute/firewall:Firewall for the same service, so they can't
+				// share trafficFirewall's bare service.Name -- Pulumi rejects that
+				// as a duplicate URN (same type + name + parent).
 				healthCheckFirewall, err := compute.NewFirewall(ctx,
-					service.Name,
+					service.Name+"-hc",
 					&compute.FirewallArgs{
 						Network: config.VpcId,
 						// Fixed health check IP ranges for internal passthrough NLB:
@@ -395,6 +412,7 @@ func createInternalLoadBalancer(
 						},
 						Direction: pulumi.String("INGRESS"),
 					},
+					opts...,
 				)
 				if err != nil {
 					return err
@@ -412,7 +430,7 @@ func createInternalLoadBalancer(
 							Port: pulumi.Int(*tcpHealthCheckPort),
 						},
 					},
-					pulumi.DependsOn([]pulumi.Resource{healthCheckFirewall}),
+					append(opts, pulumi.DependsOn([]pulumi.Resource{healthCheckFirewall}))...,
 				)
 				if err != nil {
 					return err
@@ -426,9 +444,16 @@ func createInternalLoadBalancer(
 					// https://cloud.google.com/load-balancing/docs/forwarding-rule-concepts#port_specifications
 					for ports := range slices.Chunk(allPorts, 5) {
 						portsName := strings.Trim(strings.ReplaceAll(fmt.Sprint(ports), " ", "-"), "[]")
+						// No "-backend-service"/"-forwarding-rule" suffix (the type token
+						// already says what each is); protocol is included since two
+						// protocols can chunk to the same port set, which would otherwise
+						// collide on a shared logical name (a live smoketest, defang-mvp#3181,
+						// hit this bug's sibling missing-separator variant: "smokeworkerhost-
+						// 6379-backend-service", also 68 chars -- one more reason to keep it
+						// short instead of just re-adding a "-" before "host").
+						name := fmt.Sprintf("%s-%s-%s", service.Name, strings.ToLower(string(protocol)), portsName)
 
-						backendService, err := compute.NewRegionBackendService(ctx,
-							service.Name+fmt.Sprintf("host-%v-backend-service", portsName),
+						backendService, err := compute.NewRegionBackendService(ctx, name,
 							&compute.RegionBackendServiceArgs{
 								Region:              pulumi.String(config.Region),
 								LoadBalancingScheme: pulumi.String("INTERNAL"),
@@ -443,6 +468,7 @@ func createInternalLoadBalancer(
 								ConnectionDrainingTimeoutSec: pulumi.Int(0), // Make configurable?
 								HealthChecks:                 healthCheck.ID(),
 							},
+							opts...,
 						)
 						if err != nil {
 							return err
@@ -453,8 +479,7 @@ func createInternalLoadBalancer(
 							portsInput = append(portsInput, pulumi.String(strconv.FormatUint(uint64(port), 10)))
 						}
 						// Create a forwarding rule
-						_, err = compute.NewForwardingRule(ctx,
-							service.Name+fmt.Sprintf("host-%v-forwarding-rule", portsName),
+						_, err = compute.NewForwardingRule(ctx, name,
 							&compute.ForwardingRuleArgs{
 								LoadBalancingScheme: pulumi.String("INTERNAL"),
 								IpProtocol:          pulumi.String(strings.ToUpper(string(protocol))),
@@ -466,6 +491,7 @@ func createInternalLoadBalancer(
 								// Multiple forwarding rules share the same IP so internal DNS works.
 								IpAddress: internalNlbIP.Address,
 							},
+							opts...,
 						)
 						if err != nil {
 							return err
@@ -473,13 +499,13 @@ func createInternalLoadBalancer(
 					}
 				}
 
-				if _, err := dns.NewRecordSet(ctx, projectName+"-"+service.Name+"-private-lb-dns", &dns.RecordSetArgs{
+				if _, err := dns.NewRecordSet(ctx, service.Name+"-private-lb-dns", &dns.RecordSetArgs{
 					Name:        pulumi.String(internalServiceDns(service.Name)),
 					Type:        pulumi.String("A"),
 					Ttl:         pulumi.Int(60),
 					ManagedZone: config.PrivateZone,
 					Rrdatas:     pulumi.StringArray{internalNlbIP.Address},
-				}, pulumi.DependsOn([]pulumi.Resource{trafficFirewall})); err != nil {
+				}, append(opts, pulumi.DependsOn([]pulumi.Resource{trafficFirewall}))...); err != nil {
 					return err
 				}
 			}
@@ -504,6 +530,7 @@ func createInternalLoadBalancer(
 					Role:        pulumi.String("ACTIVE"),
 					Network:     config.VpcId,
 				},
+				opts...,
 			)
 		}
 		if err != nil {
@@ -518,6 +545,7 @@ func createInternalLoadBalancer(
 				HostRules:      privateHostRules,
 				PathMatchers:   privatePathMatchers,
 			},
+			opts...,
 		)
 		if err != nil {
 			return err
@@ -529,7 +557,7 @@ func createInternalLoadBalancer(
 				Region: pulumi.String(config.Region),
 				UrlMap: privateUrlMap.SelfLink,
 			},
-			pulumi.DependsOn([]pulumi.Resource{regionalManagedProxySubnet}),
+			append(opts, pulumi.DependsOn([]pulumi.Resource{regionalManagedProxySubnet}))...,
 		)
 		if err != nil {
 			return err
@@ -545,19 +573,19 @@ func createInternalLoadBalancer(
 				PortRange:           pulumi.String("80"),
 				LoadBalancingScheme: pulumi.String("INTERNAL_MANAGED"),
 			},
-			pulumi.DependsOn([]pulumi.Resource{regionalManagedProxySubnet}),
+			append(opts, pulumi.DependsOn([]pulumi.Resource{regionalManagedProxySubnet}))...,
 		)
 		if err != nil {
 			return err
 		}
 		for _, serviceName := range internalAlbServices {
-			if _, err := dns.NewRecordSet(ctx, projectName+"-"+serviceName+"-private-lb-dns", &dns.RecordSetArgs{
+			if _, err := dns.NewRecordSet(ctx, serviceName+"-private-lb-dns", &dns.RecordSetArgs{
 				Name:        pulumi.String(internalServiceDns(serviceName)),
 				Type:        pulumi.String("A"),
 				Ttl:         pulumi.Int(60),
 				ManagedZone: config.PrivateZone,
 				Rrdatas:     pulumi.StringArray{forwardingRule.IpAddress},
-			}); err != nil {
+			}, opts...); err != nil {
 				return err
 			}
 		}
@@ -589,12 +617,15 @@ func newCertMap(
 	args := &certificatemanager.CertificateMapResourceArgs{
 		Description: pulumi.String(projectName + " public load balancer certificate map"),
 	}
-	return certificatemanager.NewCertificateMapResource(ctx, projectName+"-cert-map", args, opts...)
+	// Logical name deliberately omits projectName: Pulumi's default resource ID
+	// already prefixes it with <pulumi-project>-<stack>, which includes
+	// projectName, so repeating it here risked exceeding GCP's 63-char resource
+	// ID limit.
+	return certificatemanager.NewCertificateMapResource(ctx, "cert-map", args, opts...)
 }
 
 func buildURLMap(
 	ctx *pulumi.Context,
-	projectName string,
 	entries []LBServiceEntry,
 	region string,
 	opts ...pulumi.ResourceOption,
@@ -622,7 +653,11 @@ func buildURLMap(
 		}
 	}
 
-	return compute.NewURLMap(ctx, projectName+"-urlmap", &compute.URLMapArgs{
+	// Logical name deliberately omits projectName: Pulumi's default resource ID
+	// already prefixes it with <pulumi-project>-<stack>, which includes
+	// projectName, so repeating it here risked exceeding GCP's 63-char resource
+	// ID limit.
+	return compute.NewURLMap(ctx, "urlmap", &compute.URLMapArgs{
 		DefaultService: firstBackendID,
 		HostRules:      hostRules,
 		PathMatchers:   pathMatchers,
@@ -754,9 +789,12 @@ func migBackend(entry LBServiceEntry) *compute.BackendServiceBackendArgs {
 	return backend
 }
 
+// Logical names in createHTTPSForwardingRule and createHTTPRedirectForwardingRule
+// deliberately omit projectName: Pulumi's default resource ID already prefixes it
+// with <pulumi-project>-<stack>, which includes projectName, so repeating it here
+// risked exceeding GCP's 63-char resource ID limit.
 func createHTTPSForwardingRule(
 	ctx *pulumi.Context,
-	projectName string,
 	publicIP *compute.GlobalAddress,
 	urlMap *compute.URLMap,
 	certMap *certificatemanager.CertificateMapResource,
@@ -766,7 +804,7 @@ func createHTTPSForwardingRule(
 		return fmt.Sprintf("//certificatemanager.googleapis.com/%v", id), nil
 	}).(pulumi.StringOutput)
 
-	httpsProxy, err := compute.NewTargetHttpsProxy(ctx, projectName+"-https-proxy",
+	httpsProxy, err := compute.NewTargetHttpsProxy(ctx, "https-proxy",
 		&compute.TargetHttpsProxyArgs{
 			UrlMap:         urlMap.SelfLink,
 			CertificateMap: certMapRef,
@@ -775,7 +813,7 @@ func createHTTPSForwardingRule(
 		return err
 	}
 
-	_, err = compute.NewGlobalForwardingRule(ctx, projectName+"-https-rule",
+	_, err = compute.NewGlobalForwardingRule(ctx, "https-rule",
 		&compute.GlobalForwardingRuleArgs{
 			Target:              httpsProxy.SelfLink,
 			IpAddress:           publicIP.Address,
@@ -787,11 +825,10 @@ func createHTTPSForwardingRule(
 
 func createHTTPRedirectForwardingRule(
 	ctx *pulumi.Context,
-	projectName string,
 	publicIP *compute.GlobalAddress,
 	opts ...pulumi.ResourceOption,
 ) error {
-	redirectMap, err := compute.NewURLMap(ctx, projectName+"-http-urlmap",
+	redirectMap, err := compute.NewURLMap(ctx, "http-urlmap",
 		&compute.URLMapArgs{
 			DefaultUrlRedirect: &compute.URLMapDefaultUrlRedirectArgs{
 				HttpsRedirect:        pulumi.Bool(true),
@@ -803,13 +840,13 @@ func createHTTPRedirectForwardingRule(
 		return err
 	}
 
-	httpProxy, err := compute.NewTargetHttpProxy(ctx, projectName+"-http-proxy",
+	httpProxy, err := compute.NewTargetHttpProxy(ctx, "http-proxy",
 		&compute.TargetHttpProxyArgs{UrlMap: redirectMap.ID()}, opts...)
 	if err != nil {
 		return err
 	}
 
-	_, err = compute.NewGlobalForwardingRule(ctx, projectName+"-http-rule",
+	_, err = compute.NewGlobalForwardingRule(ctx, "http-rule",
 		&compute.GlobalForwardingRuleArgs{
 			IpAddress:           publicIP.Address,
 			IpProtocol:          pulumi.String("TCP"),

--- a/provider/defanggcp/gcp/alb_test.go
+++ b/provider/defanggcp/gcp/alb_test.go
@@ -14,6 +14,7 @@ type albResource struct {
 	name   string
 	typeof string
 	inputs resource.PropertyMap
+	parent string
 }
 
 type albMocks struct {
@@ -21,7 +22,13 @@ type albMocks struct {
 }
 
 func (m *albMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
-	m.resources = append(m.resources, albResource{name: args.Name, typeof: args.TypeToken, inputs: args.Inputs})
+	var parent string
+	if args.RegisterRPC != nil {
+		parent = args.RegisterRPC.GetParent()
+	}
+	m.resources = append(m.resources, albResource{
+		name: args.Name, typeof: args.TypeToken, inputs: args.Inputs, parent: parent,
+	})
 	return args.Name + "_id", args.Inputs, nil
 }
 
@@ -100,6 +107,82 @@ func TestCreateLoadBalancersMIGMultipleIngressPortsReturnsActionableError(t *tes
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "service api has multiple ingress ports")
 	require.Contains(t, err.Error(), "use at most one ingress port")
+}
+
+// createInternalLoadBalancer's host-mode branch (a single non-ingress TCP
+// port, e.g. a Redis-like service on 6379) never forwarded opts to any of
+// the resources it creates. Live smoketest result (defang-mvp#3181): every
+// one of them tried to use the ambient default "gcp" provider instead of the
+// explicit one this stack configures, and defang-playground-dev disables
+// that default -- "Default provider for 'gcp' disabled ... must use an
+// explicit provider." This exercises the exact failing shape and asserts
+// opts (here, an explicit Parent) actually reaches each resource.
+func TestCreateLoadBalancersHostModePropagatesOpts(t *testing.T) {
+	mocks := &albMocks{}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		mig, err := testMIG(ctx, "smokeworker")
+		if err != nil {
+			return err
+		}
+		parent, err := compute.NewNetwork(ctx, "test-parent", &compute.NetworkArgs{})
+		if err != nil {
+			return err
+		}
+		return CreateLoadBalancers(ctx, "proj", []LBServiceEntry{{
+			Name:          "smokeworker",
+			InstanceGroup: mig,
+			PrivateFqdn:   "smokeworker.google.internal",
+			Config: testServiceConfig([]compose.ServicePortConfig{
+				{Target: 6379, Mode: compose.PortModeHost},
+			}),
+		}}, testInfra(ctx), pulumi.Parent(parent))
+	}, pulumi.WithMocks("proj", "stack", mocks))
+	require.NoError(t, err)
+
+	for _, typ := range []string{
+		"gcp:compute/address:Address",
+		"gcp:compute/firewall:Firewall",
+		"gcp:compute/healthCheck:HealthCheck",
+		"gcp:compute/regionBackendService:RegionBackendService",
+		"gcp:compute/forwardingRule:ForwardingRule",
+	} {
+		found := false
+		for _, r := range mocks.resources {
+			if r.typeof == typ {
+				found = true
+				// Pulumi always assigns *some* parent (the implicit stack
+				// pseudo-resource when none is given), so a plain non-empty
+				// check would pass even with opts dropped -- assert it's
+				// specifically our explicit parent.
+				require.Contains(t, r.parent, "test-parent",
+					"%s %q has parent %q, not the explicit one from opts -- opts not propagated", typ, r.name, r.parent)
+			}
+		}
+		require.True(t, found, "no resource of type %s was created", typ)
+	}
+
+	// Two firewalls exist for one host-mode service (traffic + health-check
+	// source ranges): a live smoketest hit "Duplicate resource URN" because
+	// both used the bare service name. Pulumi's mocks don't enforce URN
+	// uniqueness themselves, so check it explicitly.
+	seen := map[string]bool{}
+	for _, r := range mocks.resources {
+		key := r.typeof + "::" + r.name
+		require.False(t, seen[key], "duplicate resource: type=%s name=%q", r.typeof, r.name)
+		seen[key] = true
+	}
+
+	// A live smoketest hit "smokeworkerhost-6379-backend-service" (68 chars,
+	// over GCP's 63-char limit) from a missing separator plus a redundant
+	// "-backend-service" type suffix. Assert the fixed, protocol-qualified
+	// name (protocol matters: two protocols chunking to the same port set
+	// would otherwise collide on one logical name).
+	for _, typ := range []string{
+		"gcp:compute/regionBackendService:RegionBackendService",
+		"gcp:compute/forwardingRule:ForwardingRule",
+	} {
+		requireResource(t, mocks.resources, typ, "smokeworker-tcp-6379")
+	}
 }
 
 func testInfra(ctx *pulumi.Context) *SharedInfra {

--- a/provider/defanggcp/gcp/compute.go
+++ b/provider/defanggcp/gcp/compute.go
@@ -9,6 +9,7 @@ import (
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/compute"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/projects"
+	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/secretmanager"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -39,6 +40,7 @@ type ComputeEngineArgs struct {
 // run on Cloud Run (e.g. background workers with no listening port).
 func CreateComputeEngine(
 	ctx *pulumi.Context,
+	configProvider compose.ConfigProvider,
 	serviceName string,
 	image pulumi.StringInput,
 	svc compose.ServiceConfig,
@@ -56,6 +58,20 @@ func CreateComputeEngine(
 			"roles/monitoring.metricWriter",
 			"roles/cloudtrace.agent",
 		}, gcpConfig, parentOpt)
+	}
+
+	// Classify each container's env into inline values and native secret refs,
+	// then grant the instance SA access to every referenced secret. Bare ${VAR}
+	// / null "KEY:" values are boot-fetched (see secretFetchScript) rather than
+	// embedded in instance metadata.
+	mainPlan := classifyComputeSecretEnv(ctx, configProvider, svc.Environment)
+	sidecarPlans := make(map[string]containerSecretPlan, len(args.Sidecars))
+	for name, sc := range args.Sidecars {
+		sidecarPlans[name] = classifyComputeSecretEnv(ctx, configProvider, sc.Environment)
+	}
+	secretMembers, err := grantSecretAccess(ctx, serviceName, args.SA, mainPlan, sidecarPlans, parentOpt)
+	if err != nil {
+		return nil, err
 	}
 
 	namedPorts := make(compute.RegionInstanceGroupManagerNamedPortArray, len(svc.Ports))
@@ -83,11 +99,16 @@ func CreateComputeEngine(
 	fqdn := common.ServiceFQDN(serviceName, svc, gcpConfig.Domain, "google.internal")
 	cloudInit := getCloudInitConfig(
 		serviceName, image, svc, gcpConfig.Region, gcpConfig.Etag, gcpConfig.ProjectName, gcpConfig.Stack, fqdn,
-		addHealthCheckSidecar, args.Sidecars)
+		gcpConfig.GcpProject, addHealthCheckSidecar, args.Sidecars, mainPlan, sidecarPlans)
 
+	// The instance template must depend on the secret IAM bindings so instances
+	// don't boot (and run the fetch script) before they can read the secrets.
 	templateOpts := []pulumi.ResourceOption{parentOpt}
-	if len(args.PolicyDeps) > 0 {
-		templateOpts = append(templateOpts, pulumi.DependsOn(args.PolicyDeps))
+	templateDeps := make([]pulumi.Resource, 0, len(args.PolicyDeps)+len(secretMembers))
+	templateDeps = append(templateDeps, args.PolicyDeps...)
+	templateDeps = append(templateDeps, secretMembers...)
+	if len(templateDeps) > 0 {
+		templateOpts = append(templateOpts, pulumi.DependsOn(templateDeps))
 	}
 	instanceTemplate, err := createInstanceTemplate(
 		ctx, serviceName, serviceName, machineType, getComputeBootImage(svc), cloudInit,
@@ -340,6 +361,52 @@ func buildMIGUpdatePolicy(numZones, targetSize int) *compute.RegionInstanceGroup
 	return policy
 }
 
+// grantSecretAccess grants the instance service account
+// roles/secretmanager.secretAccessor on every Secret Manager secret referenced
+// (as a bare ${VAR} or null "KEY:") by the main container or any sidecar, so the
+// boot-time fetch script can read them. Secret IDs are deduped across
+// containers. Returns the created members for use as instance-template
+// dependencies.
+func grantSecretAccess(
+	ctx *pulumi.Context,
+	serviceName string,
+	sa *ServiceIdentity,
+	mainPlan containerSecretPlan,
+	sidecarPlans map[string]containerSecretPlan,
+	parentOpt pulumi.ResourceOrInvokeOption,
+) ([]pulumi.Resource, error) {
+	seen := make(map[string]struct{})
+	var ids []string
+	collect := func(plan containerSecretPlan) {
+		for _, r := range plan.secretRefs {
+			if _, ok := seen[r.secretID]; !ok {
+				seen[r.secretID] = struct{}{}
+				ids = append(ids, r.secretID)
+			}
+		}
+	}
+	collect(mainPlan)
+	for _, plan := range common.Sorted(sidecarPlans) {
+		collect(plan)
+	}
+
+	var members []pulumi.Resource
+	for _, sid := range ids {
+		opts := append([]pulumi.ResourceOption{parentOpt}, sa.deleteOpts()...)
+		member, err := secretmanager.NewSecretIamMember(ctx, serviceName+"-secret-"+sid,
+			&secretmanager.SecretIamMemberArgs{
+				SecretId: pulumi.String(sid),
+				Role:     pulumi.String("roles/secretmanager.secretAccessor"),
+				Member:   pulumi.Sprintf("serviceAccount:%v", sa.Email),
+			}, opts...)
+		if err != nil {
+			return nil, fmt.Errorf("granting secret access for %s: %w", sid, err)
+		}
+		members = append(members, member)
+	}
+	return members, nil
+}
+
 // AddRolesToServiceAccount grants IAM roles to a service account at the project level.
 // Returns a resource array output that can be used as a dependency.
 func AddRolesToServiceAccount(
@@ -492,6 +559,100 @@ func dockerRunFlags(
 	return params, command
 }
 
+// computeSecretEnv maps a container env var to the Secret Manager secret ID
+// whose latest version supplies its value. The value is fetched at container
+// start (see secretFetchScript) instead of being embedded in instance metadata,
+// which is readable unauthenticated from the instance.
+type computeSecretEnv struct {
+	envKey   string
+	secretID string
+}
+
+// containerSecretPlan is the per-container result of classifyComputeSecretEnv:
+// the env values inlined into `docker run -e` and the ones boot-fetched from
+// Secret Manager.
+type containerSecretPlan struct {
+	inline     compose.Environment
+	secretRefs []computeSecretEnv
+}
+
+// classifyComputeSecretEnv splits a container's environment into values inlined
+// into the `docker run` command (static literals and dynamic Outputs) and
+// native secret references (bare ${VAR} or null "KEY:") that are boot-fetched
+// from Secret Manager. Interpolated values (mixed literal + ${VAR}) stay on the
+// inline path for now; resolving them without leaking plaintext into instance
+// metadata needs deploy-time derived configs — see issue 293. With no config
+// provider (e.g. standalone with no secrets), everything is inlined.
+func classifyComputeSecretEnv(
+	ctx *pulumi.Context, cp compose.ConfigProvider, env compose.Environment,
+) containerSecretPlan {
+	if cp == nil {
+		return containerSecretPlan{inline: env}
+	}
+	plan := containerSecretPlan{inline: make(compose.Environment, len(env))}
+	// Iterate sorted so the generated fetch script and IAM bindings are stable.
+	for k, v := range common.Sorted(env) {
+		if configKey := compose.GetConfigName2(k, v); configKey != "" {
+			if secretID, err := cp.GetSecretRef(ctx, configKey); err == nil && secretID != "" {
+				plan.secretRefs = append(plan.secretRefs, computeSecretEnv{envKey: k, secretID: secretID})
+				continue
+			}
+			// Couldn't resolve a ref: fall through and inline (matches the
+			// pre-secrets behavior rather than dropping the variable).
+		}
+		plan.inline[k] = v
+	}
+	return plan
+}
+
+// secretFetchScript returns the cloud-init write_files block for the boot-time
+// secret fetch script, the systemd ExecStartPre line that runs it, and the
+// `docker run --env-file` flag that injects the fetched values. All three are
+// empty when there are no secret refs.
+//
+// The script reads the instance service account's OAuth token from the metadata
+// server and fetches each secret's latest version from the Secret Manager REST
+// API — no gcloud (absent on Container-Optimized OS) required. Values land in a
+// tmpfs file (0600, /run) that never touches disk or instance metadata.
+//
+// NOTE: docker --env-file is line-oriented, so a secret whose value contains a
+// newline (e.g. a PEM key) cannot be injected this way. Such values need a
+// per-secret file mount; tracked as a follow-up.
+func secretFetchScript(gcpProject, unit string, refs []computeSecretEnv) (writeFile, execStartPre, envFileFlag string) {
+	if len(refs) == 0 {
+		return "", "", ""
+	}
+	scriptPath := "/opt/defang/" + unit + "-secrets.sh"
+	envFile := "/run/defang/" + unit + ".env"
+
+	var s strings.Builder
+	s.WriteString("#!/bin/bash\n")
+	s.WriteString("set -uo pipefail\n")
+	s.WriteString("umask 077\n")
+	s.WriteString("mkdir -p /run/defang\n")
+	s.WriteString(`tok=$(curl -s -H "Metadata-Flavor: Google" ` +
+		`http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token ` +
+		`| grep -o '"access_token":"[^"]*"' | cut -d'"' -f4)` + "\n")
+	fmt.Fprintf(&s, `sm() { curl -s -H "Authorization: Bearer $tok" `+
+		`"https://secretmanager.googleapis.com/v1/projects/%s/secrets/$1/versions/latest:access" `+
+		`| grep -o '"data":"[^"]*"' | cut -d'"' -f4 | base64 -d; }`+"\n", gcpProject)
+	s.WriteString("{\n")
+	for _, r := range refs {
+		fmt.Fprintf(&s, "printf '%%s=%%s\\n' '%s' \"$(sm '%s')\"\n", r.envKey, r.secretID)
+	}
+	fmt.Fprintf(&s, "} > %s\n", envFile)
+
+	// Indent the script body under the write_files `content: |` block (6 spaces).
+	var wf strings.Builder
+	fmt.Fprintf(&wf, "\n  - path: %s\n    permissions: \"0700\"\n    owner: root\n    content: |\n", scriptPath)
+	for _, line := range strings.Split(strings.TrimRight(s.String(), "\n"), "\n") {
+		wf.WriteString("      ")
+		wf.WriteString(line)
+		wf.WriteString("\n")
+	}
+	return wf.String(), "ExecStartPre=" + scriptPath, "--env-file " + envFile
+}
+
 // flattenEnvFlags renders `-e "K=V"` docker flags for the given static env
 // pairs followed by the service's compose environment. Dynamic (Output)
 // values are threaded through a Sprintf so they resolve at apply time.
@@ -541,14 +702,26 @@ func getCloudInitConfig(
 	image pulumi.StringInput,
 	svc compose.ServiceConfig,
 	region, etag, projectName, stack, fqdn string,
+	gcpProject string,
 	addHealthCheckSidecar bool,
 	sidecars map[string]compose.ServiceConfig,
+	mainPlan containerSecretPlan,
+	sidecarPlans map[string]containerSecretPlan,
 ) pulumi.StringOutput {
 	var buf strings.Builder
 	buf.WriteString("#cloud-config\n\nwrite_files:")
 
 	containerName := svc.GetContainerName(serviceName)
 	params, command := dockerRunFlags(svc, sidecars)
+
+	// Secret env vars are boot-fetched into a tmpfs env-file rather than embedded
+	// in instance metadata. The fetch script is written first so it precedes the
+	// service unit in write_files.
+	secretWriteFile, secretExecPre, secretEnvFileFlag := secretFetchScript(gcpProject, serviceName, mainPlan.secretRefs)
+	if secretEnvFileFlag != "" {
+		params = append(params, secretEnvFileFlag)
+	}
+	buf.WriteString(escapePercent(secretWriteFile))
 
 	// Defang-injected runtime vars, mirroring the Cloud Run path (buildEnvVars).
 	staticEnv := [][2]string{{"DEFANG_SERVICE", serviceName}}
@@ -558,7 +731,7 @@ func getCloudInitConfig(
 	if fqdn != "" {
 		staticEnv = append(staticEnv, [2]string{"DEFANG_FQDN", fqdn})
 	}
-	envFlags := flattenEnvFlags(staticEnv, svc.Environment)
+	envFlags := flattenEnvFlags(staticEnv, mainPlan.inline)
 
 	var dependencies strings.Builder
 	dependencies.WriteString("Wants=gcr-online.target docker.socket\n      After=gcr-online.target docker.socket")
@@ -589,7 +762,7 @@ func getCloudInitConfig(
 	}
 	for name, sc := range common.Sorted(sidecars) {
 		var unitText pulumi.StringInput
-		unitText, runcmds = buildSidecarUnit(serviceName, name, region, sc, sidecars, runcmds)
+		unitText, runcmds = buildSidecarUnit(serviceName, name, region, gcpProject, sc, sidecars, sidecarPlans[name], runcmds)
 		extraUnitsFmt.WriteString("%s")
 		extraUnitsArgs = append(extraUnitsArgs, unitText)
 	}
@@ -613,6 +786,7 @@ func getCloudInitConfig(
       Restart=always
       RestartSec=30
       Environment="HOME=/home/container-user"
+      %[9]s
       ExecStartPre=/usr/bin/docker-credential-gcr configure-docker --registries %[5]s-docker.pkg.dev
       ExecStart=/usr/bin/docker run --pull=always --rm --name=%[7]s %[3]s %%s%%s %[4]s
       ExecStop=/usr/bin/docker stop -t %[6]d %[7]s
@@ -632,7 +806,8 @@ runcmd:
 		region,
 		stopGraceSeconds(svc),
 		containerName,
-		escapePercent(strings.Join(runcmds, "\n  - ")))
+		escapePercent(strings.Join(runcmds, "\n  - ")),
+		escapePercent(secretExecPre))
 
 	// buf now contains exactly three %s placeholders (env flags, image, and
 	// extra units — the Inputs that may resolve at apply time); all other
@@ -677,15 +852,22 @@ func sidecarUnitName(serviceName, sidecarName string) string {
 // --volumes-from keeps working across restarts; a run-once sidecar (restart: "no")
 // becomes a oneshot unit the main service can order After=.
 func buildSidecarUnit(
-	serviceName, sidecarName, region string,
+	serviceName, sidecarName, region, gcpProject string,
 	sc compose.ServiceConfig,
 	sidecars map[string]compose.ServiceConfig,
+	plan containerSecretPlan,
 	runcmds []string,
 ) (pulumi.StringInput, []string) {
 	unit := sidecarUnitName(serviceName, sidecarName)
 	containerName := sc.GetContainerName(sidecarName)
 	params, command := dockerRunFlags(sc, sidecars)
-	envFlags := flattenEnvFlags(nil, sc.Environment)
+
+	// Boot-fetch this sidecar's secret env into its own tmpfs env-file.
+	secretWriteFile, secretExecPre, secretEnvFileFlag := secretFetchScript(gcpProject, unit, plan.secretRefs)
+	if secretEnvFileFlag != "" {
+		params = append(params, secretEnvFileFlag)
+	}
+	envFlags := flattenEnvFlags(nil, plan.inline)
 
 	var serviceSection string
 	if sc.Restart == "no" {
@@ -695,7 +877,10 @@ func buildSidecarUnit(
 			stopGraceSeconds(sc), containerName)
 	}
 
-	units := pulumi.Sprintf(`
+	// %[11]s (secret fetch script write_files entry) and %[12]s (its
+	// ExecStartPre) are passed as Sprintf argument values, so any '%' in the
+	// script survives literally without escaping.
+	units := pulumi.Sprintf(`%[11]s
   - path: /etc/systemd/system/%[1]s.service
     permissions: "0644"
     owner: root
@@ -709,6 +894,7 @@ func buildSidecarUnit(
       [Service]
       %[4]s
       Environment="HOME=/home/container-user"
+      %[12]s
       ExecStartPre=/usr/bin/docker-credential-gcr configure-docker --registries %[5]s-docker.pkg.dev
       ExecStartPre=-/usr/bin/docker rm -f %[6]s
       ExecStart=/usr/bin/docker run --pull=always --name=%[6]s %[7]s %[8]s%[9]s %[10]s
@@ -727,7 +913,9 @@ func buildSidecarUnit(
 		strings.Join(params, " "),
 		envFlags,
 		sc.Image, // validated non-nil in createService; may resolve at apply time
-		strings.Join(command, " "))
+		strings.Join(command, " "),
+		secretWriteFile,
+		secretExecPre)
 
 	runcmds = append(runcmds,
 		fmt.Sprintf("systemctl enable %s.service", unit),

--- a/provider/defanggcp/gcp/compute.go
+++ b/provider/defanggcp/gcp/compute.go
@@ -139,7 +139,10 @@ func CreateComputeEngine(
 	if len(zoneNames) < len(zones.Names) {
 		migArgs.DistributionPolicyZones = pulumi.ToStringArray(zoneNames)
 	}
-	instanceGroup, err := compute.NewRegionInstanceGroupManager(ctx, serviceName+"-instance-group",
+	// No "-instance-group" suffix: the type token (RegionInstanceGroupManager)
+	// already says what this is, matching the bare-name convention used for
+	// its sibling resources (Address, HealthCheck, Firewall) in this file.
+	instanceGroup, err := compute.NewRegionInstanceGroupManager(ctx, serviceName,
 		migArgs, parentOpt, pulumi.DependsOn([]pulumi.Resource{instanceTemplate}))
 	if err != nil {
 		return nil, fmt.Errorf("creating instance group for %s: %w", serviceName, err)
@@ -257,7 +260,13 @@ func createInstanceTemplate(
 	if sa.Account != nil {
 		templateOpts = append(templateOpts, pulumi.DependsOnInputs(iamDeps))
 	}
-	tmpl, err := compute.NewInstanceTemplate(ctx, serviceName+"-instance-template",
+	// "-tmpl", not "-instance-template": autonaming's pattern for this resource
+	// type is "${project}-${stack}-${name}-${hex(7)}" (cd/config.go), and a
+	// longer logical name here left no headroom for longer project/stack
+	// names before hitting GCP Compute's 63-char physical-name limit -- a live
+	// smoketest (defang-mvp#3181) hit exactly that with project "html-css-js"
+	// and stack "newprovidergcp".
+	tmpl, err := compute.NewInstanceTemplate(ctx, serviceName+"-tmpl",
 		&compute.InstanceTemplateArgs{
 			MachineType: pulumi.String(machineType),
 			Scheduling: &compute.InstanceTemplateSchedulingArgs{
@@ -296,6 +305,7 @@ func createMIGAutoHealing(
 		return nil, nil //nolint:nilnil
 	}
 
+	hcName := serviceName + "-" + strconv.Itoa(*healthCheckPort) + "-mig-hc"
 	hcArgs := &compute.HealthCheckArgs{
 		CheckIntervalSec:   pulumi.Int(30),
 		TimeoutSec:         pulumi.Int(30),
@@ -312,14 +322,16 @@ func createMIGAutoHealing(
 		}
 	}
 
-	hcName := serviceName + "-" + strconv.Itoa(*healthCheckPort) + "-mig-hc"
 	healthCheck, err := compute.NewHealthCheck(ctx, hcName, hcArgs, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("creating health check for %s: %w", serviceName, err)
 	}
 
+	// No "-fw" suffix: the GCP console's own type column already says
+	// "Firewall rule", and sharing the health check's logical name is fine --
+	// Pulumi's URN disambiguates by resource type, not name alone.
 	portStr := strconv.Itoa(*healthCheckPort)
-	if _, err := compute.NewFirewall(ctx, serviceName+"-mig-hc-fw", &compute.FirewallArgs{
+	if _, err := compute.NewFirewall(ctx, hcName, &compute.FirewallArgs{
 		Network: network,
 		// https://cloud.google.com/load-balancing/docs/health-checks#firewall_rules
 		SourceRanges: pulumi.StringArray{
@@ -633,7 +645,12 @@ func secretFetchScript(gcpProject, unit string, refs []computeSecretEnv) (string
 	if len(refs) == 0 {
 		return "", "", ""
 	}
-	scriptPath := "/opt/defang/" + unit + "-secrets.sh"
+	// /run, not /opt: Container-Optimized OS mounts its root filesystem
+	// read-only, so cloud-init's write_files fails with EROFS creating any
+	// directory under /opt -- surfaced live via defang-mvp#3181 (real GCE
+	// boot: "OSError: [Errno 30] Read-only file system: '/opt/defang'").
+	// /run is tmpfs, always writable, and already used for the env file below.
+	scriptPath := "/run/defang/" + unit + "-secrets.sh"
 	envFile := "/run/defang/" + unit + ".env"
 
 	// Fail fast: a fetch that errors out (or yields an empty token) must fail
@@ -647,13 +664,18 @@ func secretFetchScript(gcpProject, unit string, refs []computeSecretEnv) (string
 	s.WriteString("set -euo pipefail\n")
 	s.WriteString("umask 077\n")
 	s.WriteString("mkdir -p /run/defang\n")
+	// Google APIs pretty-print JSON by default (a space after the colon, e.g.
+	// `"data": "..."`), so the extraction must tolerate optional whitespace
+	// there -- a bare `":"` pattern never matches a real response and every
+	// secret-backed boot would fail fetching. See
+	// https://cloud.google.com/apis/docs/system-parameters (prettyPrint).
 	s.WriteString(`tok=$(curl -fsS -H "Metadata-Flavor: Google" ` +
 		`http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token ` +
-		`| grep -o '"access_token":"[^"]*"' | cut -d'"' -f4)` + "\n")
+		`| grep -o '"access_token": *"[^"]*"' | cut -d'"' -f4)` + "\n")
 	s.WriteString(`[ -n "$tok" ] || { echo "defang: empty metadata token" >&2; exit 1; }` + "\n")
 	fmt.Fprintf(&s, `sm() { curl -fsS -H "Authorization: Bearer $tok" `+
 		`"https://secretmanager.googleapis.com/v1/projects/%s/secrets/$1/versions/latest:access" `+
-		`| grep -o '"data":"[^"]*"' | cut -d'"' -f4 | base64 -d; }`+"\n", gcpProject)
+		`| grep -o '"data": *"[^"]*"' | cut -d'"' -f4 | base64 -d; }`+"\n", gcpProject)
 	s.WriteString("{\n")
 	for _, r := range refs {
 		fmt.Fprintf(&s, `v=$(sm '%s') || { echo "defang: failed to fetch secret %s" >&2; exit 1; }`+"\n",

--- a/provider/defanggcp/gcp/compute.go
+++ b/provider/defanggcp/gcp/compute.go
@@ -656,7 +656,8 @@ func secretFetchScript(gcpProject, unit string, refs []computeSecretEnv) (string
 		`| grep -o '"data":"[^"]*"' | cut -d'"' -f4 | base64 -d; }`+"\n", gcpProject)
 	s.WriteString("{\n")
 	for _, r := range refs {
-		fmt.Fprintf(&s, `v=$(sm '%s') || { echo "defang: failed to fetch secret %s" >&2; exit 1; }`+"\n", r.secretID, r.secretID)
+		fmt.Fprintf(&s, `v=$(sm '%s') || { echo "defang: failed to fetch secret %s" >&2; exit 1; }`+"\n",
+			r.secretID, r.secretID)
 		fmt.Fprintf(&s, "printf '%%s=%%s\\n' '%s' \"$v\"\n", r.envKey)
 	}
 	fmt.Fprintf(&s, "} > %s\n", envFile)

--- a/provider/defanggcp/gcp/compute.go
+++ b/provider/defanggcp/gcp/compute.go
@@ -636,20 +636,28 @@ func secretFetchScript(gcpProject, unit string, refs []computeSecretEnv) (string
 	scriptPath := "/opt/defang/" + unit + "-secrets.sh"
 	envFile := "/run/defang/" + unit + ".env"
 
+	// Fail fast: a fetch that errors out (or yields an empty token) must fail
+	// ExecStartPre so the unit does not start the container with an empty
+	// secret value — a silent empty credential is far harder to diagnose than
+	// a unit that refuses to start. `curl -f` turns HTTP errors into non-zero
+	// exits and `grep` exits 1 when the expected field is absent (e.g. an
+	// error payload), so with pipefail every failure mode is caught.
 	var s strings.Builder
 	s.WriteString("#!/bin/bash\n")
-	s.WriteString("set -uo pipefail\n")
+	s.WriteString("set -euo pipefail\n")
 	s.WriteString("umask 077\n")
 	s.WriteString("mkdir -p /run/defang\n")
-	s.WriteString(`tok=$(curl -s -H "Metadata-Flavor: Google" ` +
+	s.WriteString(`tok=$(curl -fsS -H "Metadata-Flavor: Google" ` +
 		`http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token ` +
 		`| grep -o '"access_token":"[^"]*"' | cut -d'"' -f4)` + "\n")
-	fmt.Fprintf(&s, `sm() { curl -s -H "Authorization: Bearer $tok" `+
+	s.WriteString(`[ -n "$tok" ] || { echo "defang: empty metadata token" >&2; exit 1; }` + "\n")
+	fmt.Fprintf(&s, `sm() { curl -fsS -H "Authorization: Bearer $tok" `+
 		`"https://secretmanager.googleapis.com/v1/projects/%s/secrets/$1/versions/latest:access" `+
 		`| grep -o '"data":"[^"]*"' | cut -d'"' -f4 | base64 -d; }`+"\n", gcpProject)
 	s.WriteString("{\n")
 	for _, r := range refs {
-		fmt.Fprintf(&s, "printf '%%s=%%s\\n' '%s' \"$(sm '%s')\"\n", r.envKey, r.secretID)
+		fmt.Fprintf(&s, `v=$(sm '%s') || { echo "defang: failed to fetch secret %s" >&2; exit 1; }`+"\n", r.secretID, r.secretID)
+		fmt.Fprintf(&s, "printf '%%s=%%s\\n' '%s' \"$v\"\n", r.envKey)
 	}
 	fmt.Fprintf(&s, "} > %s\n", envFile)
 

--- a/provider/defanggcp/gcp/compute.go
+++ b/provider/defanggcp/gcp/compute.go
@@ -74,24 +74,7 @@ func CreateComputeEngine(
 		return nil, err
 	}
 
-	namedPorts := make(compute.RegionInstanceGroupManagerNamedPortArray, len(svc.Ports))
-	var healthCheckPort *int
-	for i, port := range svc.Ports {
-		proto := port.GetProtocol()
-		namedPorts[i] = &compute.RegionInstanceGroupManagerNamedPortArgs{
-			Name: pulumi.String(fmt.Sprintf("port-%s-%d", proto, port.Target)),
-			Port: pulumi.Int(port.Target),
-		}
-		if proto == "tcp" {
-			p := int(port.Target)
-			healthCheckPort = &p
-		}
-	}
-	addHealthCheckSidecar := healthCheckPort == nil
-	if addHealthCheckSidecar {
-		p := 8080
-		healthCheckPort = &p
-	}
+	namedPorts, healthCheckPort, addHealthCheckSidecar := computeNamedPorts(svc)
 
 	// DEFANG_FQDN: custom domain, else public FQDN (ingress), else the private
 	// FQDN (<label>.google.internal) for internal services — the private zone is
@@ -163,6 +146,33 @@ func CreateComputeEngine(
 	}
 
 	return &ComputeEngineResult{InstanceGroup: instanceGroup}, nil
+}
+
+// computeNamedPorts builds the MIG named-port array from the service's ports and
+// determines the health-check port. Services with no TCP port get a dedicated
+// HTTP health-check sidecar on 8080 so the MIG auto-healer can probe liveness.
+func computeNamedPorts(svc compose.ServiceConfig) (
+	compute.RegionInstanceGroupManagerNamedPortArray, *int, bool,
+) {
+	namedPorts := make(compute.RegionInstanceGroupManagerNamedPortArray, len(svc.Ports))
+	var healthCheckPort *int
+	for i, port := range svc.Ports {
+		proto := port.GetProtocol()
+		namedPorts[i] = &compute.RegionInstanceGroupManagerNamedPortArgs{
+			Name: pulumi.String(fmt.Sprintf("port-%s-%d", proto, port.Target)),
+			Port: pulumi.Int(port.Target),
+		}
+		if proto == "tcp" {
+			p := int(port.Target)
+			healthCheckPort = &p
+		}
+	}
+	addHealthCheckSidecar := healthCheckPort == nil
+	if addHealthCheckSidecar {
+		p := 8080
+		healthCheckPort = &p
+	}
+	return namedPorts, healthCheckPort, addHealthCheckSidecar
 }
 
 // networkID returns the network to attach instances and firewalls to: the
@@ -618,7 +628,8 @@ func classifyComputeSecretEnv(
 // NOTE: docker --env-file is line-oriented, so a secret whose value contains a
 // newline (e.g. a PEM key) cannot be injected this way. Such values need a
 // per-secret file mount; tracked as a follow-up.
-func secretFetchScript(gcpProject, unit string, refs []computeSecretEnv) (writeFile, execStartPre, envFileFlag string) {
+// Returns (write_files block, ExecStartPre line, docker --env-file flag).
+func secretFetchScript(gcpProject, unit string, refs []computeSecretEnv) (string, string, string) {
 	if len(refs) == 0 {
 		return "", "", ""
 	}
@@ -692,6 +703,25 @@ func stopGraceSeconds(svc compose.ServiceConfig) int {
 	return 30
 }
 
+// buildUnitDependencies renders the [Unit] ordering directives for the main
+// service: it always waits on gcr-online + docker, and additionally requires and
+// orders After each same-instance sidecar named in depends_on (cross-instance
+// dependencies aren't enforceable from a single unit).
+func buildUnitDependencies(
+	serviceName string, svc compose.ServiceConfig, sidecars map[string]compose.ServiceConfig,
+) string {
+	var dependencies strings.Builder
+	dependencies.WriteString("Wants=gcr-online.target docker.socket\n      After=gcr-online.target docker.socket")
+	for name := range common.Sorted(svc.DependsOn) {
+		if _, ok := sidecars[name]; !ok {
+			continue // only same-instance sidecar dependencies are enforceable here
+		}
+		unit := sidecarUnitName(serviceName, name)
+		fmt.Fprintf(&dependencies, "\n      Requires=%s.service\n      After=%s.service", unit, unit)
+	}
+	return dependencies.String()
+}
+
 // getCloudInitConfig generates a cloud-init YAML string for running a container on
 // Container-Optimized OS using systemd. For portless services it adds an HTTP health
 // check sidecar so the MIG auto-healer can probe container liveness. User-defined
@@ -733,15 +763,7 @@ func getCloudInitConfig(
 	}
 	envFlags := flattenEnvFlags(staticEnv, mainPlan.inline)
 
-	var dependencies strings.Builder
-	dependencies.WriteString("Wants=gcr-online.target docker.socket\n      After=gcr-online.target docker.socket")
-	for name := range common.Sorted(svc.DependsOn) {
-		if _, ok := sidecars[name]; !ok {
-			continue // only same-instance sidecar dependencies are enforceable here
-		}
-		unit := sidecarUnitName(serviceName, name)
-		fmt.Fprintf(&dependencies, "\n      Requires=%s.service\n      After=%s.service", unit, unit)
-	}
+	dependencies := buildUnitDependencies(serviceName, svc, sidecars)
 
 	runcmds := make([]string, 0, 5+4+2*len(sidecars)+2)
 	runcmds = append(runcmds,
@@ -800,7 +822,7 @@ runcmd:
   - %[8]s
 `,
 		serviceName,
-		escapePercent(dependencies.String()),
+		escapePercent(dependencies),
 		escapePercent(strings.Join(params, " ")),
 		escapePercent(strings.Join(command, " ")),
 		region,

--- a/provider/defanggcp/gcp/compute.go
+++ b/provider/defanggcp/gcp/compute.go
@@ -260,13 +260,14 @@ func createInstanceTemplate(
 	if sa.Account != nil {
 		templateOpts = append(templateOpts, pulumi.DependsOnInputs(iamDeps))
 	}
-	// "-tmpl", not "-instance-template": autonaming's pattern for this resource
-	// type is "${project}-${stack}-${name}-${hex(7)}" (cd/config.go), and a
-	// longer logical name here left no headroom for longer project/stack
-	// names before hitting GCP Compute's 63-char physical-name limit -- a live
-	// smoketest (defang-mvp#3181) hit exactly that with project "html-css-js"
-	// and stack "newprovidergcp".
-	tmpl, err := compute.NewInstanceTemplate(ctx, serviceName+"-tmpl",
+	// No "-instance-template" suffix: the type token (InstanceTemplate) already
+	// says what this is, matching the bare-name convention used for its sibling
+	// resources in this file. It also keeps headroom under GCP Compute's 63-char
+	// physical-name limit, since autonaming's pattern for this type is
+	// "${project}-${stack}-${name}-${hex(7)}" (cd/config.go) -- a live smoketest
+	// (defang-mvp#3181) overflowed it with project "html-css-js" and stack
+	// "newprovidergcp".
+	tmpl, err := compute.NewInstanceTemplate(ctx, serviceName,
 		&compute.InstanceTemplateArgs{
 			MachineType: pulumi.String(machineType),
 			Scheduling: &compute.InstanceTemplateSchedulingArgs{
@@ -305,7 +306,10 @@ func createMIGAutoHealing(
 		return nil, nil //nolint:nilnil
 	}
 
-	hcName := serviceName + "-" + strconv.Itoa(*healthCheckPort) + "-mig-hc"
+	// No "-mig-hc" suffix: the type tokens (HealthCheck, Firewall) already say
+	// what these are. The probed port stays in the name because a service can be
+	// probed on a port it does not expose (the 8080 sidecar case below).
+	hcName := serviceName + "-" + strconv.Itoa(*healthCheckPort)
 	hcArgs := &compute.HealthCheckArgs{
 		CheckIntervalSec:   pulumi.Int(30),
 		TimeoutSec:         pulumi.Int(30),

--- a/provider/defanggcp/gcp/compute.go
+++ b/provider/defanggcp/gcp/compute.go
@@ -654,8 +654,19 @@ func secretFetchScript(gcpProject, unit string, refs []computeSecretEnv) (string
 	// directory under /opt -- surfaced live via defang-mvp#3181 (real GCE
 	// boot: "OSError: [Errno 30] Read-only file system: '/opt/defang'").
 	// /run is tmpfs, always writable, and already used for the env file below.
+	//
+	// tmpfs does not cost us the script across reboots: COS runs write_files
+	// and runcmd on EVERY boot (they are once-per-instance on other distros),
+	// because its /etc and /var/lib/cloud are stateless tmpfs too -- which is
+	// also why the systemd units below survive only by being rewritten. See
+	// https://cloud.google.com/container-optimized-os/docs/how-to/create-configure-instance
 	scriptPath := "/run/defang/" + unit + "-secrets.sh"
 	envFile := "/run/defang/" + unit + ".env"
+
+	// Bound both requests. The units that run this as ExecStartPre are
+	// Type=oneshot, which disables systemd's default start timeout, so an
+	// unbounded curl could stall a boot indefinitely on a network stall.
+	const curlOpts = `-fsS --connect-timeout 5 --max-time 30`
 
 	// Fail fast: a fetch that errors out (or yields an empty token) must fail
 	// ExecStartPre so the unit does not start the container with an empty
@@ -673,13 +684,13 @@ func secretFetchScript(gcpProject, unit string, refs []computeSecretEnv) (string
 	// there -- a bare `":"` pattern never matches a real response and every
 	// secret-backed boot would fail fetching. See
 	// https://cloud.google.com/apis/docs/system-parameters (prettyPrint).
-	s.WriteString(`tok=$(curl -fsS -H "Metadata-Flavor: Google" ` +
-		`http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token ` +
-		`| grep -o '"access_token": *"[^"]*"' | cut -d'"' -f4)` + "\n")
+	fmt.Fprintf(&s, `tok=$(curl %s -H "Metadata-Flavor: Google" `+
+		`http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token `+
+		`| grep -o '"access_token": *"[^"]*"' | cut -d'"' -f4)`+"\n", curlOpts)
 	s.WriteString(`[ -n "$tok" ] || { echo "defang: empty metadata token" >&2; exit 1; }` + "\n")
-	fmt.Fprintf(&s, `sm() { curl -fsS -H "Authorization: Bearer $tok" `+
+	fmt.Fprintf(&s, `sm() { curl %s -H "Authorization: Bearer $tok" `+
 		`"https://secretmanager.googleapis.com/v1/projects/%s/secrets/$1/versions/latest:access" `+
-		`| grep -o '"data": *"[^"]*"' | cut -d'"' -f4 | base64 -d; }`+"\n", gcpProject)
+		`| grep -o '"data": *"[^"]*"' | cut -d'"' -f4 | base64 -d; }`+"\n", curlOpts, gcpProject)
 	s.WriteString("{\n")
 	for _, r := range refs {
 		fmt.Fprintf(&s, `v=$(sm '%s') || { echo "defang: failed to fetch secret %s" >&2; exit 1; }`+"\n",

--- a/provider/defanggcp/gcp/compute_test.go
+++ b/provider/defanggcp/gcp/compute_test.go
@@ -218,7 +218,9 @@ func TestClassifyComputeSecretEnv(t *testing.T) {
 
 	// secret refs are sorted by env key: BARE, NULLED
 	require.Len(t, plan.secretRefs, 2)
+	//nolint:gosec // G101: secret resource names (IDs), not credential values.
 	assert.Equal(t, computeSecretEnv{envKey: "BARE", secretID: "Defang_proj_stack_SECRET_ONE"}, plan.secretRefs[0])
+	//nolint:gosec // G101: secret resource names (IDs), not credential values.
 	assert.Equal(t, computeSecretEnv{envKey: "NULLED", secretID: "Defang_proj_stack_NULLED"}, plan.secretRefs[1])
 	// literals and mixed interpolation stay inline
 	assert.Contains(t, plan.inline, "PLAIN")
@@ -237,8 +239,8 @@ func TestClassifyComputeSecretEnv(t *testing.T) {
 // flag that consume it.
 func TestSecretFetchScript(t *testing.T) {
 	refs := []computeSecretEnv{
-		{envKey: "DB", secretID: "Defang_p_s_DBPASS"},
-		{envKey: "API", secretID: "Defang_p_s_APIKEY"},
+		{envKey: "DB", secretID: "Defang_p_s_DBPASS"},  //nolint:gosec // G101 false positive
+		{envKey: "API", secretID: "Defang_p_s_APIKEY"}, //nolint:gosec // G101 false positive
 	}
 	wf, pre, flag := secretFetchScript("my-proj", "svc", refs)
 
@@ -268,7 +270,7 @@ func TestGetCloudInitConfigSecrets(t *testing.T) {
 	plan := containerSecretPlan{
 		inline: compose.Environment{"PLAIN": pulumi.String("x")},
 		secretRefs: []computeSecretEnv{
-			{envKey: "SECRET_ENV", secretID: "Defang_proj_stack_SECRET_ENV"},
+			{envKey: "SECRET_ENV", secretID: "Defang_proj_stack_SECRET_ENV"}, //nolint:gosec // G101 false positive
 		},
 	}
 

--- a/provider/defanggcp/gcp/compute_test.go
+++ b/provider/defanggcp/gcp/compute_test.go
@@ -45,7 +45,8 @@ func TestGetCloudInitConfigDefangEnv(t *testing.T) {
 			wg.Add(1)
 			err := pulumi.RunErr(func(ctx *pulumi.Context) error {
 				out := getCloudInitConfig(
-					"api", pulumi.String("img:latest"), svc, "us-central1", tt.etag, "", "", tt.fqdn, false, nil)
+					"api", pulumi.String("img:latest"), svc, "us-central1", tt.etag, "", "", tt.fqdn, "",
+					false, nil, containerSecretPlan{inline: svc.Environment}, nil)
 				out.ApplyT(func(s string) string {
 					defer wg.Done()
 					cloudInit = s
@@ -100,7 +101,8 @@ func TestGetCloudInitConfigLogLabels(t *testing.T) {
 			wg.Add(1)
 			err := pulumi.RunErr(func(ctx *pulumi.Context) error {
 				out := getCloudInitConfig(
-					"api", pulumi.String("img:latest"), svc, "us-central1", tt.etag, tt.projectName, tt.stack, "", false, nil)
+					"api", pulumi.String("img:latest"), svc, "us-central1", tt.etag, tt.projectName, tt.stack, "", "",
+					false, nil, containerSecretPlan{inline: svc.Environment}, nil)
 				out.ApplyT(func(s string) string {
 					defer wg.Done()
 					cloudInit = s
@@ -148,7 +150,9 @@ func TestGetCloudInitConfigSidecars(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
-		out := getCloudInitConfig("cd", pulumi.String("img:latest"), svc, "us-central1", "", "", "", "", true, sidecars)
+		out := getCloudInitConfig("cd", pulumi.String("img:latest"), svc, "us-central1", "", "", "", "", "",
+			true, sidecars, containerSecretPlan{inline: svc.Environment},
+			map[string]containerSecretPlan{"handler": {inline: sidecars["handler"].Environment}})
 		out.ApplyT(func(s string) string {
 			defer wg.Done()
 			cloudInit = s
@@ -179,5 +183,119 @@ func TestGetCloudInitConfigSidecars(t *testing.T) {
 	// '%' escaping: env value intact, image substituted
 	assert.Contains(t, cloudInit, `-e "RATIO=100%"`)
 	assert.Contains(t, cloudInit, "img:latest")
+	assert.NotContains(t, cloudInit, "%!")
+}
+
+// mockSecretConfigProvider resolves bare ${VAR} / null env refs to a
+// deterministic Secret Manager ID so the classify/cloud-init paths can be
+// tested without a live backend.
+type mockSecretConfigProvider struct{ prefix string }
+
+func (m *mockSecretConfigProvider) GetConfigValue(
+	_ *pulumi.Context, key string, _ ...pulumi.InvokeOption,
+) pulumi.StringOutput {
+	return pulumi.String("val-" + key).ToStringOutput()
+}
+
+func (m *mockSecretConfigProvider) GetSecretRef(
+	_ *pulumi.Context, key string, _ ...pulumi.InvokeOption,
+) (string, error) {
+	return m.prefix + key, nil
+}
+
+// classifyComputeSecretEnv routes bare ${VAR} and null "KEY:" values to native
+// secret refs, and leaves literals and interpolated (mixed) values inline.
+func TestClassifyComputeSecretEnv(t *testing.T) {
+	env := compose.Environment{
+		"PLAIN":  pulumi.String("literal"),
+		"BARE":   pulumi.String("${SECRET_ONE}"),
+		"NULLED": nil,
+		"MIXED":  pulumi.String("pre-${SECRET_TWO}-post"),
+	}
+	cp := &mockSecretConfigProvider{prefix: "Defang_proj_stack_"}
+
+	plan := classifyComputeSecretEnv(nil, cp, env)
+
+	// secret refs are sorted by env key: BARE, NULLED
+	require.Len(t, plan.secretRefs, 2)
+	assert.Equal(t, computeSecretEnv{envKey: "BARE", secretID: "Defang_proj_stack_SECRET_ONE"}, plan.secretRefs[0])
+	assert.Equal(t, computeSecretEnv{envKey: "NULLED", secretID: "Defang_proj_stack_NULLED"}, plan.secretRefs[1])
+	// literals and mixed interpolation stay inline
+	assert.Contains(t, plan.inline, "PLAIN")
+	assert.Contains(t, plan.inline, "MIXED")
+	assert.NotContains(t, plan.inline, "BARE")
+	assert.NotContains(t, plan.inline, "NULLED")
+
+	// with no config provider, everything is inlined
+	nilPlan := classifyComputeSecretEnv(nil, nil, env)
+	assert.Nil(t, nilPlan.secretRefs)
+	assert.Equal(t, env, nilPlan.inline)
+}
+
+// secretFetchScript emits a COS-compatible boot fetch (metadata token + Secret
+// Manager REST API) writing a tmpfs env-file, plus the ExecStartPre + env-file
+// flag that consume it.
+func TestSecretFetchScript(t *testing.T) {
+	refs := []computeSecretEnv{
+		{envKey: "DB", secretID: "Defang_p_s_DBPASS"},
+		{envKey: "API", secretID: "Defang_p_s_APIKEY"},
+	}
+	wf, pre, flag := secretFetchScript("my-proj", "svc", refs)
+
+	assert.Equal(t, "ExecStartPre=/opt/defang/svc-secrets.sh", pre)
+	assert.Equal(t, "--env-file /run/defang/svc.env", flag)
+	assert.Contains(t, wf, "path: /opt/defang/svc-secrets.sh")
+	assert.Contains(t, wf, `permissions: "0700"`)
+	assert.Contains(t, wf, "metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")
+	assert.Contains(t, wf, "https://secretmanager.googleapis.com/v1/projects/my-proj/secrets/")
+	assert.Contains(t, wf, `printf '%s=%s\n' 'DB' "$(sm 'Defang_p_s_DBPASS')"`)
+	assert.Contains(t, wf, `printf '%s=%s\n' 'API' "$(sm 'Defang_p_s_APIKEY')"`)
+	assert.Contains(t, wf, "} > /run/defang/svc.env")
+
+	// no refs -> no output
+	wf2, pre2, flag2 := secretFetchScript("p", "svc", nil)
+	assert.Empty(t, wf2)
+	assert.Empty(t, pre2)
+	assert.Empty(t, flag2)
+}
+
+// getCloudInitConfig must boot-fetch secret env (not inline it) while still
+// inlining plain values, and wire up the ExecStartPre + --env-file.
+func TestGetCloudInitConfigSecrets(t *testing.T) {
+	svc := compose.ServiceConfig{
+		Ports: []compose.ServicePortConfig{{Target: 8080, Mode: compose.PortModeHost}},
+	}
+	plan := containerSecretPlan{
+		inline: compose.Environment{"PLAIN": pulumi.String("x")},
+		secretRefs: []computeSecretEnv{
+			{envKey: "SECRET_ENV", secretID: "Defang_proj_stack_SECRET_ENV"},
+		},
+	}
+
+	var cloudInit string
+	var wg sync.WaitGroup
+	wg.Add(1)
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		out := getCloudInitConfig(
+			"api", pulumi.String("img:latest"), svc, "us-central1", "", "", "", "", "gcp-proj",
+			false, nil, plan, nil)
+		out.ApplyT(func(s string) string {
+			defer wg.Done()
+			cloudInit = s
+			return s
+		})
+		return nil
+	}, pulumi.WithMocks("proj", "stack", testMocks{}))
+	require.NoError(t, err)
+	wg.Wait()
+
+	assert.Contains(t, cloudInit, "ExecStartPre=/opt/defang/api-secrets.sh")
+	assert.Contains(t, cloudInit, "--env-file /run/defang/api.env")
+	assert.Contains(t, cloudInit, "https://secretmanager.googleapis.com/v1/projects/gcp-proj/secrets/")
+	assert.Contains(t, cloudInit, `printf '%s=%s\n' 'SECRET_ENV' "$(sm 'Defang_proj_stack_SECRET_ENV')"`)
+	// plain value inlined, secret value NOT inlined
+	assert.Contains(t, cloudInit, `-e "PLAIN=x"`)
+	assert.NotContains(t, cloudInit, `-e "SECRET_ENV`)
+	// no leftover format artifacts
 	assert.NotContains(t, cloudInit, "%!")
 }

--- a/provider/defanggcp/gcp/compute_test.go
+++ b/provider/defanggcp/gcp/compute_test.go
@@ -1,15 +1,46 @@
 package gcp
 
 import (
+	"encoding/base64"
+	"errors"
+	"os/exec"
 	"strings"
 	"sync"
 	"testing"
 
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// namedResourceMocks records the Pulumi logical name of every resource it
+// creates, keyed by Pulumi type token. Physical naming (length, case,
+// project/stack scoping) is Pulumi autonaming's job, configured in
+// cd/config.go -- these resources deliberately don't override Name.
+type namedResourceMocks struct {
+	mu    sync.Mutex
+	names map[string]string
+}
+
+func (m *namedResourceMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+	outputs := args.Inputs.Copy()
+	m.mu.Lock()
+	if m.names == nil {
+		m.names = map[string]string{}
+	}
+	m.names[args.TypeToken] = args.Name
+	m.mu.Unlock()
+	if _, ok := outputs["selfLink"]; !ok {
+		outputs["selfLink"] = resource.NewStringProperty("https://compute.googleapis.com/" + args.Name)
+	}
+	return args.Name + "_id", outputs, nil
+}
+
+func (m *namedResourceMocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
+	return args.Args, nil
+}
 
 // getCloudInitConfig must inject the Defang runtime env vars into the
 // `docker run` command, mirroring the Cloud Run path. DEFANG_SERVICE is always
@@ -244,9 +275,9 @@ func TestSecretFetchScript(t *testing.T) {
 	}
 	wf, pre, flag := secretFetchScript("my-proj", "svc", refs)
 
-	assert.Equal(t, "ExecStartPre=/opt/defang/svc-secrets.sh", pre)
+	assert.Equal(t, "ExecStartPre=/run/defang/svc-secrets.sh", pre)
 	assert.Equal(t, "--env-file /run/defang/svc.env", flag)
-	assert.Contains(t, wf, "path: /opt/defang/svc-secrets.sh")
+	assert.Contains(t, wf, "path: /run/defang/svc-secrets.sh")
 	assert.Contains(t, wf, `permissions: "0700"`)
 	assert.Contains(t, wf, "metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")
 	assert.Contains(t, wf, "https://secretmanager.googleapis.com/v1/projects/my-proj/secrets/")
@@ -267,6 +298,74 @@ func TestSecretFetchScript(t *testing.T) {
 	assert.Empty(t, wf2)
 	assert.Empty(t, pre2)
 	assert.Empty(t, flag2)
+}
+
+// Google's REST APIs pretty-print JSON by default (a space after every colon,
+// e.g. `"data": "..."`), unlike the metadata server's own minified responses.
+// The generated script's extraction must handle both, or every secret-backed
+// Compute Engine boot fails fetching. This runs the actual generated sm()
+// function against a realistic pretty-printed response instead of asserting
+// on the script text.
+func TestSecretFetchScriptExtractsPrettyPrintedJSON(t *testing.T) {
+	wf, _, _ := secretFetchScript("my-proj", "svc", []computeSecretEnv{{envKey: "DB", secretID: "my-secret"}})
+
+	// Reconstruct the raw script from the write_files `content: |` block
+	// (each line indented 6 spaces further, see secretFetchScript).
+	var raw []string
+	inContent := false
+	for _, line := range strings.Split(wf, "\n") {
+		if strings.Contains(line, "content: |") {
+			inContent = true
+			continue
+		}
+		if inContent {
+			raw = append(raw, strings.TrimPrefix(line, "      "))
+		}
+	}
+	require.NotEmpty(t, raw)
+
+	// Keep everything through the sm() definition. Drop the /run write (no
+	// permission to create it in a test sandbox) and stop before the block
+	// that would actually invoke it against the real envFile.
+	var setup []string
+	for _, line := range raw {
+		if strings.Contains(line, "mkdir -p /run/defang") {
+			continue
+		}
+		setup = append(setup, line)
+		if strings.HasPrefix(line, "sm() {") {
+			break
+		}
+	}
+	require.Contains(t, setup[len(setup)-1], "sm() {")
+
+	const secretValue = "s3cr3t"
+	encoded := base64.StdEncoding.EncodeToString([]byte(secretValue))
+	script := `
+curl() {
+  case "$*" in
+  *metadata.google.internal*) echo '{
+  "access_token": "test-token",
+  "expires_in": 3599
+}' ;;
+  *secretmanager.googleapis.com*) echo '{
+  "name": "projects/p/secrets/my-secret/versions/1",
+  "payload": {
+    "data": "` + encoded + `"
+  }
+}' ;;
+  esac
+}
+export -f curl
+` + strings.Join(setup, "\n") + "\nsm 'my-secret'\n"
+	//nolint:gosec // G204: script is test-authored, not external input
+	out, err := exec.CommandContext(t.Context(), "bash", "-c", script).Output()
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		t.Fatalf("script failed: %v\nstderr: %s", err, ee.Stderr)
+	}
+	require.NoError(t, err)
+	assert.Equal(t, secretValue, strings.TrimSpace(string(out)))
 }
 
 // getCloudInitConfig must boot-fetch secret env (not inline it) while still
@@ -299,7 +398,7 @@ func TestGetCloudInitConfigSecrets(t *testing.T) {
 	require.NoError(t, err)
 	wg.Wait()
 
-	assert.Contains(t, cloudInit, "ExecStartPre=/opt/defang/api-secrets.sh")
+	assert.Contains(t, cloudInit, "ExecStartPre=/run/defang/api-secrets.sh")
 	assert.Contains(t, cloudInit, "--env-file /run/defang/api.env")
 	assert.Contains(t, cloudInit, "https://secretmanager.googleapis.com/v1/projects/gcp-proj/secrets/")
 	assert.Contains(t, cloudInit, `v=$(sm 'Defang_proj_stack_SECRET_ENV')`)
@@ -309,4 +408,59 @@ func TestGetCloudInitConfigSecrets(t *testing.T) {
 	assert.NotContains(t, cloudInit, `-e "SECRET_ENV`)
 	// no leftover format artifacts
 	assert.NotContains(t, cloudInit, "%!")
+}
+
+// A long compose service name combined with a configured autonaming pattern
+// used to push the health check and firewall physical names over GCP's
+// 63-char RFC1035 limit (Pulumi's autoname appends <project>-<stack>-<name>
+// plus a random suffix). gcpComputeName caps them explicitly instead.
+// The MIG health check's firewall shares its logical name rather than
+// appending a "-fw" suffix: the GCP console's own type column already
+// identifies it as a firewall rule, so a type-naming suffix is redundant.
+// Physical naming (length, case, project/stack scoping) is Pulumi
+// autonaming's job, configured via the per-resource-type overrides in
+// cd/config.go -- not asserted here.
+func TestCreateMIGAutoHealingFirewallSharesHealthCheckName(t *testing.T) {
+	mocks := &namedResourceMocks{}
+	port := 6379
+
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		_, err := createMIGAutoHealing(
+			ctx, "smokeworker", "smokeworker", &port, false, pulumi.String("projects/p/global/networks/vpc"))
+		return err
+	}, pulumi.WithMocks("pulumi-project", "dev", mocks))
+	require.NoError(t, err)
+
+	hcName := mocks.names["gcp:compute/healthCheck:HealthCheck"]
+	fwName := mocks.names["gcp:compute/firewall:Firewall"]
+	assert.Equal(t, "smokeworker-6379-mig-hc", hcName)
+	assert.Equal(t, hcName, fwName, "firewall should share the health check's logical name, not append -fw")
+}
+
+// A live smoketest (defang-mvp#3181) hit GCP's 63-char compute resource name
+// limit: autonaming's pattern for InstanceTemplate is
+// "${project}-${stack}-${name}-${hex(7)}" (cd/config.go), and with the
+// logical name "smokeworker-instance-template" plus a realistic
+// project/stack ("html-css-js"/"newprovidergcp"), the physical name came to
+// 64 chars -- one over the limit. Assert the shorter "-tmpl" suffix instead
+// of re-deriving the exact character budget here (that belongs to
+// autonaming's own pattern, not this package).
+func TestCreateInstanceTemplateUsesShortSuffix(t *testing.T) {
+	mocks := &namedResourceMocks{}
+
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		_, err := createInstanceTemplate(
+			ctx, "smokeworker", "smokeworker", "e2-small", "debian-cloud/debian-12",
+			pulumi.String("#!/bin/sh\n"),
+			&ServiceIdentity{Email: pulumi.String("test@example.com")},
+			nil,
+			testInfra(ctx),
+			pulumi.ResourceArrayOutput{},
+		)
+		return err
+	}, pulumi.WithMocks("pulumi-project", "dev", mocks))
+	require.NoError(t, err)
+
+	tmplName := mocks.names["gcp:compute/instanceTemplate:InstanceTemplate"]
+	assert.Equal(t, "smokeworker-tmpl", tmplName)
 }

--- a/provider/defanggcp/gcp/compute_test.go
+++ b/provider/defanggcp/gcp/compute_test.go
@@ -433,7 +433,7 @@ func TestCreateMIGAutoHealingFirewallSharesHealthCheckName(t *testing.T) {
 
 	hcName := mocks.names["gcp:compute/healthCheck:HealthCheck"]
 	fwName := mocks.names["gcp:compute/firewall:Firewall"]
-	assert.Equal(t, "smokeworker-6379-mig-hc", hcName)
+	assert.Equal(t, "smokeworker-6379", hcName)
 	assert.Equal(t, hcName, fwName, "firewall should share the health check's logical name, not append -fw")
 }
 
@@ -442,10 +442,10 @@ func TestCreateMIGAutoHealingFirewallSharesHealthCheckName(t *testing.T) {
 // "${project}-${stack}-${name}-${hex(7)}" (cd/config.go), and with the
 // logical name "smokeworker-instance-template" plus a realistic
 // project/stack ("html-css-js"/"newprovidergcp"), the physical name came to
-// 64 chars -- one over the limit. Assert the shorter "-tmpl" suffix instead
-// of re-deriving the exact character budget here (that belongs to
-// autonaming's own pattern, not this package).
-func TestCreateInstanceTemplateUsesShortSuffix(t *testing.T) {
+// 64 chars -- one over the limit. Assert the bare service name instead of
+// re-deriving the exact character budget here (that belongs to autonaming's
+// own pattern, not this package).
+func TestCreateInstanceTemplateUsesBareServiceName(t *testing.T) {
 	mocks := &namedResourceMocks{}
 
 	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
@@ -462,5 +462,5 @@ func TestCreateInstanceTemplateUsesShortSuffix(t *testing.T) {
 	require.NoError(t, err)
 
 	tmplName := mocks.names["gcp:compute/instanceTemplate:InstanceTemplate"]
-	assert.Equal(t, "smokeworker-tmpl", tmplName)
+	assert.Equal(t, "smokeworker", tmplName)
 }

--- a/provider/defanggcp/gcp/compute_test.go
+++ b/provider/defanggcp/gcp/compute_test.go
@@ -292,6 +292,10 @@ func TestSecretFetchScript(t *testing.T) {
 	assert.Contains(t, wf, "set -euo pipefail")
 	assert.Contains(t, wf, `[ -n "$tok" ]`)
 	assert.Contains(t, wf, "curl -fsS")
+	// Both requests must be bounded: ExecStartPre runs in Type=oneshot units,
+	// which have no default systemd start timeout, so an unbounded curl would
+	// stall the boot indefinitely.
+	assert.Equal(t, 2, strings.Count(wf, "--connect-timeout 5 --max-time 30"))
 
 	// no refs -> no output
 	wf2, pre2, flag2 := secretFetchScript("p", "svc", nil)

--- a/provider/defanggcp/gcp/compute_test.go
+++ b/provider/defanggcp/gcp/compute_test.go
@@ -250,9 +250,15 @@ func TestSecretFetchScript(t *testing.T) {
 	assert.Contains(t, wf, `permissions: "0700"`)
 	assert.Contains(t, wf, "metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")
 	assert.Contains(t, wf, "https://secretmanager.googleapis.com/v1/projects/my-proj/secrets/")
-	assert.Contains(t, wf, `printf '%s=%s\n' 'DB' "$(sm 'Defang_p_s_DBPASS')"`)
-	assert.Contains(t, wf, `printf '%s=%s\n' 'API' "$(sm 'Defang_p_s_APIKEY')"`)
+	assert.Contains(t, wf, `v=$(sm 'Defang_p_s_DBPASS') || { echo "defang: failed to fetch secret Defang_p_s_DBPASS" >&2; exit 1; }`)
+	assert.Contains(t, wf, `printf '%s=%s\n' 'DB' "$v"`)
+	assert.Contains(t, wf, `v=$(sm 'Defang_p_s_APIKEY') || { echo "defang: failed to fetch secret Defang_p_s_APIKEY" >&2; exit 1; }`)
+	assert.Contains(t, wf, `printf '%s=%s\n' 'API' "$v"`)
 	assert.Contains(t, wf, "} > /run/defang/svc.env")
+	// fetch failures must fail ExecStartPre, never write an empty value
+	assert.Contains(t, wf, "set -euo pipefail")
+	assert.Contains(t, wf, `[ -n "$tok" ]`)
+	assert.Contains(t, wf, "curl -fsS")
 
 	// no refs -> no output
 	wf2, pre2, flag2 := secretFetchScript("p", "svc", nil)
@@ -294,7 +300,8 @@ func TestGetCloudInitConfigSecrets(t *testing.T) {
 	assert.Contains(t, cloudInit, "ExecStartPre=/opt/defang/api-secrets.sh")
 	assert.Contains(t, cloudInit, "--env-file /run/defang/api.env")
 	assert.Contains(t, cloudInit, "https://secretmanager.googleapis.com/v1/projects/gcp-proj/secrets/")
-	assert.Contains(t, cloudInit, `printf '%s=%s\n' 'SECRET_ENV' "$(sm 'Defang_proj_stack_SECRET_ENV')"`)
+	assert.Contains(t, cloudInit, `v=$(sm 'Defang_proj_stack_SECRET_ENV')`)
+	assert.Contains(t, cloudInit, `printf '%s=%s\n' 'SECRET_ENV' "$v"`)
 	// plain value inlined, secret value NOT inlined
 	assert.Contains(t, cloudInit, `-e "PLAIN=x"`)
 	assert.NotContains(t, cloudInit, `-e "SECRET_ENV`)

--- a/provider/defanggcp/gcp/compute_test.go
+++ b/provider/defanggcp/gcp/compute_test.go
@@ -250,9 +250,11 @@ func TestSecretFetchScript(t *testing.T) {
 	assert.Contains(t, wf, `permissions: "0700"`)
 	assert.Contains(t, wf, "metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")
 	assert.Contains(t, wf, "https://secretmanager.googleapis.com/v1/projects/my-proj/secrets/")
-	assert.Contains(t, wf, `v=$(sm 'Defang_p_s_DBPASS') || { echo "defang: failed to fetch secret Defang_p_s_DBPASS" >&2; exit 1; }`)
+	assert.Contains(t, wf,
+		`v=$(sm 'Defang_p_s_DBPASS') || { echo "defang: failed to fetch secret Defang_p_s_DBPASS" >&2; exit 1; }`)
 	assert.Contains(t, wf, `printf '%s=%s\n' 'DB' "$v"`)
-	assert.Contains(t, wf, `v=$(sm 'Defang_p_s_APIKEY') || { echo "defang: failed to fetch secret Defang_p_s_APIKEY" >&2; exit 1; }`)
+	assert.Contains(t, wf,
+		`v=$(sm 'Defang_p_s_APIKEY') || { echo "defang: failed to fetch secret Defang_p_s_APIKEY" >&2; exit 1; }`)
 	assert.Contains(t, wf, `printf '%s=%s\n' 'API' "$v"`)
 	assert.Contains(t, wf, "} > /run/defang/svc.env")
 	// fetch failures must fail ExecStartPre, never write an empty value

--- a/provider/defanggcp/gcp/gcp.go
+++ b/provider/defanggcp/gcp/gcp.go
@@ -41,8 +41,10 @@ type SharedInfra struct {
 	Etag string
 }
 
-// EnableGcpAPIs enables the GCP APIs required by the project.
-func EnableGcpAPIs(ctx *pulumi.Context, gcpProject string, opts ...pulumi.ResourceOption) error {
+// EnableGcpAPIs enables the GCP APIs required by the project. Project is
+// deliberately left unset on each Service: it falls back to the provider's
+// configured project when omitted.
+func EnableGcpAPIs(ctx *pulumi.Context, opts ...pulumi.ResourceOption) error {
 	apis := []string{
 		"storage.googleapis.com",              // Cloud Storage API
 		"artifactregistry.googleapis.com",     // Artifact Registry API
@@ -63,7 +65,6 @@ func EnableGcpAPIs(ctx *pulumi.Context, gcpProject string, opts ...pulumi.Resour
 	opts = append(opts, pulumi.RetainOnDelete(true))
 	for _, api := range apis {
 		if _, err := projects.NewService(ctx, api, &projects.ServiceArgs{
-			Project: pulumi.String(gcpProject),
 			Service: pulumi.String(api),
 		}, opts...); err != nil {
 			return fmt.Errorf("failed to enable API %s: %w", api, err)
@@ -99,14 +100,18 @@ func BuildGlobalConfig(
 	region := GcpRegion(ctx)
 	gcpProject := config.GetProject(ctx)
 
-	vpc, err := compute.NewNetwork(ctx, projectName+"-vpc", &compute.NetworkArgs{
+	// Logical names below deliberately omit projectName, same as the firewalls and
+	// private-dns zone further down: Pulumi's default resource ID already prefixes
+	// it with <pulumi-project>-<stack>, which includes projectName, so repeating it
+	// here risked exceeding GCP's 63-char resource ID limit.
+	vpc, err := compute.NewNetwork(ctx, "vpc", &compute.NetworkArgs{
 		AutoCreateSubnetworks: pulumi.Bool(false),
 	}, append(opts, pulumi.RetainOnDelete(true))...)
 	if err != nil {
 		return nil, err
 	}
 
-	subnet, err := compute.NewSubnetwork(ctx, projectName+"-subnet", &compute.SubnetworkArgs{
+	subnet, err := compute.NewSubnetwork(ctx, "subnet", &compute.SubnetworkArgs{
 		IpCidrRange: pulumi.String("10.0.0.0/16"),
 		Region:      pulumi.String(region),
 		Network:     vpc.ID(),
@@ -115,7 +120,7 @@ func BuildGlobalConfig(
 		return nil, err
 	}
 
-	publicIP, err := compute.NewGlobalAddress(ctx, projectName+"-ip", &compute.GlobalAddressArgs{
+	publicIP, err := compute.NewGlobalAddress(ctx, "ip", &compute.GlobalAddressArgs{
 		AddressType: pulumi.String("EXTERNAL"),
 	}, opts...)
 	if err != nil {
@@ -123,7 +128,13 @@ func BuildGlobalConfig(
 	}
 
 	// Allow SSH ingress to all instances in the VPC (required for GCP Console SSH).
-	if _, err := compute.NewFirewall(ctx, projectName+"-allow-ssh", &compute.FirewallArgs{
+	// Logical name deliberately omits projectName: Pulumi's default resource ID
+	// already prefixes it with <pulumi-project>-<stack>, which includes
+	// projectName, so repeating it here risked exceeding GCP's 63-char resource
+	// ID limit (observed: "...-allow-icmp-<hash>" at 64 chars, one over, while
+	// the one-shorter "...-allow-ssh-<hash>" landed at exactly 63 and happened
+	// to still pass). Same fix as the wildcard-cert name below.
+	if _, err := compute.NewFirewall(ctx, "allow-ssh", &compute.FirewallArgs{
 		Network:      vpc.ID(),
 		SourceRanges: pulumi.StringArray{pulumi.String("0.0.0.0/0")},
 		Allows: compute.FirewallAllowArray{
@@ -138,7 +149,7 @@ func BuildGlobalConfig(
 	}
 
 	// Allow ICMP ping to all instances in the VPC.
-	if _, err := compute.NewFirewall(ctx, projectName+"-allow-icmp", &compute.FirewallArgs{
+	if _, err := compute.NewFirewall(ctx, "allow-icmp", &compute.FirewallArgs{
 		Network:      vpc.ID(),
 		SourceRanges: pulumi.StringArray{pulumi.String("0.0.0.0/0")},
 		Allows: compute.FirewallAllowArray{
@@ -151,7 +162,11 @@ func BuildGlobalConfig(
 		return nil, err
 	}
 
-	privateZone, err := dns.NewManagedZone(ctx, projectName+"-private-dns", &dns.ManagedZoneArgs{
+	// Logical name deliberately omits projectName, same as the firewalls above and
+	// public-dns below: Pulumi's default resource ID already prefixes it with
+	// <pulumi-project>-<stack>, which includes projectName, so repeating it here
+	// risked exceeding GCP's 63-char resource ID limit.
+	privateZone, err := dns.NewManagedZone(ctx, "private-dns", &dns.ManagedZoneArgs{
 		Description: pulumi.String(fmt.Sprintf("Private DNS zone for %v", projectName)),
 		DnsName:     pulumi.String("google.internal."),
 		Visibility:  pulumi.String("private"),
@@ -217,7 +232,7 @@ func buildOptionalInfra(
 	}
 
 	if needsVpcPeering(services) {
-		serviceConn, err := createVPCPeeringInfra(ctx, projectName, cfg.VpcId, opts...)
+		serviceConn, err := createVPCPeeringInfra(ctx, cfg.VpcId, opts...)
 		if err != nil {
 			return err
 		}

--- a/provider/defanggcp/gcp/vpc_peering.go
+++ b/provider/defanggcp/gcp/vpc_peering.go
@@ -21,11 +21,14 @@ func needsVpcPeering(services map[string]compose.ServiceConfig) bool {
 // connection for Cloud SQL private IP access.
 func createVPCPeeringInfra(
 	ctx *pulumi.Context,
-	projectName string,
 	vpcId pulumi.StringOutput,
 	opts ...pulumi.ResourceOption,
 ) (*servicenetworking.Connection, error) {
-	privateIpAlloc, err := compute.NewGlobalAddress(ctx, projectName+"-peering-ip", &compute.GlobalAddressArgs{
+	// Logical names below deliberately omit projectName: Pulumi's default resource
+	// ID already prefixes it with <pulumi-project>-<stack>, which includes
+	// projectName, so repeating it here risked exceeding GCP's 63-char resource
+	// ID limit.
+	privateIpAlloc, err := compute.NewGlobalAddress(ctx, "peering-ip", &compute.GlobalAddressArgs{
 		Purpose:      pulumi.String("VPC_PEERING"),
 		AddressType:  pulumi.String("INTERNAL"),
 		PrefixLength: pulumi.Int(16),
@@ -35,7 +38,7 @@ func createVPCPeeringInfra(
 		return nil, err
 	}
 
-	serviceConn, err := servicenetworking.NewConnection(ctx, projectName+"-svc-conn",
+	serviceConn, err := servicenetworking.NewConnection(ctx, "svc-conn",
 		&servicenetworking.ConnectionArgs{
 			Network:               vpcId,
 			Service:               pulumi.String("servicenetworking.googleapis.com"),

--- a/provider/defanggcp/project.go
+++ b/provider/defanggcp/project.go
@@ -101,7 +101,7 @@ func buildProject(
 	}
 	config.Etag = args.Etag
 
-	if err := providergcp.EnableGcpAPIs(ctx, config.GcpProject, childOpts...); err != nil {
+	if err := providergcp.EnableGcpAPIs(ctx, childOpts...); err != nil {
 		return nil, err
 	}
 
@@ -122,7 +122,7 @@ func buildProject(
 		_, err := projects.NewService(ctx, projectName+"-defang-llm", &projects.ServiceArgs{
 			Project: pulumi.StringPtr(config.GcpProject),
 			Service: pulumi.String("aiplatform.googleapis.com"),
-		}, pulumi.RetainOnDelete(true)) // Do not try disabling on compose down
+		}, append(childOpts, pulumi.RetainOnDelete(true))...) // Do not try disabling on compose down
 		if err != nil {
 			return nil, err
 		}

--- a/provider/defanggcp/service.go
+++ b/provider/defanggcp/service.go
@@ -314,7 +314,7 @@ func createService(
 			PolicyDeps: policyDeps,
 		}
 		ceResult, ceErr := providergcp.CreateComputeEngine(
-			ctx, serviceName, image, svc, ceArgs, infra, parentOpt,
+			ctx, configProvider, serviceName, image, svc, ceArgs, infra, parentOpt,
 		)
 		if ceErr != nil {
 			return fmt.Errorf("creating Compute Engine service %s: %w", serviceName, ceErr)


### PR DESCRIPTION
> Migrated from [#358](https://github.com/DefangLabs/pulumi-defang/pull/358) so the source branch lives in the upstream repository. Earlier discussion and reviews remain on the original PR.Closes half of #164 (the "secrets for compute services" half). See caveats below (⚠️ not yet validated on a live GCP deploy).

## Problem

GCP Compute Engine services get **no** config-provider resolution today:
- a bare `${VAR}` env value reaches the container as the literal string `${VAR}` (silent breakage);
- there is no way to inject a secret without inlining its plaintext into the `docker run` command embedded in **instance metadata**, which is readable **unauthenticated** from the instance (the worst sink discussed in #293).

## Approach (validates @edwardrf's hint in #164, adjusted for COS)

COS ships no `gcloud`, so instead of a native Secret Manager ↔ Compute Engine integration, cloud-init writes a small fetch script that:
1. reads the instance service account's OAuth token from the metadata server,
2. calls the Secret Manager REST API (`.../versions/latest:access`) for each secret (`curl` + `grep`/`cut` + `base64 -d`, all present on COS),
3. writes `KEY=value` lines to a tmpfs env-file (`/run/defang/<unit>.env`, `umask 077`).

The systemd unit runs it as `ExecStartPre=` and the container consumes it via `docker run --env-file`. The value never touches disk or instance metadata. Per-secret `roles/secretmanager.secretAccessor` is granted to the instance SA, and the instance template depends on those bindings so instances don't boot before they can read.

Env classification mirrors Cloud Run's `buildEnvVars`:
- **bare `${VAR}` / null `KEY:`** → native secret ref (boot-fetched);
- **static literal / dynamic Output** → inlined as `-e K=V` (unchanged);
- **interpolated (mixed literal + `${VAR}`)** → left inline for now (see below).

Covers the main container and sidecars.

## Scope / follow-ups

- **Interpolated env is deferred to #293.** Resolving `postgres://...${PW}...` leak-free means writing the result to a deploy-time derived config, which #293 is standardizing cross-cloud (@lionello). CE will consume whatever #293 lands rather than forking the naming here. (No regression: interpolated env on CE is not resolved today either.)
- **Multiline secrets:** `docker --env-file` is line-oriented, so a secret value containing a newline (e.g. a PEM key) can't be injected this way yet. Flagged with a `NOTE` in `secretFetchScript`; needs a per-secret file mount as a follow-up.

## Tests

Unit tests on the generated cloud-init: env classification (`TestClassifyComputeSecretEnv`), fetch-script generation (`TestSecretFetchScript`), and end-to-end cloud-init (`TestGetCloudInitConfigSecrets`) asserting the secret is boot-fetched and **not** inlined while plain values still are. Existing compute/sidecar tests updated for the new signature.

⚠️ **Not yet exercised against a live GCP deploy** — the fetch script's behavior on real COS (token parse, `:access` response shape, `--env-file` consumption) should be validated on a stack before this leaves draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compute Engine deployments now securely retrieve configured container secrets at startup.
  * Secret values are injected into main and sidecar containers without exposing them in plain-text configuration.
  * GCP load balancer resources now use clearer, protocol- and port-specific names.

* **Improvements**
  * Shortened generated GCP resource names across networking, compute, and load-balancing resources.
  * Improved resource relationships and dependency handling for more reliable deployments.
  * Added consistent default naming behavior across AWS and GCP resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->