### PR TITLE
ci: apply the 7-day Dependabot cooldown to gomod and docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,8 @@ updates:
       - "/cd"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       # azure-native is the only Pulumi SDK we use that ships as many
       # independently-versioned subpackages (app/v3, network/v3,
@@ -51,3 +53,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Follow-up to the cooldown policy applied in DefangLabs/portal#1029: every Dependabot entry should carry a 7-day cooldown.

The `github-actions` entry here already had `cooldown: default-days: 7`. The `gomod` and `docker` entries did not, so version bumps in those ecosystems were proposed as soon as a release appeared. Four-line diff:

```yaml
  - package-ecosystem: "gomod"
    ...
    cooldown:
      default-days: 7

  - package-ecosystem: "docker"
    ...
    cooldown:
      default-days: 7
```

## Security updates are not delayed

Worth being explicit, since this repo has a `gomod-security` group with `applies-to: security-updates`: cooldown applies to **version** updates only. Per the options reference, *"The `cooldown` option is only available for version updates, not security updates."* So the security group keeps opening PRs immediately — this change cannot slow down a CVE fix.

## Why `default-days` and nothing else

`default-days` is the one cooldown key supported across every ecosystem. `gomod` also accepts the `semver-*-days` variants but `docker` does not, so both entries use `default-days` for consistency. An invalid `dependabot.yml` fails closed — Dependabot stops rather than warning — so the narrower key is the safe choice.

Also note GitHub made a **3-day cooldown the default** for version updates on 2026-07-14, so this widens an existing delay rather than introducing one.

## Verification

`.github/dependabot.yml` parses and all three entries now report `default-days: 7`. The existing `pulumi-azure-native-sdk`, `gomod-security` and `github-actions` groups are untouched, as are the comments explaining the explicit `directories` lists.