### PR TITLE
fix(gcp): retry boot-time secret fetch to survive IAM propagation

### DIFF
--- a/provider/defanggcp/gcp/compute.go
+++ b/provider/defanggcp/gcp/compute.go
@@ -668,7 +668,7 @@ func secretFetchScript(gcpProject, unit string, refs []computeSecretEnv) (string
 	scriptPath := "/run/defang/" + unit + "-secrets.sh"
 	envFile := "/run/defang/" + unit + ".env"
 
-	// Bound both requests. The units that run this as ExecStartPre are
+	// Bound each request. The units that run this as ExecStartPre are
 	// Type=oneshot, which disables systemd's default start timeout, so an
 	// unbounded curl could stall a boot indefinitely on a network stall.
 	const curlOpts = `-fsS --connect-timeout 5 --max-time 30`
@@ -684,18 +684,35 @@ func secretFetchScript(gcpProject, unit string, refs []computeSecretEnv) (string
 	s.WriteString("set -euo pipefail\n")
 	s.WriteString("umask 077\n")
 	s.WriteString("mkdir -p /run/defang\n")
+	// The instance template depends on the per-secret secretAccessor IAM
+	// binding, so provisioning is ordered correctly, but IAM propagation can
+	// still lag several minutes behind that ordering: an instance that boots
+	// inside that window gets a 403 from Secret Manager, and a bare metadata
+	// server hiccup has the same shape. curl_retry gives both requests 5
+	// attempts with exponential backoff (2/4/8/16s, ~30s total) before giving
+	// up -- each attempt is still bounded by curlOpts above, so this cannot
+	// stall a boot indefinitely.
+	fmt.Fprintf(&s, "curl_retry() {\n"+
+		"  local attempt=1 max=5 delay=2\n"+
+		"  while ! curl %s \"$@\"; do\n"+
+		"    [ \"$attempt\" -ge \"$max\" ] && return 1\n"+
+		"    sleep \"$delay\"\n"+
+		"    delay=$((delay * 2))\n"+
+		"    attempt=$((attempt + 1))\n"+
+		"  done\n"+
+		"}\n", curlOpts)
 	// Google APIs pretty-print JSON by default (a space after the colon, e.g.
 	// `"data": "..."`), so the extraction must tolerate optional whitespace
 	// there -- a bare `":"` pattern never matches a real response and every
 	// secret-backed boot would fail fetching. See
 	// https://cloud.google.com/apis/docs/system-parameters (prettyPrint).
-	fmt.Fprintf(&s, `tok=$(curl %s -H "Metadata-Flavor: Google" `+
-		`http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token `+
-		`| grep -o '"access_token": *"[^"]*"' | cut -d'"' -f4)`+"\n", curlOpts)
+	s.WriteString(`tok=$(curl_retry -H "Metadata-Flavor: Google" ` +
+		`http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token ` +
+		`| grep -o '"access_token": *"[^"]*"' | cut -d'"' -f4)` + "\n")
 	s.WriteString(`[ -n "$tok" ] || { echo "defang: empty metadata token" >&2; exit 1; }` + "\n")
-	fmt.Fprintf(&s, `sm() { curl %s -H "Authorization: Bearer $tok" `+
+	fmt.Fprintf(&s, `sm() { curl_retry -H "Authorization: Bearer $tok" `+
 		`"https://secretmanager.googleapis.com/v1/projects/%s/secrets/$1/versions/latest:access" `+
-		`| grep -o '"data": *"[^"]*"' | cut -d'"' -f4 | base64 -d; }`+"\n", curlOpts, gcpProject)
+		`| grep -o '"data": *"[^"]*"' | cut -d'"' -f4 | base64 -d; }`+"\n", gcpProject)
 	s.WriteString("{\n")
 	for _, r := range refs {
 		fmt.Fprintf(&s, `v=$(sm '%s') || { echo "defang: failed to fetch secret %s" >&2; exit 1; }`+"\n",

--- a/provider/defanggcp/gcp/compute_test.go
+++ b/provider/defanggcp/gcp/compute_test.go
@@ -292,10 +292,12 @@ func TestSecretFetchScript(t *testing.T) {
 	assert.Contains(t, wf, "set -euo pipefail")
 	assert.Contains(t, wf, `[ -n "$tok" ]`)
 	assert.Contains(t, wf, "curl -fsS")
-	// Both requests must be bounded: ExecStartPre runs in Type=oneshot units,
-	// which have no default systemd start timeout, so an unbounded curl would
-	// stall the boot indefinitely.
-	assert.Equal(t, 2, strings.Count(wf, "--connect-timeout 5 --max-time 30"))
+	// Both requests share one curl_retry helper, so the per-attempt bound
+	// (ExecStartPre runs in Type=oneshot units, which have no default systemd
+	// start timeout -- an unbounded curl would stall the boot indefinitely)
+	// appears once, in the helper's definition, not once per call site.
+	assert.Equal(t, 1, strings.Count(wf, "--connect-timeout 5 --max-time 30"))
+	assert.Equal(t, 2, strings.Count(wf, "curl_retry -H"))
 
 	// no refs -> no output
 	wf2, pre2, flag2 := secretFetchScript("p", "svc", nil)
@@ -312,21 +314,7 @@ func TestSecretFetchScript(t *testing.T) {
 // on the script text.
 func TestSecretFetchScriptExtractsPrettyPrintedJSON(t *testing.T) {
 	wf, _, _ := secretFetchScript("my-proj", "svc", []computeSecretEnv{{envKey: "DB", secretID: "my-secret"}})
-
-	// Reconstruct the raw script from the write_files `content: |` block
-	// (each line indented 6 spaces further, see secretFetchScript).
-	var raw []string
-	inContent := false
-	for _, line := range strings.Split(wf, "\n") {
-		if strings.Contains(line, "content: |") {
-			inContent = true
-			continue
-		}
-		if inContent {
-			raw = append(raw, strings.TrimPrefix(line, "      "))
-		}
-	}
-	require.NotEmpty(t, raw)
+	raw := rawScriptLines(t, wf)
 
 	// Keep everything through the sm() definition. Drop the /run write (no
 	// permission to create it in a test sandbox) and stop before the block
@@ -370,6 +358,119 @@ export -f curl
 	}
 	require.NoError(t, err)
 	assert.Equal(t, secretValue, strings.TrimSpace(string(out)))
+}
+
+// rawScriptLines reconstructs the raw bash script from a write_files
+// `content: |` block (each line indented 6 spaces further, see
+// secretFetchScript), so tests can run the actual generated script instead of
+// asserting on its text.
+func rawScriptLines(t *testing.T, wf string) []string {
+	t.Helper()
+	var raw []string
+	inContent := false
+	for _, line := range strings.Split(wf, "\n") {
+		if strings.Contains(line, "content: |") {
+			inContent = true
+			continue
+		}
+		if inContent {
+			raw = append(raw, strings.TrimPrefix(line, "      "))
+		}
+	}
+	require.NotEmpty(t, raw)
+	return raw
+}
+
+// curlRetrySetup returns the script lines through the closing brace of the
+// generated curl_retry() definition, dropping the /run write (no permission
+// to create it in a test sandbox).
+func curlRetrySetup(t *testing.T, wf string) []string {
+	t.Helper()
+	raw := rawScriptLines(t, wf)
+	var setup []string
+	inFunc := false
+	for _, line := range raw {
+		if strings.Contains(line, "mkdir -p /run/defang") {
+			continue
+		}
+		setup = append(setup, line)
+		if strings.Contains(line, "curl_retry() {") {
+			inFunc = true
+			continue
+		}
+		if inFunc && strings.TrimSpace(line) == "}" {
+			return setup
+		}
+	}
+	t.Fatal("curl_retry() definition not found in generated script")
+	return nil
+}
+
+// curl_retry must retry a failing request with backoff before giving up. This
+// runs the actual generated retry loop against a curl stub that fails twice
+// then succeeds, and a no-op sleep stub so the test doesn't block on the real
+// ~30s of backoff -- it asserts on attempt count and behavior, not timing.
+func TestSecretFetchScriptRetriesOnTransientFailure(t *testing.T) {
+	wf, _, _ := secretFetchScript("my-proj", "svc", []computeSecretEnv{{envKey: "DB", secretID: "my-secret"}})
+	setup := curlRetrySetup(t, wf)
+
+	script := `
+n=0
+sleeps=0
+curl() {
+  n=$((n+1))
+  [ "$n" -lt 3 ] && return 22
+  echo ok
+}
+export -f curl
+sleep() { sleeps=$((sleeps+1)); }
+export -f sleep
+` + strings.Join(setup, "\n") + `
+curl_retry -H test http://example.invalid || rc=$?
+echo "rc=${rc:-0} n=$n sleeps=$sleeps"
+`
+	//nolint:gosec // G204: script is test-authored, not external input
+	out, err := exec.CommandContext(t.Context(), "bash", "-c", script).Output()
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		t.Fatalf("script failed: %v\nstderr: %s", err, ee.Stderr)
+	}
+	require.NoError(t, err)
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	// Succeeds on the 3rd attempt, after 2 backoff sleeps. curl_retry's own
+	// stdout (the stubbed "ok" from the successful attempt) precedes this.
+	assert.Equal(t, "rc=0 n=3 sleeps=2", lines[len(lines)-1])
+}
+
+// Once curl_retry's attempts are exhausted it must give up rather than retry
+// forever, returning failure so the caller's existing fail-fast handling
+// (non-zero exit, stderr message, ExecStartPre failure) still applies.
+func TestSecretFetchScriptGivesUpAfterMaxAttempts(t *testing.T) {
+	wf, _, _ := secretFetchScript("my-proj", "svc", []computeSecretEnv{{envKey: "DB", secretID: "my-secret"}})
+	setup := curlRetrySetup(t, wf)
+
+	script := `
+n=0
+curl() {
+  n=$((n+1))
+  return 22
+}
+export -f curl
+sleep() { :; }
+export -f sleep
+` + strings.Join(setup, "\n") + `
+curl_retry -H test http://example.invalid || rc=$?
+echo "rc=${rc:-0} n=$n"
+`
+	//nolint:gosec // G204: script is test-authored, not external input
+	out, err := exec.CommandContext(t.Context(), "bash", "-c", script).Output()
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		t.Fatalf("script failed: %v\nstderr: %s", err, ee.Stderr)
+	}
+	require.NoError(t, err)
+	// 5 attempts total, then gives up -- never retries forever.
+	assert.Equal(t, "rc=1 n=5", strings.TrimSpace(string(out)))
 }
 
 // getCloudInitConfig must boot-fetch secret env (not inline it) while still


### PR DESCRIPTION
## Summary

Fixes #472.

- `secretFetchScript` (`provider/defanggcp/gcp/compute.go`) now generates a `curl_retry` bash helper wrapping both boot-time requests: the metadata-server token read and the per-secret Secret Manager `versions/latest:access` read.
- `curl_retry` retries a failing request with exponential backoff: 5 attempts total, sleeps of 2s/4s/8s/16s between them (~30s of backoff), on top of the existing per-request `--connect-timeout 5 --max-time 30` bound (added in cb19b10) — so the retry loop still cannot stall a boot indefinitely.
- Once attempts are exhausted, behavior is unchanged: non-zero exit, a clear stderr message, and `ExecStartPre` fails rather than starting the container with an empty secret.

This closes the real gap called out in #472: the instance template is *ordered* correctly behind the per-secret `secretAccessor` IAM binding, but ordering isn't propagation — GCP IAM changes can take up to several minutes to take effect, and a boot inside that window got a 403 with no retry. A transient metadata-server/network blip had the same failure mode.

## Test plan

- [x] `go test ./provider/defanggcp/...` — all green
- [x] Updated `TestSecretFetchScript` for the new script shape (the curl-bound string now appears once, in the shared `curl_retry` def, instead of once per call site)
- [x] Added `TestSecretFetchScriptRetriesOnTransientFailure` — runs the actual generated retry loop against a stubbed `curl` that fails twice then succeeds and a no-op `sleep` stub, asserting on attempt count/behavior (not real timing)
- [x] Added `TestSecretFetchScriptGivesUpAfterMaxAttempts` — same approach, asserts the loop gives up after exactly 5 attempts rather than retrying forever
- [x] `go vet ./provider/defanggcp/...`
- [x] `golangci-lint run ./provider/defanggcp/...` — no new issues beyond pre-existing `goconst` noise already present on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JD2UKYrkuJd6vQd4S4MfyH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when retrieving boot-time secrets by automatically retrying transient Secret Manager request failures.
  * Added exponential backoff and per-request timeouts, with retries limited to five attempts.
  * Prevented prolonged failures by enforcing a bounded retry period.

* **Tests**
  * Added coverage for successful recovery after temporary failures and failure after all retry attempts are exhausted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->