### PR TITLE
refactor(cd): drop the dedicated stage for the scratch image's /tmp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,15 +123,6 @@ ARG PROVIDER_VERSION
 COPY --link --from=build-azure /out/pulumi-resource-defang-azure /tmp/
 RUN pulumi plugin install resource defang-azure ${PROVIDER_VERSION} -f /tmp/pulumi-resource-defang-azure
 
-# An empty, world-writable /tmp to copy into the scratch image below. Pulumi needs /tmp for its
-# workspace temp files, and scratch has no filesystem at all. `WORKDIR /tmp` used to stand in for
-# this, but whether WORKDIR materialises a directory in the exported image is builder-specific:
-# BuildKit does, buildah/podman does not, and the resulting image fails at runtime with
-# "unable to create tmp directory for workspace: stat /tmp: no such file or directory" only once
-# it is actually deployed. Copying an explicit directory works the same way everywhere.
-FROM --platform=${BUILDPLATFORM} ${BUILDBASE} AS tmpdir
-RUN mkdir -m 1777 /empty-tmp
-
 # Final minimal image — no OS, no language runtimes
 FROM ${CDBASE} AS cd-base
 # CA certs for HTTPS
@@ -139,7 +130,13 @@ COPY --link --from=build-base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 # Pulumi CLI only (no language runtimes)
 COPY --link --from=plugins-base /pulumi/bin/pulumi /pulumi/bin/pulumi
 ENV PATH="/pulumi/bin:${PATH}" HOME="/root" USER=root
-COPY --link --from=tmpdir /empty-tmp /tmp
+# Pulumi needs /tmp for its workspace temp files and scratch has no filesystem at all.
+# `WORKDIR /tmp` used to stand in for creating it, but whether WORKDIR materialises a directory
+# in the exported image is builder-specific: BuildKit does, buildah/podman does not, and the
+# image then fails at runtime with "unable to create tmp directory for workspace: stat /tmp: no
+# such file or directory" only once it is deployed. build-base's own /tmp is empty and already
+# empty, so copying it works the same way in every builder and needs no stage of its own.
+COPY --link --from=build-base /tmp /tmp
 # App
 WORKDIR /app
 COPY --link --from=build-base /out/cd ./


### PR DESCRIPTION
Follow-up to #474, answering @lionello's question there: no, that line is not needed.

`build-base`'s own `/tmp` is empty (verified: `ls -la /tmp` in that stage shows nothing but `.` and `..`), so it can be copied directly and the `tmpdir` stage goes away.

The `-m 1777` was not doing anything either. Listing the exported image, `/tmp` comes out `drwxr-xr-x` root-owned in **all three** variants — the `tmpdir` stage as merged, a plain copy from `build-base`, and a copy with `--chmod=1777`. The CD runs as root, so the mode never mattered.

What does still matter is that the directory is copied rather than conjured by `WORKDIR`, which is builder-specific: BuildKit materialises it, buildah/podman does not, and the image then dies at deploy time with `unable to create tmp directory for workspace: stat /tmp: no such file or directory`. That part of #474 stays.

Verified by building the `gcp` target with podman and confirming `tmp/` is present in the exported image, identical to what #474 produced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified container image setup by streamlining temporary directory handling.
  * Preserved expected temporary file access and permissions in the final image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->