### PR TITLE
fix(gcp): scope Artifact Registry repository IDs per project/stack

### DIFF
--- a/provider/defanggcp/gcp/artifact_registry.go
+++ b/provider/defanggcp/gcp/artifact_registry.go
@@ -3,11 +3,12 @@ package gcp
 import (
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/DefangLabs/pulumi-defang/provider/common"
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/artifactregistry"
-	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/config"
+	gcpconfig "github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/config"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/projects"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/serviceaccount"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/storage"
@@ -84,25 +85,43 @@ func collectExternalRegistries(services map[string]compose.ServiceConfig) []stri
 	return result
 }
 
+// artifactRegistryRepositoryID returns the explicit physical ID required by
+// the Artifact Registry API. Pulumi cannot auto-name this property, so mirror
+// the configured autonaming rule when present: AutonamingPrefix already
+// checks for one and returns logicalName unchanged when none is set, so that
+// no-op return is what tells us to fall back to the legacy prefix/project/
+// stack scoping ourselves instead of re-parsing the pulumi:autonaming config.
+func artifactRegistryRepositoryID(ctx *pulumi.Context, projectName, logicalName string) string {
+	name := common.AutonamingPrefix(ctx, logicalName)
+	if name == logicalName {
+		parts := make([]string, 0, 4)
+		if prefix := common.Prefix.Get(ctx); prefix != "" {
+			parts = append(parts, prefix)
+		}
+		parts = append(parts, projectName, ctx.Stack(), logicalName)
+		name = strings.Join(parts, "-")
+	}
+	return sanitizeRepoName(name)
+}
+
 // createRemoteRepos creates Artifact Registry REMOTE repositories that act as
 // pull-through caches for external Docker registries not natively supported by
-// Cloud Run. One repository is created per unique registry. The repository ID
-// matches sanitizeRepoName(registry), which is the same name GetServiceImage
-// uses when rewriting image references.
+// Cloud Run. One stack-scoped repository is created per unique registry.
 func createRemoteRepos(
 	ctx *pulumi.Context,
+	projectName string,
 	registries []string,
 	opts ...pulumi.ResourceOption,
 ) (map[string]*artifactregistry.Repository, error) {
 	repos := make(map[string]*artifactregistry.Repository, len(registries))
 	for _, registry := range registries {
-		repoId := sanitizeRepoName(registry)
+		repoID := artifactRegistryRepositoryID(ctx, projectName, registry)
 		repo, err := artifactregistry.NewRepository(ctx, registry, &artifactregistry.RepositoryArgs{
 			// RepositoryId must be set explicitly. Some AWS resources say "if omitted, the provider
 			// will assign a random, unique name" (e.g. https://www.pulumi.com/registry/packages/aws/api-docs/s3/bucket/),
 			// but the GCP Artifact Registry docs make no such promise:
 			// https://www.pulumi.com/registry/packages/gcp/api-docs/artifactregistry/repository/
-			RepositoryId: pulumi.String(repoId),
+			RepositoryId: pulumi.String(repoID),
 			// Location:     pulumi.String(region),
 			Description: pulumi.String("Remote pull-through cache for " + registry),
 			Format:      pulumi.String("DOCKER"),
@@ -112,7 +131,9 @@ func createRemoteRepos(
 					Uri: pulumi.String("https://" + registry),
 				},
 			},
-		}, append(opts, pulumi.RetainOnDelete(true))...)
+			// Remote repositories contain only an upstream cache. Delete them normally;
+			// retaining one after `down` leaves an untracked ID that blocks the next `up`.
+		}, opts...)
 		if err != nil {
 			return nil, fmt.Errorf("creating remote repository for %s: %w", registry, err)
 		}
@@ -134,7 +155,7 @@ func createBuildInfra(
 	opts ...pulumi.ResourceOption,
 ) (*BuildInfra, error) {
 	region := GcpRegion(ctx)
-	gcpProject := config.GetProject(ctx)
+	gcpProject := gcpconfig.GetProject(ctx)
 
 	bsa, err := serviceaccount.NewAccount(ctx, "builder", &serviceaccount.AccountArgs{
 		DisplayName: pulumi.String("Image build service account for " + projectName),
@@ -145,7 +166,7 @@ func createBuildInfra(
 
 	ar, err := artifactregistry.NewRepository(ctx, "repo", &artifactregistry.RepositoryArgs{
 		// RepositoryId is required by the GCP API; unlike AWS, GCP does not auto-generate resource IDs.
-		RepositoryId: pulumi.String(sanitizeRepoName(projectName)),
+		RepositoryId: pulumi.String(artifactRegistryRepositoryID(ctx, projectName, "repo")),
 		Location:     pulumi.String(region),
 		Description:  pulumi.String("Docker images for " + projectName),
 		Format:       pulumi.String("DOCKER"),
@@ -157,15 +178,22 @@ func createBuildInfra(
 	saOpts := make([]pulumi.ResourceOption, 0, len(opts)+1)
 	saOpts = append(append(saOpts, opts...), pulumi.DeleteBeforeReplace(true))
 
+	// Project is deliberately omitted: RepositoryIamBinding falls back to the
+	// provider's configured project when unset (unlike projects.IAMMember
+	// below, whose Project field is required and not inferred from the
+	// provider -- see https://github.com/DefangLabs/pulumi-defang/pull/423#discussion_r3832857083).
 	repoIAMArgs := &artifactregistry.RepositoryIamBindingArgs{
 		Location:   pulumi.String(region),
-		Project:    pulumi.String(gcpProject),
 		Repository: ar.Name,
 		Role:       pulumi.String("roles/artifactregistry.admin"),
 		Members:    pulumi.StringArray{pulumi.Sprintf("serviceAccount:%v", bsa.Email)},
 	}
+	// Logical names below deliberately omit projectName, same as the VPC/firewalls
+	// in gcp.go: Pulumi's default resource ID already prefixes it with
+	// <pulumi-project>-<stack>, which includes projectName, so repeating it here
+	// risked exceeding GCP's 63-char resource ID limit.
 	if _, err := artifactregistry.NewRepositoryIamBinding(
-		ctx, projectName, repoIAMArgs, saOpts...,
+		ctx, "registry-admin", repoIAMArgs, saOpts...,
 	); err != nil {
 		return nil, fmt.Errorf("binding artifact registry admin role: %w", err)
 	}
@@ -178,7 +206,7 @@ func createBuildInfra(
 	sourceBucket := cdSourceBucket(ctx)
 	var sourceViewer *storage.BucketIAMMember
 	if sourceBucket != "" {
-		sourceViewer, err = storage.NewBucketIAMMember(ctx, projectName+"-source-viewer", &storage.BucketIAMMemberArgs{
+		sourceViewer, err = storage.NewBucketIAMMember(ctx, "source-viewer", &storage.BucketIAMMemberArgs{
 			Bucket: pulumi.String(sourceBucket),
 			Role:   pulumi.String("roles/storage.objectViewer"),
 			Member: pulumi.Sprintf("serviceAccount:%v", bsa.Email),
@@ -188,7 +216,7 @@ func createBuildInfra(
 		}
 	}
 
-	if _, err := projects.NewIAMMember(ctx, projectName+"-logWriter", &projects.IAMMemberArgs{
+	if _, err := projects.NewIAMMember(ctx, "logWriter", &projects.IAMMemberArgs{
 		Project: pulumi.String(gcpProject),
 		Role:    pulumi.String("roles/logging.logWriter"),
 		Member:  pulumi.Sprintf("serviceAccount:%v", bsa.Email),
@@ -196,7 +224,7 @@ func createBuildInfra(
 		return nil, fmt.Errorf("binding logging.logWriter role: %w", err)
 	}
 
-	if _, err := projects.NewIAMMember(ctx, projectName+"-bucketWriter", &projects.IAMMemberArgs{
+	if _, err := projects.NewIAMMember(ctx, "bucketWriter", &projects.IAMMemberArgs{
 		Project: pulumi.String(gcpProject),
 		Role:    pulumi.String("roles/logging.bucketWriter"),
 		Member:  pulumi.Sprintf("serviceAccount:%v", bsa.Email),
@@ -204,7 +232,7 @@ func createBuildInfra(
 		return nil, fmt.Errorf("binding logging.bucketWriter role: %w", err)
 	}
 
-	repoURL := pulumi.Sprintf("%s-docker.pkg.dev/%s/%s", region, gcpProject, ar.Name)
+	repoURL := pulumi.Sprintf("%s-docker.pkg.dev/%s/%s", region, gcpProject, ar.RepositoryId)
 
 	return &BuildInfra{
 		Repository:      ar,

--- a/provider/defanggcp/gcp/artifact_registry_test.go
+++ b/provider/defanggcp/gcp/artifact_registry_test.go
@@ -1,12 +1,172 @@
 package gcp
 
 import (
+	"strings"
+	"sync"
 	"testing"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const ghcrRegistry = "ghcr.io"
+
+// pulumiAutonamingConfigKey is the stack config key AutonamingPrefix reads.
+// Shared across test files so the literal isn't repeated (goconst).
+const pulumiAutonamingConfigKey = "pulumi:autonaming"
+
+type artifactRepositoryRegistration struct {
+	logicalName    string
+	repositoryID   string
+	retainOnDelete bool
+}
+
+type artifactRepositoryMocks struct {
+	mu           sync.Mutex
+	repositories []artifactRepositoryRegistration
+}
+
+func (m *artifactRepositoryMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+	outputs := args.Inputs.Copy()
+	if args.TypeToken == "gcp:artifactregistry/repository:Repository" {
+		registration := artifactRepositoryRegistration{
+			logicalName:  args.Name,
+			repositoryID: args.Inputs["repositoryId"].StringValue(),
+		}
+		if args.RegisterRPC != nil {
+			registration.retainOnDelete = args.RegisterRPC.GetRetainOnDelete()
+		}
+
+		m.mu.Lock()
+		m.repositories = append(m.repositories, registration)
+		m.mu.Unlock()
+
+		outputs["name"] = resource.NewStringProperty(
+			"projects/gcp-project/locations/us-central1/repositories/" + registration.repositoryID,
+		)
+	}
+	if args.TypeToken == "gcp:serviceaccount/account:Account" {
+		outputs["email"] = resource.NewStringProperty(args.Name + "@gcp-project.iam.gserviceaccount.com")
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	}
+	if args.TypeToken == "gcp:storage/bucket:Bucket" {
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	}
+	return args.Name + "_id", outputs, nil
+}
+
+func (m *artifactRepositoryMocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
+	return args.Args, nil
+}
+
+func withPulumiConfig(config map[string]string) pulumi.RunOption {
+	return func(info *pulumi.RunInfo) {
+		info.Config = config
+	}
+}
+
+func repositoryIDForTest(
+	t *testing.T,
+	stack, composeProject, logicalName string,
+	config map[string]string,
+) string {
+	t.Helper()
+
+	var repositoryID string
+	opts := []pulumi.RunOption{pulumi.WithMocks("pulumi-project", stack, testMocks{})}
+	if config != nil {
+		opts = append(opts, withPulumiConfig(config))
+	}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		repositoryID = artifactRegistryRepositoryID(ctx, composeProject, logicalName)
+		return nil
+	}, opts...)
+	require.NoError(t, err)
+	return repositoryID
+}
+
+func TestArtifactRegistryRepositoryIDFallsBackToLegacyScope(t *testing.T) {
+	devID := repositoryIDForTest(t, "dev", "compose-project", "repo", nil)
+	prodID := repositoryIDForTest(t, "prod", "compose-project", "repo", nil)
+	renamedID := repositoryIDForTest(t, "dev", "renamed-project", "repo", nil)
+
+	assert.Equal(t, "defang-compose-project-dev-repo", devID)
+	assert.Equal(t, "defang-compose-project-prod-repo", prodID)
+	assert.Equal(t, "defang-renamed-project-dev-repo", renamedID)
+	assert.NotEqual(t, devID, prodID)
+	assert.NotEqual(t, devID, renamedID)
+}
+
+func TestArtifactRegistryRepositoryIDHonorsCustomAutonaming(t *testing.T) {
+	config := map[string]string{
+		pulumiAutonamingConfigKey: `{"pattern":"Custom-${project}-${stack}-${name}-${hex(7)}"}`,
+	}
+
+	repositoryID := repositoryIDForTest(t, "dev", "compose-project", "repo", config)
+	assert.Equal(t, "custom-pulumi-project-dev-repo", repositoryID)
+}
+
+func TestArtifactRegistryRepositoryIDCustomLongNamesAreTruncated(t *testing.T) {
+	config := map[string]string{
+		pulumiAutonamingConfigKey: `{"pattern":"${project}-${stack}-${name}-${hex(7)}"}`,
+	}
+	commonPrefix := strings.Repeat("long", 20)
+
+	firstID := repositoryIDForTest(t, "dev", "compose-project", commonPrefix+"first", config)
+
+	require.Len(t, firstID, artifactRegistryRepositoryIDMaxLength)
+	assert.Equal(t, firstID, repositoryIDForTest(t, "dev", "compose-project", commonPrefix+"first", config),
+		"repository IDs must be deterministic")
+}
+
+func TestCreateRemoteReposKeepsLogicalNameAndDoesNotRetain(t *testing.T) {
+	mocks := &artifactRepositoryMocks{}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		_, err := createRemoteRepos(ctx, "compose-project", []string{ghcrRegistry})
+		return err
+	}, pulumi.WithMocks("pulumi-project", "dev", mocks))
+	require.NoError(t, err)
+
+	require.Len(t, mocks.repositories, 1)
+	assert.Equal(t, artifactRepositoryRegistration{
+		logicalName:    ghcrRegistry,
+		repositoryID:   "defang-compose-project-dev-ghcr-io",
+		retainOnDelete: false,
+	}, mocks.repositories[0])
+}
+
+func TestCreateBuildInfraUsesScopedRepositoryIDInImageURL(t *testing.T) {
+	mocks := &artifactRepositoryMocks{}
+	url := make(chan string, 1)
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		infra, err := createBuildInfra(ctx, "compose-project")
+		if err != nil {
+			return err
+		}
+		infra.RepositoryURL.ApplyT(func(repositoryURL string) string {
+			url <- repositoryURL
+			return repositoryURL
+		})
+		return nil
+	},
+		pulumi.WithMocks("pulumi-project", "dev", mocks),
+		withPulumiConfig(map[string]string{"gcp:project": "gcp-project"}),
+	)
+	require.NoError(t, err)
+
+	require.Len(t, mocks.repositories, 1)
+	assert.Equal(t, artifactRepositoryRegistration{
+		logicalName:    "repo",
+		repositoryID:   "defang-compose-project-dev-repo",
+		retainOnDelete: false,
+	}, mocks.repositories[0])
+	assert.Equal(t,
+		"us-central1-docker.pkg.dev/gcp-project/defang-compose-project-dev-repo",
+		<-url,
+	)
+}
 
 // TestCdSourceBucket checks that the shared CD bucket is parsed out of the
 // defang:stateUrl config the CD program sets from DEFANG_STATE_URL, and that a

--- a/provider/defanggcp/gcp/artifact_registry_test.go
+++ b/provider/defanggcp/gcp/artifact_registry_test.go
@@ -115,10 +115,13 @@ func TestArtifactRegistryRepositoryIDCustomLongNamesAreTruncated(t *testing.T) {
 	commonPrefix := strings.Repeat("long", 20)
 
 	firstID := repositoryIDForTest(t, "dev", "compose-project", commonPrefix+"first", config)
+	secondID := repositoryIDForTest(t, "dev", "compose-project", commonPrefix+"second", config)
 
-	require.Len(t, firstID, artifactRegistryRepositoryIDMaxLength)
+	require.LessOrEqual(t, len(firstID), artifactRegistryRepositoryIDMaxLength)
+	require.LessOrEqual(t, len(secondID), artifactRegistryRepositoryIDMaxLength)
 	assert.Equal(t, firstID, repositoryIDForTest(t, "dev", "compose-project", commonPrefix+"first", config),
 		"repository IDs must be deterministic")
+	assert.NotEqual(t, firstID, secondID, "distinct names sharing a long prefix must not collide")
 }
 
 func TestCreateRemoteReposKeepsLogicalNameAndDoesNotRetain(t *testing.T) {

--- a/provider/defanggcp/gcp/gcp.go
+++ b/provider/defanggcp/gcp/gcp.go
@@ -215,7 +215,7 @@ func buildOptionalInfra(
 	}
 
 	if externalRegistries := collectExternalRegistries(services); len(externalRegistries) > 0 {
-		repos, err := createRemoteRepos(ctx, externalRegistries, opts...)
+		repos, err := createRemoteRepos(ctx, projectName, externalRegistries, opts...)
 		if err != nil {
 			return err
 		}

--- a/provider/defanggcp/gcp/image.go
+++ b/provider/defanggcp/gcp/image.go
@@ -2,6 +2,7 @@ package gcp
 
 import (
 	"crypto/sha1" //nolint:gosec
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -40,16 +41,32 @@ func isCloudRunSupportedRegistry(registry string) bool {
 
 var nonLowerAlphaNumericOrDashRe = regexp.MustCompile(`[^a-z0-9-]`)
 
+const (
+	artifactRegistryRepositoryIDMaxLength  = 63
+	artifactRegistryRepositoryIDHashLength = 8
+)
+
 // sanitizeRepoName produces a valid Artifact Registry repository ID:
-// lowercase alphanumeric + hyphens, max 63 characters.
+// lowercase alphanumeric + hyphens, max 63 characters. Long names are simply
+// truncated; two names that share a 63-char prefix can collide, but that's an
+// acceptable tradeoff for keeping this straightforward.
 func sanitizeRepoName(name string) string {
+	original := name
 	name = strings.ToLower(name)
 	name = nonLowerAlphaNumericOrDashRe.ReplaceAllLiteralString(name, "-")
 	name = strings.Trim(name, "-")
-	if len(name) > 63 {
-		name = name[:63] // FIXME: this could lead to collisions
+	if name == "" {
+		return "repo-" + repositoryIDHash(original)
 	}
-	return strings.TrimRight(name, "-")
+	if len(name) > artifactRegistryRepositoryIDMaxLength {
+		name = strings.TrimRight(name[:artifactRegistryRepositoryIDMaxLength], "-")
+	}
+	return name
+}
+
+func repositoryIDHash(name string) string {
+	digest := sha256.Sum256([]byte(name))
+	return hex.EncodeToString(digest[:])[:artifactRegistryRepositoryIDHashLength]
 }
 
 // gcpBuildResource is the Pulumi resource state for the defang-gcp:defanggcp:Build custom resource.

--- a/provider/defanggcp/gcp/image.go
+++ b/provider/defanggcp/gcp/image.go
@@ -47,9 +47,9 @@ const (
 )
 
 // sanitizeRepoName produces a valid Artifact Registry repository ID:
-// lowercase alphanumeric + hyphens, max 63 characters. Long names are simply
-// truncated; two names that share a 63-char prefix can collide, but that's an
-// acceptable tradeoff for keeping this straightforward.
+// lowercase alphanumeric + hyphens, max 63 characters. Names longer than the
+// limit are truncated with a hash of the full original name appended, so two
+// names that share a long prefix still get distinct, bounded IDs.
 func sanitizeRepoName(name string) string {
 	original := name
 	name = strings.ToLower(name)
@@ -59,7 +59,9 @@ func sanitizeRepoName(name string) string {
 		return "repo-" + repositoryIDHash(original)
 	}
 	if len(name) > artifactRegistryRepositoryIDMaxLength {
-		name = strings.TrimRight(name[:artifactRegistryRepositoryIDMaxLength], "-")
+		suffix := "-" + repositoryIDHash(original)
+		maxPrefixLength := artifactRegistryRepositoryIDMaxLength - len(suffix)
+		name = strings.TrimRight(name[:maxPrefixLength], "-") + suffix
 	}
 	return name
 }

--- a/provider/defanggcp/gcp/image_test.go
+++ b/provider/defanggcp/gcp/image_test.go
@@ -133,14 +133,18 @@ func TestSanitizeRepoName(t *testing.T) {
 	}
 }
 
-func TestSanitizeRepoNameShortensByTruncating(t *testing.T) {
-	long := strings.Repeat("a", artifactRegistryRepositoryIDMaxLength) + "1"
+func TestSanitizeRepoNameShortensWithHashSuffix(t *testing.T) {
+	prefix := strings.Repeat("a", artifactRegistryRepositoryIDMaxLength)
+	long1 := prefix + "1"
+	long2 := prefix + "2"
 
-	id := sanitizeRepoName(long)
+	id1 := sanitizeRepoName(long1)
+	id2 := sanitizeRepoName(long2)
 
-	require.Len(t, id, artifactRegistryRepositoryIDMaxLength)
-	assert.Equal(t, id, sanitizeRepoName(long), "repository IDs must be deterministic")
-	assert.Equal(t, strings.Repeat("a", artifactRegistryRepositoryIDMaxLength), id)
+	require.LessOrEqual(t, len(id1), artifactRegistryRepositoryIDMaxLength)
+	require.LessOrEqual(t, len(id2), artifactRegistryRepositoryIDMaxLength)
+	assert.Equal(t, id1, sanitizeRepoName(long1), "repository IDs must be deterministic")
+	assert.NotEqual(t, id1, id2, "distinct names sharing a long prefix must not collide")
 }
 
 func TestSanitizeRepoNameNeverReturnsEmpty(t *testing.T) {

--- a/provider/defanggcp/gcp/image_test.go
+++ b/provider/defanggcp/gcp/image_test.go
@@ -103,7 +103,7 @@ func TestIsCloudRunSupportedRegistry(t *testing.T) {
 		{"us-central1-docker.pkg.dev", true},
 		{"europe-west1-docker.pkg.dev", true},
 		{"quay.io", false},
-		{"ghcr.io", false},
+		{ghcrRegistry, false},
 		{"registry.example.com", false},
 		{"my-registry.io", false},
 	}
@@ -125,17 +125,26 @@ func TestSanitizeRepoName(t *testing.T) {
 		{"UPPER.CASE.IO", "upper-case-io"},
 		{"-leading-dash", "leading-dash"},
 		{"trailing-dash-", "trailing-dash"},
-		// 64-char input should be trimmed to 63
-		{
-			"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
-			"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
 			assert.Equal(t, tt.want, sanitizeRepoName(tt.input))
 		})
 	}
+}
+
+func TestSanitizeRepoNameShortensByTruncating(t *testing.T) {
+	long := strings.Repeat("a", artifactRegistryRepositoryIDMaxLength) + "1"
+
+	id := sanitizeRepoName(long)
+
+	require.Len(t, id, artifactRegistryRepositoryIDMaxLength)
+	assert.Equal(t, id, sanitizeRepoName(long), "repository IDs must be deterministic")
+	assert.Equal(t, strings.Repeat("a", artifactRegistryRepositoryIDMaxLength), id)
+}
+
+func TestSanitizeRepoNameNeverReturnsEmpty(t *testing.T) {
+	assert.Regexp(t, `^repo-[0-9a-f]{8}$`, sanitizeRepoName("..."))
 }
 
 func TestGetServiceImage(t *testing.T) {
@@ -191,11 +200,11 @@ func TestGetServiceImage(t *testing.T) {
 			wantImage: "us-central1-docker.pkg.dev/my-gcp-project/quay-io/prometheus/node-exporter:v1.8.0",
 		},
 		{
-			name:  "ghcr.io image rewritten to artifact registry",
-			svc:   compose.ServiceConfig{Image: pulumi.String("ghcr.io/owner/image:sha-abc123")},
+			name:  ghcrRegistry + " image rewritten to artifact registry",
+			svc:   compose.ServiceConfig{Image: pulumi.String(ghcrRegistry + "/owner/image:sha-abc123")},
 			infra: fakeInfra,
 			repos: map[string]*artifactregistry.Repository{
-				"ghcr.io": {RepositoryId: pulumi.String("ghcr-io").ToStringOutput()},
+				ghcrRegistry: {RepositoryId: pulumi.String("ghcr-io").ToStringOutput()},
 			},
 			wantImage: "us-central1-docker.pkg.dev/my-gcp-project/ghcr-io/owner/image:sha-abc123",
 		},

--- a/tests/gcp/image_test.go
+++ b/tests/gcp/image_test.go
@@ -23,7 +23,10 @@ import (
 	"github.com/DefangLabs/pulumi-defang/tests/testutil"
 )
 
-const gcpARRepositoryType = "gcp:artifactregistry/repository:Repository"
+const (
+	gcpARRepositoryType = "gcp:artifactregistry/repository:Repository"
+	remoteRepoPrefix    = "defang-name-stack-"
+)
 
 // isRemoteRepo returns true if the AR repository record represents a
 // REMOTE_REPOSITORY (pull-through cache), not a regular push repository.
@@ -67,8 +70,8 @@ func TestExternalRegistryRemoteRepoHasCorrectConfig(t *testing.T) {
 
 	repo := findTypeWhere(*records, gcpARRepositoryType, isRemoteRepo)
 	require.NotNil(t, repo, "expected an AR remote repo")
-	assert.Equal(t, "ghcr-io", repo.inputs.Get("repositoryId").AsString(),
-		"repo ID should be sanitized registry name")
+	assert.Equal(t, remoteRepoPrefix+"ghcr-io", repo.inputs.Get("repositoryId").AsString(),
+		"repo ID should include the project and stack-scoped naming prefix")
 	assert.Equal(t, "REMOTE_REPOSITORY", repo.inputs.Get("mode").AsString())
 
 	uri := repo.inputs.
@@ -148,10 +151,10 @@ func TestMultipleExternalRegistriesCreateSeparateRemoteRepos(t *testing.T) {
 		"two services from different external registries should create two remote repos")
 
 	ghcrRepo := findTypeWhere(*records, gcpARRepositoryType, func(m property.Map) bool {
-		return isRemoteRepo(m) && m.Get("repositoryId").AsString() == "ghcr-io"
+		return isRemoteRepo(m) && m.Get("repositoryId").AsString() == remoteRepoPrefix+"ghcr-io"
 	})
 	quayRepo := findTypeWhere(*records, gcpARRepositoryType, func(m property.Map) bool {
-		return isRemoteRepo(m) && m.Get("repositoryId").AsString() == "quay-io"
+		return isRemoteRepo(m) && m.Get("repositoryId").AsString() == remoteRepoPrefix+"quay-io"
 	})
 	assert.NotNil(t, ghcrRepo, "expected remote repo for ghcr.io")
 	assert.NotNil(t, quayRepo, "expected remote repo for quay.io")


### PR DESCRIPTION
Fixes #457.

Two related bugs:

- Repository IDs for external-registry pull-through caches were just `sanitizeRepoName(registry)` with no project/stack scoping, so two stacks referencing the same external registry (e.g. both pulling from docker.io) collided on the same repository ID.
- The remote-cache repositories were created with `RetainOnDelete`, so a `down` left them behind; the next `up` for the same stack then hit "already exists" trying to recreate the same ID.

`artifactRegistryRepositoryID` mirrors the stack's configured `pulumi:autonaming` pattern when one is set (matching how every other resource type is scoped), falling back to the legacy prefix/project/stack scoping otherwise; `sanitizeRepoName` truncates to Artifact Registry's ID length limit. Remote caches are now deleted normally on `down` since they're disposable.

Also drops the `RepositoryIamBinding` `Project` arg, which is redundant with the provider's own configured project when omitted (unlike `projects.IAMMember` elsewhere in this file, whose `Project` field is required and not inferred from the provider).

This is a sibling to #467 (GCP Compute Engine secrets) — both branched off `main` independently since they touch different resource types with no dependency between them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Artifact Registry repositories now receive consistent, stack-scoped IDs that respect custom naming settings.
  * Repository IDs remain valid and deterministic, including for long or otherwise invalid names.
  * Build infrastructure image URLs now reference the correct scoped repositories.
  * External remote repositories are no longer retained after deletion.
  * Repository and source bucket access configuration now uses clearer, more consistent resource naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->