### PR TITLE
fix(gcp): stop retaining the VPC and subnet so a failed down surfaces

### DIFF
--- a/provider/defanggcp/gcp/cloudsql.go
+++ b/provider/defanggcp/gcp/cloudsql.go
@@ -171,9 +171,9 @@ func CreateCloudSQL(
 			Instance:       instance.Name,
 			Password:       pg.Password,
 			Type: pulumi.String("BUILT_IN"),
-			// ABANDON alone: deleting the instance removes its users anyway, so the API call is
-			// pointless, but Pulumi should still drop this from state. A RetainOnDelete on top
-			// would only leave an entry no `down` can clear.
+			// ABANDON alone. Deleting the instance removes its users, so there is nothing here to
+			// delete and nothing to leak; the RetainOnDelete that used to sit on top was
+			// redundant with the deletion policy, which already suppresses the API call.
 			DeletionPolicy: pulumi.String("ABANDON"),
 		}, opts...)
 		if err != nil {

--- a/provider/defanggcp/gcp/cloudsql.go
+++ b/provider/defanggcp/gcp/cloudsql.go
@@ -170,9 +170,12 @@ func CreateCloudSQL(
 			Name:           pg.Username,
 			Instance:       instance.Name,
 			Password:       pg.Password,
-			Type:           pulumi.String("BUILT_IN"),
+			Type: pulumi.String("BUILT_IN"),
+			// ABANDON alone: deleting the instance removes its users anyway, so the API call is
+			// pointless, but Pulumi should still drop this from state. A RetainOnDelete on top
+			// would only leave an entry no `down` can clear.
 			DeletionPolicy: pulumi.String("ABANDON"),
-		}, append(opts, pulumi.RetainOnDelete(true))...)
+		}, opts...)
 		if err != nil {
 			return nil, fmt.Errorf("creating Cloud SQL user: %w", err)
 		}
@@ -185,9 +188,10 @@ func CreateCloudSQL(
 	if rawDB != nil && *rawDB != "" && *rawDB != compose.DEFAULT_POSTGRES_DB {
 		_, err := sql.NewDatabase(ctx, serviceName+"-db", &sql.DatabaseArgs{
 			Name:           pg.DBName,
-			Instance:       instance.Name,
+			Instance: instance.Name,
+			// ABANDON alone, same reasoning as the user above.
 			DeletionPolicy: pulumi.String("ABANDON"),
-		}, append(opts, pulumi.RetainOnDelete(true))...)
+		}, opts...)
 		if err != nil {
 			return nil, fmt.Errorf("creating Cloud SQL database: %w", err)
 		}

--- a/provider/defanggcp/gcp/compute.go
+++ b/provider/defanggcp/gcp/compute.go
@@ -256,6 +256,12 @@ func createInstanceTemplate(
 
 	templateOpts := make([]pulumi.ResourceOption, 0, len(opts)+2)
 	templateOpts = append(templateOpts, opts...)
+	// Unlike the VPC and the subnet, this retain stays. Changing an instance template is a
+	// replacement, and the delete of the old one fails with "The instance_template resource is
+	// already being used by" while its MIG still points at it, so without the retain every
+	// redeploy of a Compute Engine service fails. The cost is a template left holding the subnet
+	// on teardown, which the CLI's cleanup tool deletes (DefangLabs/defang#2157, the
+	// "instance-template" category, which it removes before the subnet).
 	templateOpts = append(templateOpts, pulumi.RetainOnDelete(true))
 	if sa.Account != nil {
 		templateOpts = append(templateOpts, pulumi.DependsOnInputs(iamDeps))

--- a/provider/defanggcp/gcp/compute.go
+++ b/provider/defanggcp/gcp/compute.go
@@ -256,13 +256,12 @@ func createInstanceTemplate(
 
 	templateOpts := make([]pulumi.ResourceOption, 0, len(opts)+2)
 	templateOpts = append(templateOpts, opts...)
-	// Unlike the VPC and the subnet, this retain stays. Changing an instance template is a
-	// replacement, and the delete of the old one fails with "The instance_template resource is
-	// already being used by" while its MIG still points at it, so without the retain every
-	// redeploy of a Compute Engine service fails. The cost is a template left holding the subnet
-	// on teardown, which the CLI's cleanup tool deletes (DefangLabs/defang#2157, the
-	// "instance-template" category, which it removes before the subnet).
-	templateOpts = append(templateOpts, pulumi.RetainOnDelete(true))
+	// Deliberately NOT RetainOnDelete. The legacy CD retained this to dodge "The
+	// instance_template resource is already being used by", which the delete half of a
+	// replacement can raise while the MIG still points at the old template. That traded one
+	// error for two leaks: a template per redeploy, and a template left holding the subnet on
+	// teardown, which then blocks the subnet and the VPC (issue #183) with nothing left in state
+	// to delete it. If the replace error comes back, fix the ordering rather than the symptom.
 	if sa.Account != nil {
 		templateOpts = append(templateOpts, pulumi.DependsOnInputs(iamDeps))
 	}

--- a/provider/defanggcp/gcp/gcp.go
+++ b/provider/defanggcp/gcp/gcp.go
@@ -62,10 +62,11 @@ func EnableGcpAPIs(ctx *pulumi.Context, opts ...pulumi.ResourceOption) error {
 		"firestore.googleapis.com",            // For Firestore MongoDB
 	}
 
-	// DisableOnDestroy false, not RetainOnDelete. Both stop `down` from disabling an API that
-	// the rest of the project may depend on, but this one is the provider's own switch: Pulumi
-	// still drops the resource from state on destroy, so a later `up` re-adopts it cleanly.
-	// RetainOnDelete would leave state entries no `down` can ever clear.
+	// DisableOnDestroy false, not RetainOnDelete. Both leave the API enabled after a `down`, and
+	// both drop the resource from Pulumi state: RetainOnDelete by skipping the provider's delete
+	// call outright, this by telling the provider not to disable. The difference is that this is
+	// the provider's own switch for exactly this intent, which keeps RetainOnDelete reserved for
+	// the one case that warrants it — a recipe deliberately keeping a non-defang resource.
 	for _, api := range apis {
 		if _, err := projects.NewService(ctx, api, &projects.ServiceArgs{
 			Service:          pulumi.String(api),

--- a/provider/defanggcp/gcp/gcp.go
+++ b/provider/defanggcp/gcp/gcp.go
@@ -62,10 +62,14 @@ func EnableGcpAPIs(ctx *pulumi.Context, opts ...pulumi.ResourceOption) error {
 		"firestore.googleapis.com",            // For Firestore MongoDB
 	}
 
-	opts = append(opts, pulumi.RetainOnDelete(true))
+	// DisableOnDestroy false, not RetainOnDelete. Both stop `down` from disabling an API that
+	// the rest of the project may depend on, but this one is the provider's own switch: Pulumi
+	// still drops the resource from state on destroy, so a later `up` re-adopts it cleanly.
+	// RetainOnDelete would leave state entries no `down` can ever clear.
 	for _, api := range apis {
 		if _, err := projects.NewService(ctx, api, &projects.ServiceArgs{
-			Service: pulumi.String(api),
+			Service:          pulumi.String(api),
+			DisableOnDestroy: pulumi.Bool(false),
 		}, opts...); err != nil {
 			return fmt.Errorf("failed to enable API %s: %w", api, err)
 		}

--- a/provider/defanggcp/gcp/gcp.go
+++ b/provider/defanggcp/gcp/gcp.go
@@ -104,9 +104,16 @@ func BuildGlobalConfig(
 	// private-dns zone further down: Pulumi's default resource ID already prefixes
 	// it with <pulumi-project>-<stack>, which includes projectName, so repeating it
 	// here risked exceeding GCP's 63-char resource ID limit.
+	// Deliberately NOT RetainOnDelete, even though GCP holds the subnet's IP addresses for 1-2
+	// hours after the last Cloud Run service using them is deleted (Direct VPC egress; see
+	// buildVpcAccess in cloudrun.go), so a `down` inside that window fails to delete the subnet
+	// and, behind it, the VPC. Retaining hid that failure but dropped both resources from the
+	// Pulumi state, which left the VPC orphaned with nothing left to delete it: the project then
+	// ran into its NETWORKS quota (issue #183). Letting the destroy fail is what puts the CLI's
+	// cleanup tool (DefangLabs/defang#2157) in front of the user.
 	vpc, err := compute.NewNetwork(ctx, "vpc", &compute.NetworkArgs{
 		AutoCreateSubnetworks: pulumi.Bool(false),
-	}, append(opts, pulumi.RetainOnDelete(true))...)
+	}, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +122,7 @@ func BuildGlobalConfig(
 		IpCidrRange: pulumi.String("10.0.0.0/16"),
 		Region:      pulumi.String(region),
 		Network:     vpc.ID(),
-	}, append(opts, pulumi.RetainOnDelete(true))...)
+	}, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/defanggcp/gcp/vpc_peering.go
+++ b/provider/defanggcp/gcp/vpc_peering.go
@@ -38,13 +38,26 @@ func createVPCPeeringInfra(
 		return nil, err
 	}
 
+	// DeletionPolicy ABANDON, and deliberately NOT RetainOnDelete. The provider's delete calls
+	// servicenetworking deleteConnection, which cannot be relied on: GCP requires every service
+	// instance to be gone first and producer-side cleanup lags the instance delete by up to 4
+	// days for Cloud SQL, and hashicorp/terraform-provider-google#18834 (still open) records that
+	// the call fails even after that, because Google's own console removes the peering through
+	// the Compute API instead. ABANDON skips the doomed call; the CLI's cleanup tool
+	// (DefangLabs/defang#2157) then calls compute.networks.removePeering, which releases the
+	// reserved range so the subnet and the VPC can go. RetainOnDelete would instead drop the
+	// connection from the Pulumi state while leaving the whole VPC standing (issue #183).
+	//
+	// The field is Optional+Computed and not ForceNew, so it updates in place on an existing
+	// stack and never replaces the peering.
 	serviceConn, err := servicenetworking.NewConnection(ctx, "svc-conn",
 		&servicenetworking.ConnectionArgs{
 			Network:               vpcId,
 			Service:               pulumi.String("servicenetworking.googleapis.com"),
 			ReservedPeeringRanges: pulumi.StringArray{privateIpAlloc.Name},
+			DeletionPolicy:        pulumi.String("ABANDON"),
 		},
-		append(opts, pulumi.RetainOnDelete(true))...,
+		opts...,
 	)
 	if err != nil {
 		return nil, err

--- a/provider/defanggcp/project.go
+++ b/provider/defanggcp/project.go
@@ -120,9 +120,10 @@ func buildProject(
 	if common.IsProjectUsingLLM(args.Services) {
 		// FIXME: create dependency between this NewService and the services that need this API
 		_, err := projects.NewService(ctx, projectName+"-defang-llm", &projects.ServiceArgs{
-			Project: pulumi.StringPtr(config.GcpProject),
-			Service: pulumi.String("aiplatform.googleapis.com"),
-		}, append(childOpts, pulumi.RetainOnDelete(true))...) // Do not try disabling on compose down
+			Project:          pulumi.StringPtr(config.GcpProject),
+			Service:          pulumi.String("aiplatform.googleapis.com"),
+			DisableOnDestroy: pulumi.Bool(false), // do not try disabling on compose down
+		}, childOpts...)
 		if err != nil {
 			return nil, err
 		}

--- a/provider/defanggcp/project.go
+++ b/provider/defanggcp/project.go
@@ -122,7 +122,7 @@ func buildProject(
 		_, err := projects.NewService(ctx, projectName+"-defang-llm", &projects.ServiceArgs{
 			Project:          pulumi.StringPtr(config.GcpProject),
 			Service:          pulumi.String("aiplatform.googleapis.com"),
-			DisableOnDestroy: pulumi.Bool(false), // do not try disabling on compose down
+			DisableOnDestroy: pulumi.Bool(false), // do not try disabling on compose down; see EnableGcpAPIs
 		}, childOpts...)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Closes #183. Supersedes #462, which put the retry logic in the CD; the CLI now owns it (DefangLabs/defang#2157).

## The rule

`RetainOnDelete` is only legitimate where a recipe deliberately keeps a **non-defang** resource — a built image, a customer's bucket, a DNS zone the customer owns. Everywhere else it is a leak generator, because it deletes the resource from the Pulumi state file: the `down` reports success, the resource stays in the cloud, and no later `down` has anything left to delete.

None of the GCP retains met that bar. **`provider/defanggcp` now has no `RetainOnDelete` at all.**

## The leak this fixes

The VPC and its subnet were retained, so every `defang down` reported success and left the network standing. The project eventually ran into its `NETWORKS` quota. That is issue #183.

Now the destroy fails instead. The failure is expected, not exceptional: Cloud Run attaches to the subnet with Direct VPC egress (`buildVpcAccess`, `cloudrun.go`) and GCP holds the subnet's IP addresses for **1-2 hours** after the service is gone:

> "After you delete or move your Cloud Run resources, wait 1-2 hours for Cloud Run to release the IP addresses before you delete the subnet."
> — [Cloud Run Direct VPC docs](https://docs.cloud.google.com/run/docs/configuring/vpc-direct-vpc)

Nothing can wait that out inside an apply. So the `down` fails, the CLI starts the AI debugger, the debugger runs the GCP cleanup tool added in DefangLabs/defang#2157, and the tool removes the peering, the reserved range, the subnet and the network through the Compute API. A later `defang down` then completes.

## Resource by resource

**VPC and subnet** (`gcp/gcp.go`) — retain removed, as above.

**Service Networking connection** (`gcp/vpc_peering.go`) — `DeletionPolicy: "ABANDON"` replaces the retain. The provider's delete calls servicenetworking `deleteConnection`, which cannot be relied on for two independent reasons:

- GCP requires every service instance to be gone before the connection goes, and producer-side cleanup **lags the instance delete by up to 4 days for Cloud SQL** ([private services access docs](https://docs.cloud.google.com/vpc/docs/configure-private-services-access)).
- hashicorp/terraform-provider-google#18834, **still open**, records that Google's own console removes the peering through the Compute API instead. A maintainer there offers exactly two options: abandon state, or restore `removePeering`.

ABANDON skips the doomed call so Pulumi can finish the rest of the teardown; the CLI then calls `compute.networks.removePeering`. The field is `Optional`+`Computed` and not `ForceNew`, so it updates in place on an existing stack and never replaces the peering.

**MIG instance template** (`gcp/compute.go`) — retain removed. The legacy CD added it to dodge "The instance_template resource is already being used by", which the delete half of a replacement can raise while the MIG still points at the old template. That traded one error for two leaks: a template per redeploy, and a template left holding the subnet on teardown. If the replace error comes back, the fix is the ordering, not the symptom.

**Enabled APIs** (`gcp/gcp.go`, `project.go`) — `DisableOnDestroy: false` replaces the retain. This one is not a leak fix: both options leave the API enabled after a `down`, and both drop the resource from Pulumi state. The point is to use the provider's own switch for exactly this intent, so that `RetainOnDelete` is left meaning only the one thing it should mean.

**Cloud SQL user and database** (`gcp/cloudsql.go`) — retain removed, `DeletionPolicy: ABANDON` kept. Also not a leak fix: deleting the instance removes its users and databases, so there is nothing here to delete and nothing to leak. The retain was simply redundant with the deletion policy, which already suppresses the API call.

## Trade-off to be aware of

A GCP `down` inside the 1-2 hour window now **fails** where it used to report success. That is the point — the leak was the silence — but it is a visible behaviour change, and the good outcome depends on DefangLabs/defang#2157 shipping alongside it.

## Stacks whose state predates this change

`retainOnDelete` is recorded per resource in the checkpoint, and `pulumi destroy` does not re-run the program, so removing it in provider code changes nothing for a stack whose current state was written by the old code. Those stacks still `down` "successfully" and still leak. The CLI cleanup tool covers them, because it finds orphans through the GCP API by network-name prefix rather than through Pulumi state.

## Not in scope

AWS and Azure still carry retains. The recipe-driven ones (`RetainBucketOnDelete`, `RetainDnsOnDelete`) are exactly the legitimate case. The unconditional ones are worth their own pass: `defangaws/aws/cert.go:241`, `defangaws/aws/route53.go:83`, `defangaws/aws/infra.go:150`, `defangazure/azure/keyvault.go:83`, `defangazure/project.go:315`. The Artifact Registry retain is #457's subject.

## Testing

`go test ./provider/...` and `cd tests && go test -short ./...` are green. No test asserted on the retain flags.

End-to-end verification is a real GCP `up` / `down` cycle against a CD image built from this branch; that is in progress separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of VPCs, subnets, and VPC peering connections by removing unexpected resource retention.
  * Prevented instance templates from being retained after deletion, reducing template leaks and teardown failures.
  * Improved cleanup behavior for cloud services, databases, and database users while preserving required services.
  * Replacement failures now surface through resource ordering rather than being masked by retained resources.

* **Documentation**
  * Added guidance explaining instance template retention changes and recommended resource ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->