### PR TITLE
fix(aws): extract the tar.gz build context CodeBuild won't auto-unzip

### DIFF
--- a/provider/defangaws/aws/codebuild.go
+++ b/provider/defangaws/aws/codebuild.go
@@ -60,8 +60,9 @@ func parseS3Host(host string) (string, bool) {
 		s3 -= 2 // s3.dualstack.<region>
 	case s3 >= 1 && labels[s3-1] == "s3" && labels[s3] != "dualstack":
 		s3-- // s3.<region>
-	case labels[s3] == "s3" || strings.HasPrefix(labels[s3], "s3-"):
-		// s3 (legacy global) or s3-<region> (legacy regional).
+	case labels[s3] == "s3" || len(labels[s3]) > len("s3-") && strings.HasPrefix(labels[s3], "s3-"):
+		// s3 (legacy global) or s3-<region> (legacy regional); the dash form
+		// needs a region after the dash, so a bare "s3-" is not an endpoint.
 	default:
 		return "", false
 	}

--- a/provider/defangaws/aws/codebuild.go
+++ b/provider/defangaws/aws/codebuild.go
@@ -2,7 +2,9 @@ package aws
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/DefangLabs/pulumi-defang/provider/common"
@@ -14,6 +16,49 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
+
+var (
+	errCodeBuildS3NoObjectKey = errors.New("CodeBuild S3 source URL has no object key")
+	errCodeBuildNotS3URL      = errors.New("CodeBuild source must be an S3 URL")
+	errCodeBuildS3Incomplete  = errors.New("CodeBuild source must include an S3 bucket and object key")
+)
+
+func normalizeCodeBuildS3Location(rawURL string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("parsing CodeBuild source URL: %w", err)
+	}
+
+	object := strings.TrimPrefix(u.EscapedPath(), "/")
+	var bucket string
+	switch u.Scheme {
+	case "s3":
+		bucket = u.Host
+	case "http", "https":
+		host := u.Hostname()
+		if before, _, ok := strings.Cut(host, ".s3."); ok {
+			// Virtual-hosted style: https://bucket.s3.region.amazonaws.com/key.
+			bucket = before
+		} else if before, _, ok := strings.Cut(host, ".s3-"); ok {
+			// Legacy virtual-hosted style: https://bucket.s3-region.amazonaws.com/key.
+			bucket = before
+		} else if strings.HasPrefix(host, "s3.") || strings.HasPrefix(host, "s3-") {
+			// Path style: https://s3.region.amazonaws.com/bucket/key.
+			var found bool
+			bucket, object, found = strings.Cut(object, "/")
+			if !found {
+				return "", fmt.Errorf("%w: %q", errCodeBuildS3NoObjectKey, rawURL)
+			}
+		}
+	default:
+		return "", fmt.Errorf("%w: got %q", errCodeBuildNotS3URL, rawURL)
+	}
+
+	if bucket == "" || object == "" {
+		return "", fmt.Errorf("%w: got %q", errCodeBuildS3Incomplete, rawURL)
+	}
+	return bucket + "/" + object, nil
+}
 
 // codeBuildResult holds the outputs of creating a CodeBuild project.
 type codeBuildResult struct {
@@ -216,8 +261,15 @@ func getBuildSpec(build compose.BuildConfig, destination string) (string, error)
 		cacheArgs = append(cacheArgs, "--cache-to="+c)
 	}
 
-	preBuildCommands := make([]string, 0, 12)
+	preBuildCommands := make([]string, 0, 13)
 	preBuildCommands = append(preBuildCommands,
+		// CodeBuild's S3 source only auto-extracts .zip; the CLI uploads the
+		// build context as a .tar.gz (same format for every provider -- GCP's
+		// Cloud Build extracts that natively, CodeBuild does not), so a
+		// non-zip source lands here as a single untouched archive file with
+		// no Dockerfile anywhere. Extract it ourselves; a no-op if the source
+		// was already a zip (nothing named *.tar.gz to find).
+		`archive=$(ls *.tar.gz 2>/dev/null | head -n1); if [ -n "$archive" ]; then tar xzf "$archive"; fi`,
 		"aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $(aws sts get-caller-identity --query Account --output text).dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com", //nolint:lll
 		"aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws",
 	)
@@ -332,11 +384,13 @@ func createCodeBuildProject(
 		})
 	}
 
-	// Context must be an S3 URL
+	// CodeBuild expects S3 sources as bucket/key, while the CLI supplies either
+	// an s3:// URL or the query-free HTTPS URL returned by S3's presigner.
 	sourceType := "S3"
-	sourceLocation := pulumix.Apply(pulumix.Output[string](build.Context.ToStringOutput()), func(s string) string {
-		return strings.TrimPrefix(s, "s3://")
-	})
+	sourceLocation := pulumix.ApplyErr(
+		pulumix.Output[string](build.Context.ToStringOutput()),
+		normalizeCodeBuildS3Location,
+	)
 
 	project, err := codebuild.NewProject(ctx, name, &codebuild.ProjectArgs{
 		Description: pulumi.Sprintf("Build image for %s", name),

--- a/provider/defangaws/aws/codebuild.go
+++ b/provider/defangaws/aws/codebuild.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"path"
 	"regexp"
 	"strings"
 
@@ -63,6 +64,32 @@ func normalizeCodeBuildS3Location(rawURL string) (string, error) {
 		return "", fmt.Errorf("%w: got %q", errCodeBuildS3Incomplete, rawURL)
 	}
 	return bucket + "/" + object, nil
+}
+
+// codeBuildExtractArchiveCommand returns the pre_build shell command that extracts the
+// uploaded build context, or "" if the context is a .zip -- CodeBuild's S3 source only
+// auto-extracts .zip, so a .zip context arrives in $CODEBUILD_SRC_DIR already extracted
+// and there is nothing to do.
+//
+// The CLI uploads the build context as .tar.gz (or .tgz) for every non-Railpack build on
+// every provider (GCP's Cloud Build extracts that natively, CodeBuild does not), so a
+// non-zip source otherwise lands here as a single untouched archive file with no Dockerfile
+// anywhere. CodeBuild downloads a non-zip S3 source into $CODEBUILD_SRC_DIR under the same
+// filename as the object key, so that name is known up front from the source URL -- extract
+// that exact file rather than glob-discovering it (matches the legacy TS CD's use of the
+// known contextFile path). The archive is removed afterward so a Dockerfile that COPYs the
+// whole build context doesn't also pick up its own multi-megabyte source tarball.
+func codeBuildExtractArchiveCommand(contextURL string) (string, error) {
+	loc, err := normalizeCodeBuildS3Location(contextURL)
+	if err != nil {
+		return "", err
+	}
+	archive := path.Base(loc)
+	if !strings.HasSuffix(archive, ".tar.gz") && !strings.HasSuffix(archive, ".tgz") {
+		return "", nil
+	}
+	quoted := "'" + strings.ReplaceAll(archive, "'", `'\''`) + "'"
+	return fmt.Sprintf("tar xzf %s && rm %s", quoted, quoted), nil
 }
 
 // codeBuildResult holds the outputs of creating a CodeBuild project.
@@ -233,9 +260,16 @@ func getSetupMirrorSteps(mirrors []string) ([]string, error) {
 }
 
 // getBuildSpec generates the CodeBuild buildspec YAML for a Docker image build.
+// contextURL is the same S3 location used as the CodeBuild project's source, so the
+// generated extraction step can name the archive exactly rather than glob-discovering it.
 // Matches TS getBuildSpec: pre_build sets up mirrors and buildx, build runs docker buildx build --push.
-func getBuildSpec(build compose.BuildConfig, destination string) (string, error) {
+func getBuildSpec(build compose.BuildConfig, destination, contextURL string) (string, error) {
 	dockerfile := build.GetDockerfile()
+
+	extractArchiveCmd, err := codeBuildExtractArchiveCommand(contextURL)
+	if err != nil {
+		return "", err
+	}
 
 	// Build args in deterministic order (matches TS: Object.keys(buildArgs).sort())
 	var buildArgsStr string
@@ -267,18 +301,10 @@ func getBuildSpec(build compose.BuildConfig, destination string) (string, error)
 	}
 
 	preBuildCommands := make([]string, 0, 13)
+	if extractArchiveCmd != "" {
+		preBuildCommands = append(preBuildCommands, extractArchiveCmd)
+	}
 	preBuildCommands = append(preBuildCommands,
-		// CodeBuild's S3 source only auto-extracts .zip; the CLI uploads the
-		// build context as a .tar.gz (same format for every provider -- GCP's
-		// Cloud Build extracts that natively, CodeBuild does not), so a
-		// non-zip source lands here as a single untouched archive file with
-		// no Dockerfile anywhere. Extract it ourselves; a no-op if the source
-		// was already a zip (nothing named *.tar.gz to find). Remove the
-		// archive afterward (matching the legacy TS CD's behavior) so a
-		// Dockerfile that COPYs the whole build context doesn't also pick up
-		// its own multi-megabyte source tarball.
-		`archive=$(ls *.tar.gz 2>/dev/null | head -n1); ` +
-			`if [ -n "$archive" ]; then tar xzf "$archive" && rm "$archive"; fi`,
 		"aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $(aws sts get-caller-identity --query Account --output text).dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com", //nolint:lll
 		"aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws",
 	)
@@ -374,9 +400,12 @@ func createCodeBuildProject(
 		return url + ":latest"
 	})
 
-	// The buildspec needs the destination at apply time
-	buildspecOutput := pulumix.ApplyErr(destination, func(dest string) (string, error) {
-		return getBuildSpec(build, dest)
+	contextOutput := pulumix.Output[string](build.Context.ToStringOutput())
+
+	// The buildspec needs the destination and the resolved build-context URL (so its
+	// extraction step can name the uploaded archive exactly) at apply time.
+	buildspecOutput := pulumix.Apply2Err(destination, contextOutput, func(dest, contextURL string) (string, error) {
+		return getBuildSpec(build, dest, contextURL)
 	})
 
 	// Build environment variables (build args become env vars)
@@ -396,10 +425,7 @@ func createCodeBuildProject(
 	// CodeBuild expects S3 sources as bucket/key, while the CLI supplies either
 	// an s3:// URL or the query-free HTTPS URL returned by S3's presigner.
 	sourceType := "S3"
-	sourceLocation := pulumix.ApplyErr(
-		pulumix.Output[string](build.Context.ToStringOutput()),
-		normalizeCodeBuildS3Location,
-	)
+	sourceLocation := pulumix.ApplyErr(contextOutput, normalizeCodeBuildS3Location)
 
 	project, err := codebuild.NewProject(ctx, name, &codebuild.ProjectArgs{
 		Description: pulumi.Sprintf("Build image for %s", name),

--- a/provider/defangaws/aws/codebuild.go
+++ b/provider/defangaws/aws/codebuild.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/DefangLabs/pulumi-defang/provider/common"
@@ -23,6 +24,13 @@ var (
 	errCodeBuildS3Incomplete  = errors.New("CodeBuild source must include an S3 bucket and object key")
 )
 
+// s3HostPattern matches real AWS S3 HTTPS endpoint hostnames -- both
+// virtual-hosted ("bucket.s3[-.]<region>.amazonaws.com") and path-style
+// ("s3[-.]<region>.amazonaws.com") -- anchored on both ends so a lookalike
+// like "bucket.s3.evil.example" or "s3.evil.example" cannot be mistaken for
+// one (a naive substring/prefix check on the hostname would accept both).
+var s3HostPattern = regexp.MustCompile(`^(?:(?P<bucket>[^.]+)\.)?s3(?:[.-][a-z0-9-]+)?\.amazonaws\.com$`)
+
 func normalizeCodeBuildS3Location(rawURL string) (string, error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
@@ -35,14 +43,11 @@ func normalizeCodeBuildS3Location(rawURL string) (string, error) {
 	case "s3":
 		bucket = u.Host
 	case "http", "https":
-		host := u.Hostname()
-		if before, _, ok := strings.Cut(host, ".s3."); ok {
-			// Virtual-hosted style: https://bucket.s3.region.amazonaws.com/key.
-			bucket = before
-		} else if before, _, ok := strings.Cut(host, ".s3-"); ok {
-			// Legacy virtual-hosted style: https://bucket.s3-region.amazonaws.com/key.
-			bucket = before
-		} else if strings.HasPrefix(host, "s3.") || strings.HasPrefix(host, "s3-") {
+		m := s3HostPattern.FindStringSubmatch(u.Hostname())
+		if m == nil {
+			return "", fmt.Errorf("%w: got %q", errCodeBuildNotS3URL, rawURL)
+		}
+		if bucket = m[s3HostPattern.SubexpIndex("bucket")]; bucket == "" {
 			// Path style: https://s3.region.amazonaws.com/bucket/key.
 			var found bool
 			bucket, object, found = strings.Cut(object, "/")
@@ -268,8 +273,12 @@ func getBuildSpec(build compose.BuildConfig, destination string) (string, error)
 		// Cloud Build extracts that natively, CodeBuild does not), so a
 		// non-zip source lands here as a single untouched archive file with
 		// no Dockerfile anywhere. Extract it ourselves; a no-op if the source
-		// was already a zip (nothing named *.tar.gz to find).
-		`archive=$(ls *.tar.gz 2>/dev/null | head -n1); if [ -n "$archive" ]; then tar xzf "$archive"; fi`,
+		// was already a zip (nothing named *.tar.gz to find). Remove the
+		// archive afterward (matching the legacy TS CD's behavior) so a
+		// Dockerfile that COPYs the whole build context doesn't also pick up
+		// its own multi-megabyte source tarball.
+		`archive=$(ls *.tar.gz 2>/dev/null | head -n1); ` +
+			`if [ -n "$archive" ]; then tar xzf "$archive" && rm "$archive"; fi`,
 		"aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $(aws sts get-caller-identity --query Account --output text).dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com", //nolint:lll
 		"aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws",
 	)

--- a/provider/defangaws/aws/codebuild.go
+++ b/provider/defangaws/aws/codebuild.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/url"
 	"path"
-	"regexp"
 	"strings"
 
 	"github.com/DefangLabs/pulumi-defang/provider/common"
@@ -25,19 +24,49 @@ var (
 	errCodeBuildS3Incomplete  = errors.New("CodeBuild source must include an S3 bucket and object key")
 )
 
-// s3HostPattern matches real AWS S3 HTTPS endpoint hostnames -- both
-// virtual-hosted ("bucket.s3[-.]<region>.amazonaws.com") and path-style
-// ("s3[-.]<region>.amazonaws.com") -- anchored on both ends so a lookalike
-// like "bucket.s3.evil.example" or "s3.evil.example" cannot be mistaken for
-// one (a naive substring/prefix check on the hostname would accept both).
+// s3EndpointSuffix is the DNS suffix every real AWS S3 HTTPS endpoint ends in.
+const s3EndpointSuffix = ".amazonaws.com"
+
+// parseS3Host returns the bucket an AWS S3 HTTPS endpoint hostname addresses,
+// which is empty for path-style endpoints (there the bucket is the first path
+// segment instead). The bool reports whether the hostname is an S3 endpoint at
+// all, so a lookalike like "bucket.s3.evil.example", "s3.evil.example" or
+// "bucket.s3.amazonaws.com.evil.example" cannot be mistaken for one (a naive
+// substring or prefix check on the hostname would accept all three).
 //
-// The optional "dualstack" label covers the IPv6 dual-stack endpoints
-// ("s3.dualstack.<region>.amazonaws.com" and its virtual-hosted form), which
-// the AWS SDK emits when it is configured with AWS_USE_DUALSTACK_ENDPOINT --
-// without it a dual-stack presigned context URL would fail this check and
-// surface as a confusing "must be an S3 URL" error at project-creation time.
-var s3HostPattern = regexp.MustCompile(
-	`^(?:(?P<bucket>[^.]+)\.)?s3(?:\.dualstack)?(?:[.-][a-z0-9-]+)?\.amazonaws\.com$`)
+// The accepted endpoint hostnames, each optionally prefixed with "<bucket>."
+// for the virtual-hosted form:
+//
+//	s3.amazonaws.com                     legacy global endpoint
+//	s3.<region>.amazonaws.com            regional
+//	s3-<region>.amazonaws.com            legacy regional, dash form
+//	s3.dualstack.<region>.amazonaws.com  IPv6 dual-stack
+//
+// The dual-stack endpoints are what the AWS SDK emits when it is configured
+// with AWS_USE_DUALSTACK_ENDPOINT -- without them a dual-stack presigned
+// context URL would fail this check and surface as a confusing "must be an S3
+// URL" error at project-creation time. They are always regional: there is no
+// global "s3.dualstack.amazonaws.com", so "dualstack" is never a region itself.
+func parseS3Host(host string) (string, bool) {
+	rest, isAWS := strings.CutSuffix(host, s3EndpointSuffix)
+	if !isAWS {
+		return "", false
+	}
+	// Match the endpoint labels from the right; whatever is left of them is the bucket.
+	labels := strings.Split(rest, ".")
+	s3 := len(labels) - 1 // index of the "s3" label, once we know where it is
+	switch {
+	case s3 >= 2 && labels[s3-2] == "s3" && labels[s3-1] == "dualstack":
+		s3 -= 2 // s3.dualstack.<region>
+	case s3 >= 1 && labels[s3-1] == "s3" && labels[s3] != "dualstack":
+		s3-- // s3.<region>
+	case labels[s3] == "s3" || strings.HasPrefix(labels[s3], "s3-"):
+		// s3 (legacy global) or s3-<region> (legacy regional).
+	default:
+		return "", false
+	}
+	return strings.Join(labels[:s3], "."), true
+}
 
 func normalizeCodeBuildS3Location(rawURL string) (string, error) {
 	u, err := url.Parse(rawURL)
@@ -51,11 +80,11 @@ func normalizeCodeBuildS3Location(rawURL string) (string, error) {
 	case "s3":
 		bucket = u.Host
 	case "http", "https":
-		m := s3HostPattern.FindStringSubmatch(u.Hostname())
-		if m == nil {
+		var isS3Host bool
+		if bucket, isS3Host = parseS3Host(u.Hostname()); !isS3Host {
 			return "", fmt.Errorf("%w: got %q", errCodeBuildNotS3URL, rawURL)
 		}
-		if bucket = m[s3HostPattern.SubexpIndex("bucket")]; bucket == "" {
+		if bucket == "" {
 			// Path style: https://s3.region.amazonaws.com/bucket/key.
 			var found bool
 			bucket, object, found = strings.Cut(object, "/")

--- a/provider/defangaws/aws/codebuild.go
+++ b/provider/defangaws/aws/codebuild.go
@@ -30,7 +30,14 @@ var (
 // ("s3[-.]<region>.amazonaws.com") -- anchored on both ends so a lookalike
 // like "bucket.s3.evil.example" or "s3.evil.example" cannot be mistaken for
 // one (a naive substring/prefix check on the hostname would accept both).
-var s3HostPattern = regexp.MustCompile(`^(?:(?P<bucket>[^.]+)\.)?s3(?:[.-][a-z0-9-]+)?\.amazonaws\.com$`)
+//
+// The optional "dualstack" label covers the IPv6 dual-stack endpoints
+// ("s3.dualstack.<region>.amazonaws.com" and its virtual-hosted form), which
+// the AWS SDK emits when it is configured with AWS_USE_DUALSTACK_ENDPOINT --
+// without it a dual-stack presigned context URL would fail this check and
+// surface as a confusing "must be an S3 URL" error at project-creation time.
+var s3HostPattern = regexp.MustCompile(
+	`^(?:(?P<bucket>[^.]+)\.)?s3(?:\.dualstack)?(?:[.-][a-z0-9-]+)?\.amazonaws\.com$`)
 
 func normalizeCodeBuildS3Location(rawURL string) (string, error) {
 	u, err := url.Parse(rawURL)

--- a/provider/defangaws/aws/codebuild_test.go
+++ b/provider/defangaws/aws/codebuild_test.go
@@ -48,6 +48,11 @@ func TestNormalizeCodeBuildS3Location(t *testing.T) {
 		"https://bucket.s3.amazonaws.com/uploads/context.tar.gz?signature=value": "bucket/uploads/context.tar.gz",
 		"https://bucket.s3.us-west-2.amazonaws.com/uploads/context.tar.gz":       "bucket/uploads/context.tar.gz",
 		"https://s3.us-west-2.amazonaws.com/bucket/uploads/context.tar.gz":       "bucket/uploads/context.tar.gz",
+		// Legacy dash form of the regional endpoint, in both styles.
+		"https://bucket.s3-us-west-2.amazonaws.com/uploads/context.tar.gz": "bucket/uploads/context.tar.gz",
+		"https://s3-us-west-2.amazonaws.com/bucket/uploads/context.tar.gz": "bucket/uploads/context.tar.gz",
+		// The legacy global endpoint, path style.
+		"https://s3.amazonaws.com/bucket/uploads/context.tar.gz": "bucket/uploads/context.tar.gz",
 		// IPv6 dual-stack endpoints, in both virtual-hosted and path style. The
 		// SDK emits these when AWS_USE_DUALSTACK_ENDPOINT is set.
 		"https://bucket.s3.dualstack.us-west-2.amazonaws.com/uploads/context.tar.gz": "bucket/uploads/context.tar.gz",
@@ -74,6 +79,11 @@ func TestNormalizeCodeBuildS3LocationRejectsInvalidURL(t *testing.T) {
 		// The dual-stack label must not become an escape hatch for lookalikes.
 		"https://s3.dualstack.evil.example/bucket/context.tar.gz",
 		"https://bucket.s3.dualstack.us-west-2.amazonaws.com.evil.example/context.tar.gz",
+		// Dual-stack endpoints are always regional -- there is no global
+		// "s3.dualstack.amazonaws.com", so "dualstack" must never be read as
+		// the region itself, in either addressing style.
+		"https://s3.dualstack.amazonaws.com/bucket/context.tar.gz",
+		"https://bucket.s3.dualstack.amazonaws.com/context.tar.gz",
 	}
 	for _, input := range tests {
 		t.Run(input, func(t *testing.T) {

--- a/provider/defangaws/aws/codebuild_test.go
+++ b/provider/defangaws/aws/codebuild_test.go
@@ -16,9 +16,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// buildSpecCommands generates a buildspec for a realistic .tar.gz build context. Tests that
+// specifically exercise the context-extraction step should call buildSpecCommandsWithContext
+// instead, so they control the source URL (and therefore the archive filename/extension).
 func buildSpecCommands(t *testing.T, build compose.BuildConfig) []string {
 	t.Helper()
-	spec, err := getBuildSpec(build, "123.dkr.ecr.us-test-2.amazonaws.com/repo:latest")
+	return buildSpecCommandsWithContext(t, build, "s3://bucket/context.tar.gz")
+}
+
+func buildSpecCommandsWithContext(t *testing.T, build compose.BuildConfig, contextURL string) []string {
+	t.Helper()
+	spec, err := getBuildSpec(build, "123.dkr.ecr.us-test-2.amazonaws.com/repo:latest", contextURL)
 	require.NoError(t, err)
 	var parsed struct {
 		Phases struct {
@@ -85,48 +93,66 @@ func TestGetBuildSpecDefault(t *testing.T) {
 // "open Dockerfile: no such file or directory" because $CODEBUILD_SRC_DIR
 // held the untouched archive, not its contents.
 func TestGetBuildSpecExtractsArchiveBeforeAnythingElse(t *testing.T) {
-	cmds := buildSpecCommands(t, compose.BuildConfig{Context: pulumi.String("s3://bucket/ctx")})
+	cmds := buildSpecCommands(t, compose.BuildConfig{})
 	require.NotEmpty(t, cmds)
 	assert.Contains(t, cmds[0], "tar xzf",
 		"extraction must be the first pre_build command, before anything else needs the source tree")
+	assert.Contains(t, cmds[0], "context.tar.gz",
+		"must name the archive CodeBuild will actually download, taken from the source URL")
+	assert.NotContains(t, cmds[0], "ls ",
+		"the archive name is known up front from the source URL; no need to glob-discover it")
 }
 
-// Runs the actual generated extraction command (not just asserting on the
-// spec text) against a real tarball, and confirms it's a safe no-op for a
-// zip-sourced build (CodeBuild already extracted that itself, so there's
-// nothing named *.tar.gz to find).
+// The legacy TS CD also accepted ".tgz" (not just ".tar.gz"); keep parity.
+func TestGetBuildSpecExtractsTgzArchive(t *testing.T) {
+	cmds := buildSpecCommandsWithContext(t, compose.BuildConfig{}, "s3://bucket/uploads/context.tgz")
+	require.NotEmpty(t, cmds)
+	assert.Contains(t, cmds[0], "tar xzf")
+	assert.Contains(t, cmds[0], "context.tgz")
+}
+
+// A .zip source is already extracted by CodeBuild itself, so there's nothing named
+// *.tar.gz/*.tgz to find -- getBuildSpec must not emit an extraction step at all.
+func TestGetBuildSpecSkipsExtractionForZipSource(t *testing.T) {
+	cmds := buildSpecCommandsWithContext(t, compose.BuildConfig{}, "s3://bucket/uploads/context.zip")
+	assert.NotContains(t, strings.Join(cmds, "\n"), "tar xzf")
+}
+
+// Only the archive's basename is used, even when the S3 object key has a path prefix
+// (as real CLI uploads do, e.g. "uploads/<hash>.tar.gz") -- CodeBuild downloads the object
+// into $CODEBUILD_SRC_DIR under that basename, not the full key.
+func TestGetBuildSpecExtractionUsesArchiveBasename(t *testing.T) {
+	cmds := buildSpecCommandsWithContext(t, compose.BuildConfig{}, "s3://bucket/uploads/nested/abc123.tar.gz")
+	require.NotEmpty(t, cmds)
+	assert.Contains(t, cmds[0], "abc123.tar.gz")
+	assert.NotContains(t, cmds[0], "uploads/nested")
+}
+
+// Runs the actual generated extraction command (not just asserting on the spec text)
+// against a real tarball, confirming it extracts the exact archive named in the command
+// and removes it afterward.
 func TestBuildSpecExtractionCommandExtractsRealArchive(t *testing.T) {
-	cmds := buildSpecCommands(t, compose.BuildConfig{Context: pulumi.String("s3://bucket/ctx")})
+	cmds := buildSpecCommandsWithContext(t, compose.BuildConfig{}, "s3://bucket/uploads/abc123.tar.gz")
 	extractCmd := cmds[0]
 
-	t.Run("extracts a tar.gz source and removes the archive", func(t *testing.T) {
-		dir := t.TempDir()
-		archivePath := filepath.Join(dir, "abc123.tar.gz")
-		writeTestTarGz(t, archivePath, map[string]string{"Dockerfile": "FROM scratch\n"})
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "abc123.tar.gz")
+	writeTestTarGz(t, archivePath, map[string]string{"Dockerfile": "FROM scratch\n"})
 
-		cmd := exec.CommandContext(t.Context(), "bash", "-c", extractCmd) //nolint:gosec // G204: test-authored command
-		cmd.Dir = dir
-		output, err := cmd.CombinedOutput()
-		require.NoError(t, err, "output: %s", output)
+	cmd := exec.CommandContext(t.Context(), "bash", "-c", extractCmd) //nolint:gosec // G204: test-authored command
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "output: %s", output)
 
-		//nolint:gosec // G304: test-authored path in t.TempDir()
-		content, err := os.ReadFile(filepath.Join(dir, "Dockerfile"))
-		require.NoError(t, err)
-		assert.Equal(t, "FROM scratch\n", string(content))
+	//nolint:gosec // G304: test-authored path in t.TempDir()
+	content, err := os.ReadFile(filepath.Join(dir, "Dockerfile"))
+	require.NoError(t, err)
+	assert.Equal(t, "FROM scratch\n", string(content))
 
-		// Not removing it risks a naive `COPY . .` Dockerfile picking up its
-		// own multi-megabyte source tarball as part of the image.
-		_, err = os.Stat(archivePath)
-		assert.True(t, os.IsNotExist(err), "archive should be removed after extraction")
-	})
-
-	t.Run("no-op when there is nothing to extract", func(t *testing.T) {
-		dir := t.TempDir()
-		cmd := exec.CommandContext(t.Context(), "bash", "-c", extractCmd) //nolint:gosec // G204: test-authored command
-		cmd.Dir = dir
-		output, err := cmd.CombinedOutput()
-		require.NoError(t, err, "output: %s", output)
-	})
+	// Not removing it risks a naive `COPY . .` Dockerfile picking up its
+	// own multi-megabyte source tarball as part of the image.
+	_, err = os.Stat(archivePath)
+	assert.True(t, os.IsNotExist(err), "archive should be removed after extraction")
 }
 
 func writeTestTarGz(t *testing.T, path string, files map[string]string) {

--- a/provider/defangaws/aws/codebuild_test.go
+++ b/provider/defangaws/aws/codebuild_test.go
@@ -1,7 +1,12 @@
 package aws
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -29,6 +34,27 @@ func buildSpecCommands(t *testing.T, build compose.BuildConfig) []string {
 	return append(parsed.Phases.PreBuild.Commands, parsed.Phases.Build.Commands...)
 }
 
+func TestNormalizeCodeBuildS3Location(t *testing.T) {
+	tests := map[string]string{
+		"s3://bucket/uploads/context.tar.gz":                                     "bucket/uploads/context.tar.gz",
+		"https://bucket.s3.amazonaws.com/uploads/context.tar.gz?signature=value": "bucket/uploads/context.tar.gz",
+		"https://bucket.s3.us-west-2.amazonaws.com/uploads/context.tar.gz":       "bucket/uploads/context.tar.gz",
+		"https://s3.us-west-2.amazonaws.com/bucket/uploads/context.tar.gz":       "bucket/uploads/context.tar.gz",
+	}
+	for input, expected := range tests {
+		t.Run(input, func(t *testing.T) {
+			actual, err := normalizeCodeBuildS3Location(input)
+			require.NoError(t, err)
+			assert.Equal(t, expected, actual)
+		})
+	}
+}
+
+func TestNormalizeCodeBuildS3LocationRejectsInvalidURL(t *testing.T) {
+	_, err := normalizeCodeBuildS3Location("https://example.com/context.tar.gz")
+	require.Error(t, err)
+}
+
 func TestGetBuildSpecDefault(t *testing.T) {
 	cmds := buildSpecCommands(t, compose.BuildConfig{Context: pulumi.String("s3://bucket/ctx")})
 	joined := strings.Join(cmds, "\n")
@@ -37,6 +63,68 @@ func TestGetBuildSpecDefault(t *testing.T) {
 	assert.NotContains(t, joined, "--cache-to")
 	assert.Contains(t, joined,
 		"docker buildx build -t 123.dkr.ecr.us-test-2.amazonaws.com/repo:latest -f Dockerfile --push $CODEBUILD_SRC_DIR")
+}
+
+// CodeBuild's S3 source only auto-extracts .zip; the CLI uploads the build
+// context as .tar.gz for every non-Railpack build on every provider (GCP's
+// Cloud Build extracts that natively, CodeBuild does not). A live smoketest
+// (defang-mvp#3181) hit this for real: the build phase failed with
+// "open Dockerfile: no such file or directory" because $CODEBUILD_SRC_DIR
+// held the untouched archive, not its contents.
+func TestGetBuildSpecExtractsArchiveBeforeAnythingElse(t *testing.T) {
+	cmds := buildSpecCommands(t, compose.BuildConfig{Context: pulumi.String("s3://bucket/ctx")})
+	require.NotEmpty(t, cmds)
+	assert.Contains(t, cmds[0], "tar xzf",
+		"extraction must be the first pre_build command, before anything else needs the source tree")
+}
+
+// Runs the actual generated extraction command (not just asserting on the
+// spec text) against a real tarball, and confirms it's a safe no-op for a
+// zip-sourced build (CodeBuild already extracted that itself, so there's
+// nothing named *.tar.gz to find).
+func TestBuildSpecExtractionCommandExtractsRealArchive(t *testing.T) {
+	cmds := buildSpecCommands(t, compose.BuildConfig{Context: pulumi.String("s3://bucket/ctx")})
+	extractCmd := cmds[0]
+
+	t.Run("extracts a tar.gz source", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTestTarGz(t, filepath.Join(dir, "abc123.tar.gz"), map[string]string{"Dockerfile": "FROM scratch\n"})
+
+		cmd := exec.CommandContext(t.Context(), "bash", "-c", extractCmd) //nolint:gosec // G204: test-authored command
+		cmd.Dir = dir
+		output, err := cmd.CombinedOutput()
+		require.NoError(t, err, "output: %s", output)
+
+		//nolint:gosec // G304: test-authored path in t.TempDir()
+		content, err := os.ReadFile(filepath.Join(dir, "Dockerfile"))
+		require.NoError(t, err)
+		assert.Equal(t, "FROM scratch\n", string(content))
+	})
+
+	t.Run("no-op when there is nothing to extract", func(t *testing.T) {
+		dir := t.TempDir()
+		cmd := exec.CommandContext(t.Context(), "bash", "-c", extractCmd) //nolint:gosec // G204: test-authored command
+		cmd.Dir = dir
+		output, err := cmd.CombinedOutput()
+		require.NoError(t, err, "output: %s", output)
+	})
+}
+
+func writeTestTarGz(t *testing.T, path string, files map[string]string) {
+	t.Helper()
+	f, err := os.Create(path) //nolint:gosec // G304: test-authored path in t.TempDir()
+	require.NoError(t, err)
+	gz := gzip.NewWriter(f)
+	tw := tar.NewWriter(gz)
+	for name, content := range files {
+		require.NoError(t, tw.WriteHeader(&tar.Header{Name: name, Size: int64(len(content)), Mode: 0o644}))
+		_, err := tw.Write([]byte(content))
+		require.NoError(t, err)
+	}
+	// Close in dependency order: tar writer flushes into gzip, gzip flushes into the file.
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+	require.NoError(t, f.Close())
 }
 
 func TestGetBuildSpecPlatformsAndCache(t *testing.T) {

--- a/provider/defangaws/aws/codebuild_test.go
+++ b/provider/defangaws/aws/codebuild_test.go
@@ -48,6 +48,10 @@ func TestNormalizeCodeBuildS3Location(t *testing.T) {
 		"https://bucket.s3.amazonaws.com/uploads/context.tar.gz?signature=value": "bucket/uploads/context.tar.gz",
 		"https://bucket.s3.us-west-2.amazonaws.com/uploads/context.tar.gz":       "bucket/uploads/context.tar.gz",
 		"https://s3.us-west-2.amazonaws.com/bucket/uploads/context.tar.gz":       "bucket/uploads/context.tar.gz",
+		// IPv6 dual-stack endpoints, in both virtual-hosted and path style. The
+		// SDK emits these when AWS_USE_DUALSTACK_ENDPOINT is set.
+		"https://bucket.s3.dualstack.us-west-2.amazonaws.com/uploads/context.tar.gz": "bucket/uploads/context.tar.gz",
+		"https://s3.dualstack.us-west-2.amazonaws.com/bucket/uploads/context.tar.gz": "bucket/uploads/context.tar.gz",
 	}
 	for input, expected := range tests {
 		t.Run(input, func(t *testing.T) {
@@ -67,6 +71,9 @@ func TestNormalizeCodeBuildS3LocationRejectsInvalidURL(t *testing.T) {
 		"https://bucket.s3.evil.example/context.tar.gz",
 		"https://s3.evil.example/bucket/context.tar.gz",
 		"https://bucket.s3.amazonaws.com.evil.example/context.tar.gz",
+		// The dual-stack label must not become an escape hatch for lookalikes.
+		"https://s3.dualstack.evil.example/bucket/context.tar.gz",
+		"https://bucket.s3.dualstack.us-west-2.amazonaws.com.evil.example/context.tar.gz",
 	}
 	for _, input := range tests {
 		t.Run(input, func(t *testing.T) {

--- a/provider/defangaws/aws/codebuild_test.go
+++ b/provider/defangaws/aws/codebuild_test.go
@@ -51,8 +51,21 @@ func TestNormalizeCodeBuildS3Location(t *testing.T) {
 }
 
 func TestNormalizeCodeBuildS3LocationRejectsInvalidURL(t *testing.T) {
-	_, err := normalizeCodeBuildS3Location("https://example.com/context.tar.gz")
-	require.Error(t, err)
+	tests := []string{
+		"https://example.com/context.tar.gz",
+		// Lookalike hosts: a naive substring/prefix check on the hostname
+		// (".s3." anywhere, or a "s3." prefix) would accept these as if they
+		// were real S3 endpoints.
+		"https://bucket.s3.evil.example/context.tar.gz",
+		"https://s3.evil.example/bucket/context.tar.gz",
+		"https://bucket.s3.amazonaws.com.evil.example/context.tar.gz",
+	}
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			_, err := normalizeCodeBuildS3Location(input)
+			require.Error(t, err)
+		})
+	}
 }
 
 func TestGetBuildSpecDefault(t *testing.T) {
@@ -86,9 +99,10 @@ func TestBuildSpecExtractionCommandExtractsRealArchive(t *testing.T) {
 	cmds := buildSpecCommands(t, compose.BuildConfig{Context: pulumi.String("s3://bucket/ctx")})
 	extractCmd := cmds[0]
 
-	t.Run("extracts a tar.gz source", func(t *testing.T) {
+	t.Run("extracts a tar.gz source and removes the archive", func(t *testing.T) {
 		dir := t.TempDir()
-		writeTestTarGz(t, filepath.Join(dir, "abc123.tar.gz"), map[string]string{"Dockerfile": "FROM scratch\n"})
+		archivePath := filepath.Join(dir, "abc123.tar.gz")
+		writeTestTarGz(t, archivePath, map[string]string{"Dockerfile": "FROM scratch\n"})
 
 		cmd := exec.CommandContext(t.Context(), "bash", "-c", extractCmd) //nolint:gosec // G204: test-authored command
 		cmd.Dir = dir
@@ -99,6 +113,11 @@ func TestBuildSpecExtractionCommandExtractsRealArchive(t *testing.T) {
 		content, err := os.ReadFile(filepath.Join(dir, "Dockerfile"))
 		require.NoError(t, err)
 		assert.Equal(t, "FROM scratch\n", string(content))
+
+		// Not removing it risks a naive `COPY . .` Dockerfile picking up its
+		// own multi-megabyte source tarball as part of the image.
+		_, err = os.Stat(archivePath)
+		assert.True(t, os.IsNotExist(err), "archive should be removed after extraction")
 	})
 
 	t.Run("no-op when there is nothing to extract", func(t *testing.T) {

--- a/provider/defangaws/aws/codebuild_test.go
+++ b/provider/defangaws/aws/codebuild_test.go
@@ -84,6 +84,10 @@ func TestNormalizeCodeBuildS3LocationRejectsInvalidURL(t *testing.T) {
 		// the region itself, in either addressing style.
 		"https://s3.dualstack.amazonaws.com/bucket/context.tar.gz",
 		"https://bucket.s3.dualstack.amazonaws.com/context.tar.gz",
+		// The legacy dash form needs a region after the dash: a bare "s3-"
+		// is not an endpoint, in either addressing style.
+		"https://s3-.amazonaws.com/bucket/context.tar.gz",
+		"https://bucket.s3-.amazonaws.com/context.tar.gz",
 	}
 	for _, input := range tests {
 		t.Run(input, func(t *testing.T) {

--- a/provider/defangaws/aws/lb.go
+++ b/provider/defangaws/aws/lb.go
@@ -155,7 +155,8 @@ func createTgLrPair(
 
 	// Only create TG/LR for http, http2, grpc (matches TS createTgLrPair)
 	appProto := port.GetAppProtocol()
-	if appProto != "http" && appProto != "http2" && appProto != "grpc" {
+	if appProto != compose.PortAppProtocolHTTP &&
+		appProto != compose.PortAppProtocolHTTP2 && appProto != compose.PortAppProtocolGRPC {
 		return nil, nil, nil // skip
 	}
 

--- a/provider/defangaws/aws/naming.go
+++ b/provider/defangaws/aws/naming.go
@@ -16,7 +16,7 @@ func targetGroupName(
 	service string, port int, appProtocol compose.PortAppProtocol, listener compose.PortListenerProtocol,
 ) string {
 	suffix := fmt.Sprintf("-%d", port)
-	if appProtocol != "" && appProtocol != "http" {
+	if appProtocol != "" && appProtocol != compose.PortAppProtocolHTTP {
 		suffix += string(appProtocol)
 	}
 	// HTTPS is the default listener, so only non-default listeners get a suffix

--- a/tests/aws/project_test.go
+++ b/tests/aws/project_test.go
@@ -194,7 +194,7 @@ func TestConstructAwsProjectAllResourcesAreChildren(t *testing.T) {
 				"worker": testutil.ServiceWithImage("myapp:worker"),
 				"builder": property.New(property.NewMap(map[string]property.Value{
 					"build": property.New(property.NewMap(map[string]property.Value{
-						"context": property.New("./app"),
+						"context": property.New("s3://bucket/uploads/digest.tar.gz"),
 					})),
 				})),
 				"db": property.New(property.NewMap(map[string]property.Value{


### PR DESCRIPTION
CodeBuild's S3 source only auto-extracts `.zip`; the CLI uploads the build context as `.tar.gz` for every non-Railpack build on every provider (GCP's Cloud Build extracts that natively, CodeBuild does not). A live smoketest (defang-mvp#3181) hit this for real: the build phase failed with `open Dockerfile: no such file or directory` because `$CODEBUILD_SRC_DIR` held the untouched archive, not its contents.

The legacy TypeScript CD (defang-mvp's `cd/aws/image.ts`) already has an identical manual `tar -xzf` extraction step with a comment explicitly noting CodeBuild doesn't auto-extract tar.gz — this is a regression from the Go rewrite, not a new issue with the upload format.

Also normalizes the CodeBuild source URL (s3://, virtual-hosted, and path-style https:// forms all seen from the CLI's presigned URLs) to a bucket/key pair for the pre-build extraction command's working directory, and fixes a golangci-lint `goconst` hit the URL-scheme match introduced.

Verified against real AWS (Lab account): with this fix, the app image build and both ECS services (`app`, `smokeworker`) came up healthy end-to-end.

Unrelated to #467/#469 — this is a pre-existing AWS CodeBuild regression found during the same smoketest, not part of either GCP feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved CodeBuild support for S3 source locations across supported URL formats.
  * Automatically extracts `.tar.gz` and `.tgz` build contexts before running build commands.
  * Preserves archive filenames correctly when preparing build contexts.

* **Bug Fixes**
  * Strengthened S3 hostname validation to reject lookalike domains.
  * Improved error handling during build-context extraction.
  * Improved load balancer protocol handling for HTTP, HTTP/2, and gRPC configurations.
  * Improved handling of AWS project build contexts stored in S3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->