### PR TITLE
fix(cd): create /tmp explicitly in the scratch CD image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,6 +123,15 @@ ARG PROVIDER_VERSION
 COPY --link --from=build-azure /out/pulumi-resource-defang-azure /tmp/
 RUN pulumi plugin install resource defang-azure ${PROVIDER_VERSION} -f /tmp/pulumi-resource-defang-azure
 
+# An empty, world-writable /tmp to copy into the scratch image below. Pulumi needs /tmp for its
+# workspace temp files, and scratch has no filesystem at all. `WORKDIR /tmp` used to stand in for
+# this, but whether WORKDIR materialises a directory in the exported image is builder-specific:
+# BuildKit does, buildah/podman does not, and the resulting image fails at runtime with
+# "unable to create tmp directory for workspace: stat /tmp: no such file or directory" only once
+# it is actually deployed. Copying an explicit directory works the same way everywhere.
+FROM --platform=${BUILDPLATFORM} ${BUILDBASE} AS tmpdir
+RUN mkdir -m 1777 /empty-tmp
+
 # Final minimal image — no OS, no language runtimes
 FROM ${CDBASE} AS cd-base
 # CA certs for HTTPS
@@ -130,8 +139,7 @@ COPY --link --from=build-base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 # Pulumi CLI only (no language runtimes)
 COPY --link --from=plugins-base /pulumi/bin/pulumi /pulumi/bin/pulumi
 ENV PATH="/pulumi/bin:${PATH}" HOME="/root" USER=root
-# /tmp is required by Pulumi for workspace temp files; scratch has no filesystem.
-WORKDIR /tmp
+COPY --link --from=tmpdir /empty-tmp /tmp
 # App
 WORKDIR /app
 COPY --link --from=build-base /out/cd ./


### PR DESCRIPTION
## The bug

Pulumi needs `/tmp` for its workspace temp files, and the gcp and azure CD images are built `FROM scratch`, which has no filesystem at all. `WORKDIR /tmp` stood in for creating it.

Whether `WORKDIR` materialises a directory in the exported image is **builder-specific**. BuildKit does; buildah/podman does not. A podman-built image therefore has no `/tmp`, and the CD dies as soon as it is deployed:

```
failed to create stack: unable to create tmp directory for workspace: stat /tmp: no such file or directory
```

Verified both ways on the same Dockerfile — `podman export … | tar -t` shows no `tmp/` entry before this change and `tmp/` after it, while the Cloud Build image has always had it.

The failure mode is the unpleasant part: the build is green, the image pushes, `pulumi version` runs inside it. It only breaks in the customer's cloud, and the error names a missing directory rather than a broken image.

## The fix

Copy an explicit `1777` directory from a tiny stage instead of relying on `WORKDIR`. That behaves identically in every builder.

`cd-base-alpine` (the aws and all targets) is unaffected — its base already provides `/tmp`.

## Why it matters beyond local builds

CI builds with buildx, so the released images are fine today. This bites anyone building the CD image outside CI — which is exactly what testing a provider change against a real cloud requires. It cost me a deploy cycle to find.

Found while testing #473 end to end on GCP.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved temporary-directory setup in the minimal container image.
  * Enhanced compatibility and reliability for processes that require temporary file access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->