### PR TITLE
Gate PRs with an automated review instead of a human one

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# CodeRabbit is the approving reviewer on this repo.
+#
+# The DefangLabs org ruleset "Protect Default Branches" needs 1 approving review
+# on the default branch. Most PRs are now agent-authored, and human review is the
+# bottleneck. With request_changes_workflow, CodeRabbit requests changes when it
+# finds a problem, and approves when the problem is fixed. That keeps a gate on
+# main without a human in the loop.
+#
+# Managed as a set: keep this file the same in all DefangLabs repos.
+reviews:
+  request_changes_workflow: true
+
+  pre_merge_checks:
+    # The PR author can NOT dismiss a failed check; only a requested reviewer can.
+    # This stops an agent from waving through its own PR.
+    override_requested_reviewers_only: true
+    # Start every built-in check at "warning". Raise a check to "error" only when
+    # we want it to block a merge.
+    title:
+      mode: "warning"
+    description:
+      mode: "warning"
+    issue_assessment:
+      mode: "warning"
+    docstrings:
+      mode: "off"


### PR DESCRIPTION
## Why

Every PR in this org needs 1 approving review (org ruleset "Protect Default Branches"), and in practice @lionello is the only approver. Most PRs are now agent-authored, so human review is the bottleneck on velocity.

This makes CodeRabbit the approving reviewer instead:

- `request_changes_workflow: true` — CodeRabbit **requests changes** when it finds a problem and **approves** when the problem is fixed. Today it only comments, so it gates nothing.
- `pre_merge_checks.override_requested_reviewers_only: true` — the PR author can not dismiss a failed check, so an agent can not wave through its own PR.
- Built-in checks start at `warning`. Raise one to `error` when we want it to block a merge.

An app approval already satisfies the rule today: `dependabot-automerge.yml` merges with an approval from `github-actions[bot]`. Nothing in the ruleset has to change for this to work.

The ruleset itself keeps `requiredReviewThreadResolution: true`, so CodeRabbit comments must still be resolved before a merge.

## Scope

The same file goes into every active DefangLabs repo. A CI gate (one standard `ci` check per repo, required through the org ruleset) is the second layer and lands separately — the `require-ci-gate` ruleset in `defang-mvp/pulumi/infrastructure/githubx.ts`.

## Verify

After merge, open a throw-away PR and confirm `coderabbitai[bot]` posts a review with state `CHANGES_REQUESTED` or `APPROVED` (not just `COMMENTED`), and that the approval satisfies the branch rule.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code review settings to support change requests and reviewer-only pre-merge overrides.
  * Configured title, description, and issue-assessment checks to show warnings by default.
  * Disabled automated docstring checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->