### PR TITLE
fix: give self-registered Build resources a PluginDownloadURL

### DIFF
--- a/provider/common/plugin.go
+++ b/provider/common/plugin.go
@@ -1,0 +1,92 @@
+package common
+
+import "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+// PluginDownloadURL is where Pulumi fetches this plugin from when it is not
+// already in the local plugin cache. Each provider's schema metadata publishes
+// it, so the generated SDKs bake it into every resource an end-user program
+// registers. It is also the fallback for PluginIdentityFrom when a caller
+// supplied none.
+const PluginDownloadURL = "github://api.github.com/DefangLabs/pulumi-defang"
+
+// PluginIdentity says which plugin serves our own resource types: where to
+// fetch it from, and which version of it to use.
+//
+// The engine hands both to Construct — the Pulumi Go SDK copies them out of
+// the ConstructRequest onto the component's resource options — but they stop
+// there. A component's children do not inherit them, so a resource of our own
+// package that we register from inside the provider process has to be given
+// them explicitly.
+//
+// Omitting them is not visible at deploy time. Without the URL the engine
+// synthesises a bare default provider and falls back to the conventional
+// plugin location github.com/pulumi/pulumi-<name>, which does not exist for
+// any of our packages. Without the version the checkpoint does not record
+// which plugin built the resource, so later operations resolve whatever is
+// newest and pay an unauthenticated GitHub API call to ask what "latest" is —
+// a call that is rate-limited per source IP. Neither costs anything during an
+// up, because resolving the SDK-registered provider has already put the plugin
+// binary in the local cache. Both strand the stack on destroy, from a fresh
+// workspace whose cache is empty, where nothing populates it.
+type PluginIdentity struct {
+	// DownloadURL is the plugin's pluginDownloadURL. Never empty after
+	// PluginIdentityFrom: it falls back to the PluginDownloadURL constant.
+	DownloadURL string
+	// Version is the plugin's semver, or "" for a build that carries none
+	// (a dev build has no -ldflags -X, and the generated SDKs omit the
+	// option in that case too).
+	Version string
+}
+
+// PluginIdentityFrom determines the plugin identity to use for our own child
+// resources, preferring what the caller asked for and falling back to what
+// this build knows about itself.
+//
+// fallbackVersion is the provider package's linker-initialized Version. Pass
+// it from Construct, where that variable is in scope. It may be "": a dev
+// build has no -ldflags -X, and the generated SDKs omit the version option in
+// that case too.
+//
+// Reading the options first mirrors GetChildOptions in pulumi-kubernetes' yaml
+// SDK, which propagates the caller's Version and PluginDownloadURL to the
+// children it registers. Today that read always comes back empty for us:
+// pulumi-go-provider's own ConstructRequest carries neither field, so its RPC
+// builder cannot populate them and the Go SDK has nothing to copy onto the
+// options it hands to Construct. Only Providers survives that trip. The read
+// is kept because it costs nothing, it is the behaviour we want the moment the
+// framework forwards them, and it lets a caller override.
+//
+// Thread the result down to the registration that needs it. It must not travel
+// as a ResourceOption: Version is per-package, so applying ours to a
+// neighbouring aws:/gcp:/azure: resource would send the engine looking for
+// that provider at our version.
+func PluginIdentityFrom(fallbackVersion string, opts ...pulumi.ResourceOption) PluginIdentity {
+	id := PluginIdentity{DownloadURL: PluginDownloadURL, Version: fallbackVersion}
+	snapshot, err := pulumi.NewResourceOptions(opts...)
+	if err != nil {
+		// Malformed options are the caller's problem and will resurface at
+		// registration; fall back rather than failing here.
+		return id
+	}
+	if snapshot.PluginDownloadURL != "" {
+		id.DownloadURL = snapshot.PluginDownloadURL
+	}
+	if snapshot.Version != "" {
+		id.Version = snapshot.Version
+	}
+	return id
+}
+
+// ResourceOptions prefixes opts with this identity, for registering one of our
+// own resource types. Later options win in the Pulumi Go SDK, so an explicit
+// value in opts still overrides.
+func (id PluginIdentity) ResourceOptions(opts ...pulumi.ResourceOption) []pulumi.ResourceOption {
+	defaults := make([]pulumi.ResourceOption, 0, len(opts)+2)
+	if id.DownloadURL != "" {
+		defaults = append(defaults, pulumi.PluginDownloadURL(id.DownloadURL))
+	}
+	if id.Version != "" {
+		defaults = append(defaults, pulumi.Version(id.Version))
+	}
+	return append(defaults, opts...)
+}

--- a/provider/defangaws/aws/image.go
+++ b/provider/defangaws/aws/image.go
@@ -78,6 +78,7 @@ func buildServiceImage(
 	serviceName string,
 	svc compose.ServiceConfig,
 	infra *BuildInfra,
+	pluginID common.PluginIdentity,
 	opts ...pulumi.ResourceOption,
 ) (*imageBuildResult, error) {
 	if svc.Build == nil {
@@ -118,7 +119,7 @@ func buildServiceImage(
 		"region":      pulumi.String(infra.region),
 		"destination": cbResult.destination,
 		"triggers":    pulumi.StringArray{triggerHash},
-	}, &buildResource, opts...)
+	}, &buildResource, pluginID.ResourceOptions(opts...)...)
 	if err != nil {
 		return nil, fmt.Errorf("creating CodeBuild build resource for %s: %w", serviceName, err)
 	}
@@ -138,10 +139,11 @@ func GetServiceImage(
 	serviceName string,
 	svc compose.ServiceConfig,
 	infra *BuildInfra,
+	pluginID common.PluginIdentity,
 	opts ...pulumi.ResourceOption,
 ) (pulumi.StringOutput, error) {
 	if svc.Build != nil && infra != nil {
-		result, err := buildServiceImage(ctx, serviceName, svc, infra, opts...)
+		result, err := buildServiceImage(ctx, serviceName, svc, infra, pluginID, opts...)
 		if err != nil {
 			return pulumi.StringOutput{}, err
 		}

--- a/provider/defangaws/project.go
+++ b/provider/defangaws/project.go
@@ -120,7 +120,11 @@ func (*Project) Construct(
 		return nil, err
 	}
 
-	result, err := buildProject(ctx, name, inputs, pulumi.Parent(comp))
+	// The engine gives Construct the plugin identity for our own package;
+	// children do not inherit it, so carry it to the Build registration.
+	pluginID := common.PluginIdentityFrom(Version, opts)
+
+	result, err := buildProject(ctx, name, inputs, pluginID, pulumi.Parent(comp))
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to build AWS resources: %w", err)
@@ -169,6 +173,7 @@ func buildProject(
 	ctx *pulumi.Context,
 	projectName string,
 	args ProjectInputs,
+	pluginID common.PluginIdentity,
 	parentOpt pulumi.ResourceOrInvokeOption,
 ) (*projectResult, error) {
 	awsConfig := (*provideraws.AWSConfig)(args.AWS)
@@ -241,7 +246,8 @@ func buildProject(
 
 		waitForHealthy := waitForSteady[svcName] || args.WaitForSteadyState
 		endpoint, dependency, svcComp, datastoreID, err := newService(
-			ctx, configProvider, svcName, svc, args.Networks, infra, sidecars[svcName], waitForHealthy, deps, parentOpt)
+			ctx, configProvider, svcName, svc, args.Networks, infra, sidecars[svcName], waitForHealthy, deps,
+			pluginID, parentOpt)
 		if err != nil {
 			return nil, fmt.Errorf("building service %s: %w", svcName, err)
 		}
@@ -316,6 +322,7 @@ func newService(
 	sidecars map[string]compose.ServiceConfig,
 	waitForSteadyState bool,
 	deps []pulumi.Resource,
+	pluginID common.PluginIdentity,
 	parentOpt pulumi.ResourceOrInvokeOption,
 ) (pulumi.StringOutput, pulumi.Resource, *ServiceOutputs, pulumi.StringInput, error) {
 	var endpoint pulumi.StringOutput
@@ -355,7 +362,7 @@ func newService(
 		if regErr := ctx.RegisterComponentResource(ServiceComponentType, svcName, svcComp, parentOpt); regErr != nil {
 			return pulumi.StringOutput{}, nil, nil, nil, fmt.Errorf("registering service component %s: %w", svcName, regErr)
 		}
-		imageURI, imgErr := provideraws.GetServiceImage(ctx, svcName, svc, infra.BuildInfra, pulumi.Parent(svcComp))
+		imageURI, imgErr := provideraws.GetServiceImage(ctx, svcName, svc, infra.BuildInfra, pluginID, pulumi.Parent(svcComp))
 		if imgErr != nil {
 			return pulumi.StringOutput{}, nil, nil, nil, fmt.Errorf("resolving image for %s: %w", svcName, imgErr)
 		}

--- a/provider/defangaws/provider.go
+++ b/provider/defangaws/provider.go
@@ -1,6 +1,8 @@
 package defangaws
 
 import (
+	"github.com/DefangLabs/pulumi-defang/provider/common"
+
 	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/infer"
 	"github.com/pulumi/pulumi-go-provider/middleware/schema"
@@ -43,7 +45,7 @@ func Provider() p.Provider {
 			Publisher:         "Defang",
 			LogoURL:           "https://raw.githubusercontent.com/DefangLabs/pulumi-defang/refs/heads/main/docs/logo.png",
 			License:           "Apache-2.0",
-			PluginDownloadURL: "github://api.github.com/DefangLabs/pulumi-defang",
+			PluginDownloadURL: common.PluginDownloadURL,
 			LanguageMap: map[string]any{
 				// pkg/v3/codegen/dotnet (CSharpPackageInfo) moved out of pulumi/pulumi
 				// after pkg v3.227; inline the equivalent schema JSON instead of

--- a/provider/defangazure/azure/image.go
+++ b/provider/defangazure/azure/image.go
@@ -155,6 +155,7 @@ func buildServiceImage(
 	svc compose.ServiceConfig,
 	infra *BuildInfra,
 	sharedInfra *SharedInfra,
+	pluginID common.PluginIdentity,
 	opts ...pulumi.ResourceOption,
 ) (*imageBuildResult, error) {
 	if svc.Build == nil {
@@ -201,7 +202,7 @@ func buildServiceImage(
 		"contextPath":        svc.Build.Context,
 		"encodedTaskContent": pulumi.String(encodedYAML),
 		"triggers":           pulumi.StringArray{triggerHash},
-	}, &buildResource, buildOpts...)
+	}, &buildResource, pluginID.ResourceOptions(buildOpts...)...)
 	if err != nil {
 		return nil, fmt.Errorf("creating ACRImage Build resource for %s: %w", serviceName, err)
 	}
@@ -218,10 +219,11 @@ func GetServiceImage(
 	svc compose.ServiceConfig,
 	buildInfra *BuildInfra,
 	sharedInfra *SharedInfra,
+	pluginID common.PluginIdentity,
 	opts ...pulumi.ResourceOption,
 ) (pulumi.StringOutput, error) {
 	if svc.Build != nil && buildInfra != nil {
-		result, err := buildServiceImage(ctx, serviceName, svc, buildInfra, sharedInfra, opts...)
+		result, err := buildServiceImage(ctx, serviceName, svc, buildInfra, sharedInfra, pluginID, opts...)
 		if err != nil {
 			return pulumi.StringOutput{}, err
 		}

--- a/provider/defangazure/project.go
+++ b/provider/defangazure/project.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/DefangLabs/pulumi-defang/provider/common"
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
 	providerazure "github.com/DefangLabs/pulumi-defang/provider/defangazure/azure"
 	"github.com/pulumi/pulumi-azure-native-sdk/app/v3"
@@ -222,6 +223,7 @@ func createServiceResources(
 	serviceIds pulumi.StringMap,
 	llmModels map[string]string,
 	dnsZones map[string]string,
+	pluginID common.PluginIdentity,
 	childOpts []pulumi.ResourceOption,
 ) (pulumi.StringOutput, error) {
 	comp := &serviceComponent{}
@@ -271,7 +273,7 @@ func createServiceResources(
 		if err := ctx.RegisterComponentResource(ServiceComponentType, svcName, svcComp, childOpts...); err != nil {
 			return pulumi.StringOutput{}, fmt.Errorf("registering Service component %s: %w", svcName, err)
 		}
-		imageURI, err := providerazure.GetServiceImage(ctx, svcName, svc, infra.BuildInfra, infra, pulumi.Parent(svcComp))
+		imageURI, err := providerazure.GetServiceImage(ctx, svcName, svc, infra.BuildInfra, infra, pluginID, pulumi.Parent(svcComp))
 		if err != nil {
 			return pulumi.StringOutput{}, fmt.Errorf("resolving image for %s: %w", svcName, err)
 		}
@@ -522,6 +524,10 @@ func (*Project) Construct(
 	parentOpt := pulumi.Parent(comp)
 	childOpts := []pulumi.ResourceOption{parentOpt}
 
+	// The engine gives Construct the plugin identity for our own package;
+	// children do not inherit it, so carry it to the Build registration.
+	pluginID := common.PluginIdentityFrom(Version, opts)
+
 	infra, llmModels, err := setupSharedInfra(ctx, name, inputs, parentOpt)
 	if err != nil {
 		return nil, err
@@ -547,7 +553,8 @@ func (*Project) Construct(
 			continue
 		}
 		endpoint, err := createServiceResources(
-			ctx, svcName, svc, infra, managedEndpoints, serviceHosts, serviceIds, llmModels, inputs.DnsZones, childOpts,
+			ctx, svcName, svc, infra, managedEndpoints, serviceHosts, serviceIds, llmModels, inputs.DnsZones,
+			pluginID, childOpts,
 		)
 		if err != nil {
 			return nil, err
@@ -559,7 +566,8 @@ func (*Project) Construct(
 			continue
 		}
 		endpoint, err := createServiceResources(
-			ctx, svcName, svc, infra, managedEndpoints, serviceHosts, serviceIds, llmModels, inputs.DnsZones, childOpts,
+			ctx, svcName, svc, infra, managedEndpoints, serviceHosts, serviceIds, llmModels, inputs.DnsZones,
+			pluginID, childOpts,
 		)
 		if err != nil {
 			return nil, err

--- a/provider/defangazure/project.go
+++ b/provider/defangazure/project.go
@@ -273,7 +273,8 @@ func createServiceResources(
 		if err := ctx.RegisterComponentResource(ServiceComponentType, svcName, svcComp, childOpts...); err != nil {
 			return pulumi.StringOutput{}, fmt.Errorf("registering Service component %s: %w", svcName, err)
 		}
-		imageURI, err := providerazure.GetServiceImage(ctx, svcName, svc, infra.BuildInfra, infra, pluginID, pulumi.Parent(svcComp))
+		imageURI, err := providerazure.GetServiceImage(
+			ctx, svcName, svc, infra.BuildInfra, infra, pluginID, pulumi.Parent(svcComp))
 		if err != nil {
 			return pulumi.StringOutput{}, fmt.Errorf("resolving image for %s: %w", svcName, err)
 		}

--- a/provider/defangazure/provider.go
+++ b/provider/defangazure/provider.go
@@ -1,6 +1,8 @@
 package defangazure
 
 import (
+	"github.com/DefangLabs/pulumi-defang/provider/common"
+
 	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/infer"
 	"github.com/pulumi/pulumi-go-provider/middleware/schema"
@@ -43,7 +45,7 @@ func Provider() p.Provider {
 			Publisher:         "Defang",
 			LogoURL:           "https://raw.githubusercontent.com/DefangLabs/pulumi-defang/refs/heads/main/docs/logo.png",
 			License:           "Apache-2.0",
-			PluginDownloadURL: "github://api.github.com/DefangLabs/pulumi-defang",
+			PluginDownloadURL: common.PluginDownloadURL,
 			LanguageMap: map[string]any{
 				// pkg/v3/codegen/dotnet (CSharpPackageInfo) moved out of pulumi/pulumi
 				// after pkg v3.227; inline the equivalent schema JSON instead of

--- a/provider/defanggcp/gcp/image.go
+++ b/provider/defanggcp/gcp/image.go
@@ -145,10 +145,11 @@ func GetServiceImage(
 	svc compose.ServiceConfig,
 	repos map[string]*artifactregistry.Repository,
 	infra *BuildInfra,
+	pluginID common.PluginIdentity,
 	opts ...pulumi.ResourceOption,
 ) (pulumi.StringOutput, error) {
 	if svc.Build != nil && infra != nil {
-		return buildServiceImage(ctx, serviceName, svc, infra, opts...)
+		return buildServiceImage(ctx, serviceName, svc, infra, pluginID, opts...)
 	}
 	if svc.Image == nil {
 		return pulumi.StringOutput{}, fmt.Errorf("service %s: %w", serviceName, common.ErrNoImageOrBuildConfig)
@@ -271,6 +272,7 @@ func buildServiceImage(
 	serviceName string,
 	svc compose.ServiceConfig,
 	infra *BuildInfra,
+	pluginID common.PluginIdentity,
 	opts ...pulumi.ResourceOption,
 ) (pulumi.StringOutput, error) {
 	dest := pulumi.Sprintf("%s/%s:latest", infra.RepositoryURL, serviceName)
@@ -309,7 +311,7 @@ func buildServiceImage(
 			"diskSizeGb":     pulumi.Int(cloudBuildDiskSizeGb(shmBytes)),
 		},
 		&buildRes,
-		buildOpts...,
+		pluginID.ResourceOptions(buildOpts...)...,
 	); err != nil {
 		return pulumi.StringOutput{}, fmt.Errorf("creating Build resource for %s: %w", serviceName, err)
 	}

--- a/provider/defanggcp/gcp/image_test.go
+++ b/provider/defanggcp/gcp/image_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
+	"github.com/DefangLabs/pulumi-defang/provider/common"
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
 )
 
@@ -219,7 +220,7 @@ func TestGetServiceImage(t *testing.T) {
 			var gotImage string
 			var wg sync.WaitGroup
 			err := pulumi.RunErr(func(ctx *pulumi.Context) error {
-				got, err := GetServiceImage(ctx, "svc", tt.svc, tt.repos, tt.infra)
+				got, err := GetServiceImage(ctx, "svc", tt.svc, tt.repos, tt.infra, common.PluginIdentity{})
 				if tt.wantErr {
 					assert.Error(t, err)
 					return nil
@@ -442,7 +443,7 @@ func TestBuildServiceImageDependsOnBucketIAMMember(t *testing.T) {
 			},
 		}
 
-		_, err = buildServiceImage(ctx, "my-svc", svc, infra)
+		_, err = buildServiceImage(ctx, "my-svc", svc, infra, common.PluginIdentity{})
 		return err
 	}, pulumi.WithMocks("proj", "stack", spy))
 

--- a/provider/defanggcp/project.go
+++ b/provider/defanggcp/project.go
@@ -65,7 +65,11 @@ func (*Project) Construct(
 
 	childOpt := pulumi.Parent(comp)
 
-	result, err := buildProject(ctx, name, inputs, childOpt)
+	// The engine gives Construct the plugin identity for our own package;
+	// children do not inherit it, so carry it to the Build registration.
+	pluginID := common.PluginIdentityFrom(Version, opts)
+
+	result, err := buildProject(ctx, name, inputs, pluginID, childOpt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build GCP resources: %w", err)
 	}
@@ -91,6 +95,7 @@ func buildProject(
 	ctx *pulumi.Context,
 	projectName string,
 	args ProjectInputs,
+	pluginID common.PluginIdentity,
 	parentOpt pulumi.ResourceOption,
 ) (*projectResult, error) {
 	childOpts := []pulumi.ResourceOption{parentOpt}
@@ -141,7 +146,7 @@ func buildProject(
 		}
 
 		endpoint, svcComp, lbEntry, datastoreID, err := buildService(
-			ctx, projectName, configProvider, svcName, svc, config, deps, childOpts)
+			ctx, projectName, configProvider, svcName, svc, config, deps, pluginID, childOpts)
 		if err != nil {
 			return nil, err
 		}
@@ -189,6 +194,7 @@ func buildService(
 	svc compose.ServiceConfig,
 	infra *providergcp.SharedInfra,
 	deps []pulumi.Resource,
+	pluginID common.PluginIdentity,
 	childOpts []pulumi.ResourceOption,
 ) (pulumi.StringOutput, pulumi.Resource, *providergcp.LBServiceEntry, pulumi.StringInput, error) {
 	var endpoint pulumi.StringOutput
@@ -235,7 +241,7 @@ func buildService(
 		if err := ctx.RegisterComponentResource(ServiceComponentType, svcName, svcCompTyped, svcChildOpts...); err != nil {
 			return pulumi.StringOutput{}, nil, nil, nil, fmt.Errorf("registering Service component %s: %w", svcName, err)
 		}
-		image, err := providergcp.GetServiceImage(ctx, svcName, svc, infra.Repos, infra.BuildInfra, svcChildOpts...)
+		image, err := providergcp.GetServiceImage(ctx, svcName, svc, infra.Repos, infra.BuildInfra, pluginID, svcChildOpts...)
 		if err != nil {
 			return pulumi.StringOutput{}, nil, nil, nil, fmt.Errorf("resolving image for %s: %w", svcName, err)
 		}

--- a/provider/defanggcp/provider.go
+++ b/provider/defanggcp/provider.go
@@ -1,6 +1,8 @@
 package defanggcp
 
 import (
+	"github.com/DefangLabs/pulumi-defang/provider/common"
+
 	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/infer"
 	"github.com/pulumi/pulumi-go-provider/middleware/schema"
@@ -43,7 +45,7 @@ func Provider() p.Provider {
 			Publisher:         "Defang",
 			LogoURL:           "https://raw.githubusercontent.com/DefangLabs/pulumi-defang/refs/heads/main/docs/logo.png",
 			License:           "Apache-2.0",
-			PluginDownloadURL: "github://api.github.com/DefangLabs/pulumi-defang",
+			PluginDownloadURL: common.PluginDownloadURL,
 			LanguageMap: map[string]any{
 				// pkg/v3/codegen/dotnet (CSharpPackageInfo) moved out of pulumi/pulumi
 				// after pkg v3.227; inline the equivalent schema JSON instead of

--- a/tests/aws/project_test.go
+++ b/tests/aws/project_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/DefangLabs/pulumi-defang/provider/common"
+	defangaws "github.com/DefangLabs/pulumi-defang/provider/defangaws"
 	awsprov "github.com/DefangLabs/pulumi-defang/provider/defangaws/aws"
 	"github.com/DefangLabs/pulumi-defang/tests/testutil"
 )
@@ -317,4 +319,38 @@ func TestConstructAwsProjectDuplicatePoliciesDeduped(t *testing.T) {
 		}
 	}
 	assert.Equal(t, 1, count, "duplicate x-defang-policies entries must be deduped")
+}
+
+// TestConstructAwsProjectBuildCarriesPluginIdentity asserts that the Build
+// resource the provider registers for itself tells the engine both where to
+// fetch the plugin from and which version of it to use. Registrations that go
+// through a generated SDK get both for free; the ones we make with a raw
+// ctx.RegisterResource do not, and omitting them strands the stack on destroy.
+// See common.PluginIdentityFrom.
+func TestConstructAwsProjectBuildCarriesPluginIdentity(t *testing.T) {
+	// Pin a version the way the linker does for a release build, so the
+	// assertion covers the version as well as the URL.
+	prev := defangaws.Version
+	defangaws.Version = "9.9.9"
+	t.Cleanup(func() { defangaws.Version = prev })
+
+	mock, tracker := testutil.NewPluginTracker()
+	server := testutil.MakeAwsTestServer(integration.WithMocks(mock))
+
+	_, err := server.Construct(p.ConstructRequest{
+		Urn: testutil.AwsURN("Project"),
+		Inputs: property.NewMap(map[string]property.Value{
+			"domain": property.New("example.com"),
+			"services": property.New(property.NewMap(map[string]property.Value{
+				"builder": property.New(property.NewMap(map[string]property.Value{
+					"build": property.New(property.NewMap(map[string]property.Value{
+						"context": property.New("s3://bucket/uploads/digest.tar.gz"),
+					})),
+				})),
+			})),
+		}),
+	})
+	require.NoError(t, err)
+
+	tracker.AssertOwnCustomResourcesCarryPluginIdentity(t, common.PluginDownloadURL, "9.9.9")
 }

--- a/tests/azure/project_test.go
+++ b/tests/azure/project_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/require"
 
+	"github.com/DefangLabs/pulumi-defang/provider/common"
+	defangazure "github.com/DefangLabs/pulumi-defang/provider/defangazure"
 	"github.com/DefangLabs/pulumi-defang/tests/testutil"
 )
 
@@ -129,4 +131,35 @@ func TestConstructAzureProjectRejectsApplicablePolicies(t *testing.T) {
 	})
 
 	require.ErrorContains(t, err, "x-defang-policies is not supported on Azure")
+}
+
+// TestConstructAzureProjectBuildCarriesPluginIdentity asserts that the Build
+// resource the provider registers for itself tells the engine both where to
+// fetch the plugin from and which version of it to use. Registrations that go
+// through a generated SDK get both for free; the ones we make with a raw
+// ctx.RegisterResource do not, and omitting them strands the stack on destroy.
+// See common.PluginIdentityFrom.
+func TestConstructAzureProjectBuildCarriesPluginIdentity(t *testing.T) {
+	// Pin a version the way the linker does for a release build, so the
+	// assertion covers the version as well as the URL.
+	prev := defangazure.Version
+	defangazure.Version = "9.9.9"
+	t.Cleanup(func() { defangazure.Version = prev })
+
+	mock, tracker := testutil.NewPluginTracker()
+	server := testutil.MakeAzureTestServer(integration.WithMocks(mock))
+
+	_, err := server.Construct(p.ConstructRequest{
+		Urn: testutil.AzureURN("Project"),
+		Inputs: testutil.ServicesMap(map[string]property.Value{
+			"builder": property.New(property.NewMap(map[string]property.Value{
+				"build": property.New(property.NewMap(map[string]property.Value{
+					"context": property.New("https://acct.blob.core.windows.net/uploads/digest.tar.gz?sig=x"),
+				})),
+			})),
+		}),
+	})
+	require.NoError(t, err)
+
+	tracker.AssertOwnCustomResourcesCarryPluginIdentity(t, common.PluginDownloadURL, "9.9.9")
 }

--- a/tests/gcp/project_test.go
+++ b/tests/gcp/project_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/DefangLabs/pulumi-defang/provider/common"
 	defanggcp "github.com/DefangLabs/pulumi-defang/provider/defanggcp"
 	"github.com/DefangLabs/pulumi-defang/tests/testutil"
 )
@@ -1310,4 +1311,39 @@ func TestConstructGcpProjectDuplicatePoliciesDeduped(t *testing.T) {
 		return m.Get("role").AsString() == "roles/run.developer"
 	})
 	assert.Equal(t, 1, members, "duplicate x-defang-policies entries must be deduped")
+}
+
+// TestConstructGcpProjectBuildCarriesPluginIdentity asserts that the Build
+// resource the provider registers for itself tells the engine both where to
+// fetch the plugin from and which version of it to use. Registrations that go
+// through a generated SDK get both for free; the ones we make with a raw
+// ctx.RegisterResource do not, and omitting them strands the stack on destroy.
+// See common.PluginIdentityFrom.
+func TestConstructGcpProjectBuildCarriesPluginIdentity(t *testing.T) {
+	// Pin a version the way the linker does for a release build, so the
+	// assertion covers the version as well as the URL.
+	prev := defanggcp.Version
+	defanggcp.Version = "9.9.9"
+	t.Cleanup(func() { defanggcp.Version = prev })
+
+	mock, tracker := testutil.NewPluginTracker()
+	server := testutil.MakeGcpTestServer(integration.WithMocks(mock))
+
+	_, err := server.Construct(p.ConstructRequest{
+		Urn:    testutil.GcpURN("Project"),
+		Config: testutil.StackConfig("defang:stateUrl", "gs://defang-cd-test"),
+		Inputs: property.NewMap(map[string]property.Value{
+			"domain": property.New("example.com"),
+			"services": property.New(property.NewMap(map[string]property.Value{
+				"builder": property.New(property.NewMap(map[string]property.Value{
+					"build": property.New(property.NewMap(map[string]property.Value{
+						"context": property.New("gs://defang-cd-test/uploads/sha256-abc.tar.gz"),
+					})),
+				})),
+			})),
+		}),
+	})
+	require.NoError(t, err)
+
+	tracker.AssertOwnCustomResourcesCarryPluginIdentity(t, common.PluginDownloadURL, "9.9.9")
 }

--- a/tests/testutil/plugin_check.go
+++ b/tests/testutil/plugin_check.go
@@ -1,0 +1,118 @@
+package testutil
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/pulumi/pulumi-go-provider/integration"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+)
+
+// ownPackages are the resource-package prefixes this repo publishes. A type
+// token starting with one of these names a resource served by our own plugin.
+var ownPackages = []string{"defang-aws:", "defang-gcp:", "defang-azure:"}
+
+// PluginRecord captures what a single resource registration told the engine
+// about which plugin serves it.
+type PluginRecord struct {
+	Type              string
+	Name              string
+	Custom            bool
+	PluginDownloadURL string
+	Version           string
+}
+
+// PluginTracker records the plugin identity of every resource registered
+// through the mock monitor.
+type PluginTracker struct {
+	mu      sync.Mutex
+	records []PluginRecord
+}
+
+// NewPluginTracker returns a mock monitor paired with a tracker that captures
+// the PluginDownloadURL of every resource registered during Construct. The
+// mock echoes inputs back unchanged so it composes with any other test that
+// only needs Construct to succeed.
+func NewPluginTracker() (*integration.MockResourceMonitor, *PluginTracker) {
+	pt := &PluginTracker{}
+	mock := &integration.MockResourceMonitor{
+		NewResourceF: func(args integration.MockResourceArgs) (string, property.Map, error) {
+			rec := PluginRecord{Type: string(args.TypeToken), Name: args.Name}
+			// Both fields come from the RegisterResource RPC; mocks
+			// synthesized without one (e.g. ReadResource) leave them zero.
+			if args.RegisterRPC != nil {
+				rec.Custom = args.RegisterRPC.GetCustom()
+				rec.PluginDownloadURL = args.RegisterRPC.GetPluginDownloadURL()
+				rec.Version = args.RegisterRPC.GetVersion()
+			}
+			pt.mu.Lock()
+			pt.records = append(pt.records, rec)
+			pt.mu.Unlock()
+			return args.Name, args.Inputs, nil
+		},
+	}
+	return mock, pt
+}
+
+// Records returns a copy of the recorded registrations.
+func (pt *PluginTracker) Records() []PluginRecord {
+	pt.mu.Lock()
+	defer pt.mu.Unlock()
+	out := make([]PluginRecord, len(pt.records))
+	copy(out, pt.records)
+	return out
+}
+
+// AssertOwnCustomResourcesCarryPluginIdentity asserts that every CUSTOM
+// resource we register from one of our own packages tells the engine both
+// where to fetch the plugin from and which version of it to use.
+//
+// Without the URL the engine synthesises a bare default provider and falls
+// back to github.com/pulumi/pulumi-<name>, which does not exist for our
+// packages. Without the version the checkpoint does not record which plugin
+// built the resource, so later operations resolve whatever is newest and pay
+// an unauthenticated GitHub API call to ask what "latest" is. Both faults are
+// invisible during an up and strand the stack on destroy. See
+// common.PluginIdentityFrom.
+//
+// Component resources are exempt: the engine deletes them without loading a
+// plugin, so they never trigger the lookup.
+//
+// It asserts at least one own custom resource was seen, so a fixture that
+// stops exercising the build path fails loudly instead of passing vacuously.
+//
+// Failures are reported as test errors (not fatals) so a single run surfaces
+// every offending registration at once.
+func (pt *PluginTracker) AssertOwnCustomResourcesCarryPluginIdentity(t *testing.T, wantURL, wantVersion string) {
+	t.Helper()
+
+	seen := 0
+	for _, r := range pt.Records() {
+		if !r.Custom || !isOwnPackage(r.Type) {
+			continue
+		}
+		seen++
+		if r.PluginDownloadURL != wantURL {
+			t.Errorf("resource name=%q type=%s registered with PluginDownloadURL=%q, want %q",
+				r.Name, r.Type, r.PluginDownloadURL, wantURL)
+		}
+		if r.Version != wantVersion {
+			t.Errorf("resource name=%q type=%s registered with Version=%q, want %q",
+				r.Name, r.Type, r.Version, wantVersion)
+		}
+	}
+	if seen == 0 {
+		t.Errorf("no custom resources from our own packages were registered; "+
+			"the fixture no longer exercises the path this guards (records=%d)", len(pt.Records()))
+	}
+}
+
+func isOwnPackage(typeToken string) bool {
+	for _, p := range ownPackages {
+		if strings.HasPrefix(typeToken, p) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## The symptom

A stack that builds from source cannot be destroyed by any Pulumi run whose plugin cache holds no `defang-<cloud>` plugin — a plain `pulumi destroy` from a fresh workspace, or a CD container that bakes a different cloud's plugins:

```
error: could not load provider for resource
urn:...::defang-aws:index:Project$defang-aws:index:Service$defang-aws:index:Build::app:
could not create provider urn:...::pulumi:providers:defang-aws::default::f4b1f4bb-...:
load plugin for defang-aws provider: could not find latest version for provider defang-aws:
404 HTTP error fetching plugin from
https://api.github.com/repos/pulumi/pulumi-defang-aws/releases/latest
```

`pulumi/pulumi-defang-aws` has never existed. `DefangLabs/pulumi-defang` is fine — the engine asks for the wrong repo because the `Build` resource never says where its plugin comes from, so the engine falls back to the conventional `pulumi/pulumi-<name>` location.

## The cause

Each provider publishes its download URL in schema metadata (`provider/defang*/provider.go`), and the codegen bakes it into the generated SDKs' default resource options (`sdk/v2/go/*/internal/pulumiUtilities.go`). Every resource an end-user program registers therefore carries it.

`Build` does not. It is registered from inside the provider process with a raw `ctx.RegisterResource(type, ...)`, and that path applies no package defaults. The call passes `pulumi.Parent(...)` but nothing about plugin identity — neither the URL nor the version.

The checkpoint ends up with two default providers for one package:

| Provider URN | `pluginDownloadURL` | Referenced by |
|---|---|---|
| `...defang-aws::default_github_/api.github.com/DefangLabs/pulumi-defang` | present | **0 resources** |
| `...defang-aws::default` | **absent** | `Build::app` |

The URL goes to the provider nobody needs. The provider that does the work never gets it. The parent chain cannot supply a fallback either: `Build`'s parent is the `Service` component, and a component records no provider of its own (`custom: false`, no `provider` field).

## Why it has gone unnoticed

Three separate things hide it, and all three have to miss before anything breaks.

**1. `up` never fails.** Resolving the SDK-registered provider has already put the plugin binary in the local cache, so the bare provider finds it there and never calls GitHub. Destroy does not run the program, so on that path nothing warms the cache.

**2. A warm cache hides it on destroy too.** The bare provider records no version, and a versionless request matches *any* installed version of that plugin (`LegacySelectCompatiblePlugin` in pulumi/sdk `workspace/plugins.go` — with `spec.Version == nil` it accepts the first plugin of that name it finds). Each CD image installs its own cloud's plugin into `/root/.pulumi/plugins` (`Dockerfile`, `plugins-<cloud>-defang` stages), so a destroy run by the matching CD image resolves locally and never asks GitHub. That is why the sanity runs tear their stacks down cleanly.

**3. Most stacks have no `Build` resource of ours at all.** AWS and GCP production still deploy through the legacy node CD; only Azure has cut over. A legacy stack's checkpoint contains no `defang-aws:index:Build`, so there is no versionless provider to resolve.

The stranded stack hit all three at once. `html-css-js/newprovideraws` was deployed by the new AWS CD image (`cd:v2.6.0-aws`, `defang-aws` baked in), and the nightly BYOC cleanup then tried to destroy it with `defang cd down --allow-upgrade`, which runs the **production** CD image for AWS — the legacy node one (`Running command mkdir -p /app && cd /app && node lib/index.js down` in the run log). That image installs `aws`, `awsx`, `digitalocean` and `tls` only (defang-mvp `pulumi/cd.Dockerfile`), so `defang-aws` had to come over the network, and the bare provider had no address to fetch it from. It failed for four consecutive days ([defang-mvp#3204](https://github.com/DefangLabs/defang-mvp/issues/3204)) and only came to light because someone went looking for two Elastic IPs that would not release.

So this is not a claim that destroys are broken today — it is a latent hazard that the AWS/GCP cutover ([defang-mvp#3084](https://github.com/DefangLabs/defang-mvp/pull/3084)) would make routine, since after it every production stack carries the versionless provider and any destroy run outside a matched CD image hits the 404.

## The change

Adds `common.PluginIdentity`, carrying the URL and version for our own resource types, threaded from each `Project.Construct` down to the `Build` registration and applied there.

It travels as a **value, not a `ResourceOption`**. `Version` is per-package, and `createCodeBuildProject` shares the same `opts` as the `Build` registration — so letting the identity ride along in those options would hand our version to an `aws:codebuild/project` and send the engine looking for the AWS provider at version 2.6.0. **All three clouds are affected identically** — a fix to only the AWS path would look complete and would not be:

- `provider/defangaws/aws/image.go` — `defang-aws:index:Build`
- `provider/defangazure/azure/image.go` — `defang-azure:index:Build`
- `provider/defanggcp/gcp/image.go` — `defang-gcp:defanggcp:Build`

These are the only three `ctx.RegisterResource` calls in `provider/`, and `Build` is the only `infer.Resource` in each provider, so this is the complete set.

The three schema literals now reference the same constant, so the value has one home instead of four. **The emitted schema is unchanged** (same string), so no SDK regeneration is needed.

### The version matters as much as the URL

Without it the checkpoint does not record which plugin built the resource, so a later operation resolves whatever is newest rather than what deployed it. Every resolution also costs an unauthenticated GitHub API call asking what "latest" is, and that call is rate-limited per source IP. On the real stranded stack, fixing only the URL moved the failure from a 404 to:

```
could not find latest version for provider defang-aws: rate limit exceeded: 403 HTTP error
fetching plugin from https://api.github.com/repos/DefangLabs/pulumi-defang/releases/latest
```

For contrast, the same checkpoint records `version` 7.42.0 for `aws` and 3.8.0 for `awsx`, and nothing for either `defang-aws` entry.

The version is read in `Construct`, where the provider package's linker-initialized `Version` is already in scope — no global state.

### Why this only bites us

The engine's fallback is `github.com/pulumi/pulumi-<name>`. For a first-party package like `kubernetes` that resolves to a real repo, so the same omission is harmless there. For `defang-aws` it resolves to `pulumi/pulumi-defang-aws`, which does not exist. This class of bug is structurally confined to third-party providers whose package name does not map onto a pulumi-org repo — which is why the pattern survives upstream unnoticed.

### Alternatives considered

**Import our own generated SDK.** `defangaws.NewBuild` routes through `internal.PkgResourceDefaultOpts`, so URL and version would come for free and never drift from the schema. This is what `pulumi-kubernetes` does — its provider imports `sdk/v4/go/kubernetes/yaml/v2` with `replace github.com/pulumi/pulumi-kubernetes/sdk/v4 => ../sdk` in `provider/go.mod`. Not taken here: `sdk/v2/go/defang-*` are separate modules that `provider/` imports nowhere, so adopting them makes the provider depend on its own generated SDK and closes a loop in `build: provider schema sdks`. Worth doing deliberately, not smuggled into a bug fix.

**Propagate from the caller's options.** `pulumi-kubernetes`' `GetChildOptions` reads `Version` and `PluginDownloadURL` off the incoming options with `pulumi.NewResourceOptions` and re-applies them to children. That is the pattern this PR follows in `PluginIdentityFrom` — but the read currently always returns empty for us, because `pulumi-go-provider`'s `ConstructRequest` carries neither field, so its RPC builder cannot populate them and the Go SDK has nothing to copy onto the options `Construct` receives. Only `Providers` survives that trip. (`pulumi-kubernetes` is unaffected because that path is a hand-written provider on the Go SDK's `provider.Construct`, not this framework.) The read is kept because it costs nothing, it is the behaviour we want the moment the framework forwards them, and it lets a caller override. Until then the version comes from the provider's own linker-initialized `Version`.

If you would like, the framework gap looks worth an upstream issue against `pulumi-go-provider`.

## Test

`tests/testutil/plugin_check.go` adds a `PluginTracker` in the style of the existing `parent_check.go`, reading `PluginDownloadURL`, `Version` and `Custom` off the RegisterResource RPC. It asserts every custom resource from our own packages registers with both the URL and the running version — each test pins `Version` the way the linker does — and errors if none were seen — so it cannot start passing vacuously if a fixture stops exercising the build path. One test per cloud.

## Verification — please read

I could not run the full build or the test suite. I authored this on a 2 vCPU / 4 GiB ARM box, and `pulumi-gcp/sdk/v9/go/gcp/compute` and `pulumi-azure-native-sdk/network/v3` each exceed its memory; the Go compiler is OOM-killed (`signal: terminated`) even at `-p 1` with `GOGC=20`. `tests/testutil` imports all three clouds, so the tests cannot compile there either.

What I did verify locally:

- `gofmt -l` — clean on all 11 changed/added files
- `go build` and `go vet ./provider/common/` — pass (the new helper)
- `go build` and `go vet ./provider/defangaws/...` — pass (the full AWS threading)

The GCP and Azure changes mirror the verified AWS ones hop for hop, but this PR threads a parameter through several signatures in each provider, so please treat CI as the real gate rather than my word — a missed call site would surface there, not here.

## Existing stacks

This fixes new deployments. Stacks already deployed keep the bare provider in their checkpoint and will still fail to destroy. The workaround is to add the field to the `default` provider's inputs in the checkpoint:

```json
"__internal": { "pluginDownloadURL": "github://api.github.com/DefangLabs/pulumi-defang" }
```

Worth considering whether the CD path should repair this automatically, since affected stacks cannot be deleted any other way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsqGhkpjsb4kKAdVz25xKN


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added plugin identity support for provider-created resources, including download URL and version metadata.
  - Preserved caller-provided resource settings while applying provider identity defaults.
  - Applied consistent plugin metadata to AWS, Azure, and GCP build resources.
  - Provider downloads now use a shared plugin URL configuration.

- **Tests**
  - Added coverage verifying plugin URL and version metadata across AWS, Azure, and GCP project builds.
  - Added utilities for tracking and validating resource plugin identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->