### PR TITLE
feat(aws): dispatch x-defang-s3 from the project and grant dependents bucket access

### DIFF
--- a/cd/program/aws.go
+++ b/cd/program/aws.go
@@ -174,6 +174,11 @@ func toAWSServiceArgs(svc compose.ServiceConfig) awscompose.ServiceConfigArgs {
 			FromSnapshot:  pulumi.StringPtrFromPtr(svc.Redis.FromSnapshot),
 		}
 	}
+	if svc.ObjectStore != nil {
+		args.ObjectStore = awscompose.ObjectStoreConfigArgs{
+			Bucket: pulumi.String(svc.ObjectStore.Bucket),
+		}
+	}
 	if svc.HealthCheck != nil {
 		args.HealthCheck = awscompose.HealthCheckConfigArgs{
 			Test:               pulumi.ToStringArray(svc.HealthCheck.Test),

--- a/cd/program/aws_test.go
+++ b/cd/program/aws_test.go
@@ -1,0 +1,32 @@
+package program
+
+import (
+	"testing"
+
+	"github.com/DefangLabs/pulumi-defang/provider/compose"
+	awscompose "github.com/DefangLabs/pulumi-defang/sdk/v2/go/defang-aws/compose"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// toAWSServiceArgs copies the compose service into the SDK args field by
+// field, so a managed extension the copy forgets is dropped in silence: the
+// provider sees no extension and deploys the service as an ordinary ECS task.
+// That is how x-defang-s3 reached AWS as a MinIO container on its first
+// end-to-end run, with the bucket never created.
+func TestToAWSServiceArgsCarriesManagedExtensions(t *testing.T) {
+	args := toAWSServiceArgs(compose.ServiceConfig{
+		Image:       pulumi.String("minio/minio"),
+		ObjectStore: &compose.ObjectStoreConfig{Bucket: "proj-uploads"},
+	})
+
+	store, ok := args.ObjectStore.(awscompose.ObjectStoreConfigArgs)
+	require.True(t, ok, "x-defang-s3 did not survive the copy into ServiceConfigArgs")
+	assert.Equal(t, pulumi.String("proj-uploads"), store.Bucket)
+}
+
+func TestToAWSServiceArgsWithoutObjectStore(t *testing.T) {
+	args := toAWSServiceArgs(compose.ServiceConfig{Image: pulumi.String("nginx")})
+	assert.Nil(t, args.ObjectStore)
+}

--- a/provider/defangaws/aws/ecs.go
+++ b/provider/defangaws/aws/ecs.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"slices"
 	"strconv"
@@ -168,6 +169,11 @@ type ECSServiceArgs struct {
 	// Keyed by service name; volumesFrom/dependsOn on the main service may
 	// reference these names.
 	Sidecars map[string]compose.ServiceConfig
+	// ObjectStoreArns are the S3 bucket ARNs this service is granted access
+	// to, keyed by the x-defang-s3 service name that owns each bucket. Ignored
+	// when TaskRoleArn is caller-supplied — the caller owns that role's
+	// policies, same as the route53/bedrock/x-defang-policies attachments.
+	ObjectStoreArns map[string]pulumi.StringInput
 	// Triggers force a service redeployment when any value changes.
 	Triggers pulumi.StringMapInput
 }
@@ -508,6 +514,17 @@ func CreateECSService(
 			}, parentOpt)
 			if err != nil {
 				return nil, fmt.Errorf("attaching bedrock policy: %w", err)
+			}
+			lbDependsOn = append(lbDependsOn, dep)
+		}
+
+		// Grant access to the buckets of the x-defang-s3 services this one
+		// depends on. Sorted for a deterministic resource name per store.
+		for _, storeName := range slices.Sorted(maps.Keys(args.ObjectStoreArns)) {
+			dep, err := attachObjectStorePolicy(
+				ctx, taskRole, serviceName, storeName, args.ObjectStoreArns[storeName], parentOpt)
+			if err != nil {
+				return nil, fmt.Errorf("granting %s access to object store %q: %w", serviceName, storeName, err)
 			}
 			lbDependsOn = append(lbDependsOn, dep)
 		}

--- a/provider/defangaws/aws/iam.go
+++ b/provider/defangaws/aws/iam.go
@@ -146,6 +146,69 @@ func attachPullThroughCachePolicy(
 	return err
 }
 
+// objectStoreActions are the S3 actions granted to a service that depends on
+// an x-defang-s3 store, split by the ARN they apply to.
+//
+// The bucket-level half is not optional: HeadBucket — what many S3 clients
+// call at startup to check their credentials — is authorized by s3:ListBucket
+// on the BUCKET ARN, and no object-level action covers it. A grant of only the
+// object actions lets every read and write succeed while that probe returns
+// 403, and a client that treats the probe as fatal then disables storage for
+// the life of the process. GetBucketLocation is here for the SDKs that resolve
+// the region before their first call.
+var (
+	objectStoreBucketActions = []string{
+		"s3:ListBucket",
+		"s3:GetBucketLocation",
+		"s3:ListBucketMultipartUploads",
+	}
+	objectStoreObjectActions = []string{
+		"s3:GetObject",
+		"s3:PutObject",
+		"s3:DeleteObject",
+		"s3:AbortMultipartUpload",
+		"s3:ListMultipartUploadParts",
+	}
+)
+
+// attachObjectStorePolicy grants serviceName's task role access to one
+// x-defang-s3 bucket, named by storeName. Inline rather than a managed policy:
+// the document names a single bucket ARN, so it has exactly one consumer.
+func attachObjectStorePolicy(
+	ctx *pulumi.Context,
+	taskRole *iam.Role,
+	serviceName string,
+	storeName string,
+	bucketArn pulumi.StringInput,
+	opts ...pulumi.ResourceOption,
+) (pulumi.Resource, error) {
+	policyJson := bucketArn.ToStringOutput().ApplyT(func(arn string) (string, error) {
+		b, err := json.Marshal(PolicyDocument{
+			Version: "2012-10-17",
+			Statement: []PolicyStatement{
+				{
+					Sid:      "AllowObjectStoreBucket",
+					Effect:   "Allow",
+					Action:   objectStoreBucketActions,
+					Resource: arn,
+				},
+				{
+					Sid:      "AllowObjectStoreObjects",
+					Effect:   "Allow",
+					Action:   objectStoreObjectActions,
+					Resource: arn + "/*",
+				},
+			},
+		})
+		return string(b), err
+	}).(pulumi.StringOutput)
+
+	return iam.NewRolePolicy(ctx, serviceName+"-objectstore-"+storeName, &iam.RolePolicyArgs{
+		Role:   taskRole.Name,
+		Policy: policyJson,
+	}, opts...)
+}
+
 // resolvePolicyArn turns an x-defang-policies entry into a policy ARN. Full
 // ARNs pass through; bare names resolve to a customer-managed policy in the
 // caller's account (matches makeArn in defang-mvp: partition "aws", no region).

--- a/provider/defangaws/project.go
+++ b/provider/defangaws/project.go
@@ -15,7 +15,7 @@ var (
 	errDependencyNotFound     = errors.New("service not found in dependencies map")
 	errSidecarParentNotFound  = errors.New("sidecar parent service not found")
 	errSidecarParentIsSidecar = errors.New("sidecar parent is itself a sidecar")
-	errSidecarParentManaged   = errors.New("sidecar parent must be a container service, not managed Postgres/Redis")
+	errSidecarParentManaged   = errors.New("sidecar parent must be a container service, not a managed service")
 )
 
 // partitionSidecars splits services into standalone services and sidecar
@@ -39,7 +39,7 @@ func partitionSidecars(
 			return nil, nil, fmt.Errorf("service %s: %w: %q", name, errSidecarParentNotFound, parent)
 		case parentSvc.SidecarParent() != "":
 			return nil, nil, fmt.Errorf("service %s: parent %q: %w", name, parent, errSidecarParentIsSidecar)
-		case parentSvc.Postgres != nil || parentSvc.Redis != nil:
+		case isManagedService(parentSvc):
 			return nil, nil, fmt.Errorf("service %s: parent %q: %w", name, parent, errSidecarParentManaged)
 		}
 		if sidecars[parent] == nil {
@@ -48,6 +48,14 @@ func partitionSidecars(
 		sidecars[parent][name] = svc
 	}
 	return standalone, sidecars, nil
+}
+
+// isManagedService reports whether a service is dispatched to a managed AWS
+// backend (RDS, ElastiCache, S3) instead of an ECS task. Kept local to this
+// provider: GCP and Azure do not dispatch x-defang-s3 yet, so
+// common.IsManagedService must keep its current meaning for them.
+func isManagedService(svc compose.ServiceConfig) bool {
+	return svc.Postgres != nil || svc.Redis != nil || svc.ObjectStore != nil
 }
 
 // Project is the controller struct for the defang-aws:index:Project component.
@@ -196,6 +204,11 @@ func buildProject(
 	taskRoleArns := pulumi.StringMap{}
 	serviceIds := pulumi.StringMap{}
 	dependencies := map[string]pulumi.Resource{} // service name → dependency resource for dependees
+	// x-defang-s3 service name → bucket ARN, for the IAM grants attached to
+	// the task roles of the services that depend on them. Filled as the loop
+	// dispatches each store; the topological sort guarantees a store is
+	// created before any service that depends_on it.
+	objectStoreArns := map[string]pulumi.StringInput{}
 
 	var configProvider compose.ConfigProvider
 	if ctx.DryRun() {
@@ -229,44 +242,38 @@ func buildProject(
 	for _, svcName := range sortedNames {
 		svc := standalone[svcName]
 
-		// Collect dependency resources from services this one depends on;
-		// depends_on entries naming this service's own sidecars are handled
-		// as container dependencies inside the task definition.
-		var deps []pulumi.Resource
-		for dep, val := range svc.DependsOn {
-			if _, isOwnSidecar := sidecars[svcName][dep]; isOwnSidecar {
-				continue
-			}
-			if r, ok := dependencies[dep]; ok {
-				deps = append(deps, r)
-			} else if val.Required {
-				return nil, fmt.Errorf("service %s requires %s: %w", svcName, dep, errDependencyNotFound)
-			}
+		deps, err := collectDeps(svcName, svc, sidecars[svcName], dependencies)
+		if err != nil {
+			return nil, err
 		}
 
 		waitForHealthy := waitForSteady[svcName] || args.WaitForSteadyState
-		endpoint, dependency, svcComp, datastoreID, err := newService(
+		res, err := newService(
 			ctx, configProvider, svcName, svc, args.Networks, infra, sidecars[svcName], waitForHealthy, deps,
-			pluginID, parentOpt)
+			objectStoreGrants(svc, sidecars[svcName], objectStoreArns), pluginID, parentOpt)
 		if err != nil {
 			return nil, fmt.Errorf("building service %s: %w", svcName, err)
 		}
 
-		endpoints[svcName] = endpoint
-		if svcComp != nil {
-			serviceNames[svcName] = svcComp.ServiceName.Untyped().(pulumi.StringOutput)
-			taskRoleArns[svcName] = svcComp.TaskRoleArn.Untyped().(pulumi.StringOutput)
-			serviceIds[svcName] = svcComp.ServiceName.Untyped().(pulumi.StringOutput)
+		endpoints[svcName] = res.Endpoint
+		if res.Service != nil {
+			serviceNames[svcName] = res.Service.ServiceName.Untyped().(pulumi.StringOutput)
+			taskRoleArns[svcName] = res.Service.TaskRoleArn.Untyped().(pulumi.StringOutput)
+			serviceIds[svcName] = res.Service.ServiceName.Untyped().(pulumi.StringOutput)
 		}
-		// For datastore services, deliberately overwrite the ECS service name set
+		// For managed services, deliberately overwrite the ECS service name set
 		// above with the backing resource's physical ID (RDS instance, MemoryDB/
-		// ElastiCache cluster). newService returns a non-nil datastoreID only for
-		// those, so container services keep their ECS service name.
-		if datastoreID != nil {
-			serviceIds[svcName] = datastoreID
+		// ElastiCache cluster, S3 bucket). newService returns a non-nil
+		// DatastoreID only for those, so container services keep their ECS
+		// service name.
+		if res.DatastoreID != nil {
+			serviceIds[svcName] = res.DatastoreID
 		}
-		if dependency != nil {
-			dependencies[svcName] = dependency
+		if res.Dependency != nil {
+			dependencies[svcName] = res.Dependency
+		}
+		if res.BucketArn != nil {
+			objectStoreArns[svcName] = res.BucketArn
 		}
 	}
 
@@ -294,9 +301,10 @@ func apexServiceName(services compose.Services) string {
 	owner := ""
 	ingressPorts := 0
 	for name, svc := range services {
-		// Managed datastores are dispatched as Postgres/Redis, never as ALB
-		// ingress targets, so they can't own the apex even if a port is set.
-		if svc.Postgres != nil || svc.Redis != nil {
+		// Managed services are dispatched as Postgres/Redis/ObjectStore, never
+		// as ALB ingress targets, so they can't own the apex even if a port is
+		// set.
+		if isManagedService(svc) {
 			continue
 		}
 		for _, port := range svc.Ports {
@@ -312,6 +320,89 @@ func apexServiceName(services compose.Services) string {
 	return owner
 }
 
+// collectDeps returns the resources svc must be created after: the dependency
+// handles of the services it names in depends_on. Entries naming svc's own
+// sidecars are skipped — those are container dependencies inside the shared
+// task definition, not separate resources.
+func collectDeps(
+	svcName string,
+	svc compose.ServiceConfig,
+	sidecars map[string]compose.ServiceConfig,
+	dependencies map[string]pulumi.Resource,
+) ([]pulumi.Resource, error) {
+	var deps []pulumi.Resource
+	for dep, val := range svc.DependsOn {
+		if _, isOwnSidecar := sidecars[dep]; isOwnSidecar {
+			continue
+		}
+		if r, ok := dependencies[dep]; ok {
+			deps = append(deps, r)
+		} else if val.Required {
+			return nil, fmt.Errorf("service %s requires %s: %w", svcName, dep, errDependencyNotFound)
+		}
+	}
+	return deps, nil
+}
+
+// objectStoreGrants returns the bucket ARNs of the x-defang-s3 services that
+// svc — or one of its sidecars, which share svc's task role — names in
+// depends_on. depends_on is the wiring contract: the CLI injects <STORE>_BUCKET
+// and <STORE>_REGION into a service off that same edge, so a service that can
+// see a bucket name is exactly the one whose task role must reach the bucket.
+// Returns nil when the service depends on no store.
+func objectStoreGrants(
+	svc compose.ServiceConfig,
+	sidecars map[string]compose.ServiceConfig,
+	stores map[string]pulumi.StringInput,
+) map[string]pulumi.StringInput {
+	if len(stores) == 0 {
+		return nil
+	}
+	var grants map[string]pulumi.StringInput
+	collect := func(dependsOn compose.DependsOnConfig) {
+		for dep := range dependsOn {
+			arn, ok := stores[dep]
+			if !ok {
+				continue
+			}
+			if grants == nil {
+				grants = map[string]pulumi.StringInput{}
+			}
+			grants[dep] = arn
+		}
+	}
+	collect(svc.DependsOn)
+	for _, sidecar := range sidecars {
+		collect(sidecar.DependsOn)
+	}
+	return grants
+}
+
+// serviceResult is what dispatching one compose service yields: its endpoint,
+// the handle dependees order against, and the backend-specific extras.
+type serviceResult struct {
+	// Endpoint is the service's address — an ALB/private DNS URL for a
+	// container service, the datastore's connection endpoint, or the bucket's
+	// regional endpoint for an object store.
+	Endpoint pulumi.StringOutput
+	// Dependency is the resource a dependent service waits on.
+	Dependency pulumi.Resource
+	// Service is the ECS component; nil for managed services.
+	Service *ServiceOutputs
+	// DatastoreID is the managed backend's physical identifier (RDS instance,
+	// MemoryDB/ElastiCache cluster, S3 bucket name), surfaced through the
+	// Project's serviceIds output. nil for container services, whose ECS
+	// service name is used instead.
+	DatastoreID pulumi.StringInput
+	// BucketArn is the object store's bucket ARN; nil for every other kind of
+	// service. The project loop hands it to the task-role grant of each
+	// service that depends_on this one.
+	BucketArn pulumi.StringInput
+}
+
+// newService dispatches one compose service to its AWS backend: RDS for
+// x-defang-postgres, ElastiCache for x-defang-redis, S3 for x-defang-s3, and
+// an ECS service for everything else.
 func newService(
 	ctx *pulumi.Context,
 	configProvider compose.ConfigProvider,
@@ -322,49 +413,57 @@ func newService(
 	sidecars map[string]compose.ServiceConfig,
 	waitForSteadyState bool,
 	deps []pulumi.Resource,
+	objectStoreArns map[string]pulumi.StringInput,
 	pluginID common.PluginIdentity,
 	parentOpt pulumi.ResourceOrInvokeOption,
-) (pulumi.StringOutput, pulumi.Resource, *ServiceOutputs, pulumi.StringInput, error) {
-	var endpoint pulumi.StringOutput
-	var dependency pulumi.Resource
-	var svcComp *ServiceOutputs
-	// datastoreID is the managed database's physical identifier (nil for
-	// container services, whose ECS service name is used instead), surfaced
-	// through the Project's serviceIds output.
-	var datastoreID pulumi.StringInput
+) (*serviceResult, error) {
+	res := &serviceResult{}
 	var err error
 	switch {
 	case svc.Postgres != nil:
 		// Managed Postgres → RDS
 		pgComp := &PostgresOutputs{}
 		if regErr := ctx.RegisterComponentResource(PostgresComponentType, svcName, pgComp, parentOpt); regErr != nil {
-			return pulumi.StringOutput{}, nil, nil, nil, fmt.Errorf("registering postgres component %s: %w", svcName, regErr)
+			return nil, fmt.Errorf("registering postgres component %s: %w", svcName, regErr)
 		}
 		if err = createPostgres(ctx, pgComp, configProvider, svcName, svc, infra, deps); err == nil {
-			endpoint = pgComp.Endpoint
-			dependency = pgComp.Dependency
-			datastoreID = pgComp.InstanceIdentifier
+			res.Endpoint = pgComp.Endpoint
+			res.Dependency = pgComp.Dependency
+			res.DatastoreID = pgComp.InstanceIdentifier
 		}
 	case svc.Redis != nil:
 		// Managed Redis → ElastiCache
 		redisComp := &RedisOutputs{}
 		if regErr := ctx.RegisterComponentResource(RedisComponentType, svcName, redisComp, parentOpt); regErr != nil {
-			return pulumi.StringOutput{}, nil, nil, nil, fmt.Errorf("registering redis component %s: %w", svcName, regErr)
+			return nil, fmt.Errorf("registering redis component %s: %w", svcName, regErr)
 		}
 		if err = createRedis(ctx, redisComp, svcName, svc, infra, deps); err == nil {
-			endpoint = redisComp.Endpoint
-			dependency = redisComp.Dependency
-			datastoreID = redisComp.ClusterId
+			res.Endpoint = redisComp.Endpoint
+			res.Dependency = redisComp.Dependency
+			res.DatastoreID = redisComp.ClusterId
+		}
+	case svc.ObjectStore != nil:
+		// Managed object store → S3 bucket
+		storeComp := &ObjectStoreOutputs{}
+		if regErr := ctx.RegisterComponentResource(ObjectStoreComponentType, svcName, storeComp, parentOpt); regErr != nil {
+			return nil, fmt.Errorf("registering object store component %s: %w", svcName, regErr)
+		}
+		if err = createObjectStore(ctx, storeComp, svcName, svc, infra, deps); err == nil {
+			res.Endpoint = storeComp.Endpoint
+			res.Dependency = storeComp.Dependency
+			res.DatastoreID = storeComp.Bucket
+			res.BucketArn = storeComp.Arn
 		}
 	default:
 		// Container service → ECS
-		svcComp = &ServiceOutputs{}
+		svcComp := &ServiceOutputs{}
+		res.Service = svcComp
 		if regErr := ctx.RegisterComponentResource(ServiceComponentType, svcName, svcComp, parentOpt); regErr != nil {
-			return pulumi.StringOutput{}, nil, nil, nil, fmt.Errorf("registering service component %s: %w", svcName, regErr)
+			return nil, fmt.Errorf("registering service component %s: %w", svcName, regErr)
 		}
 		imageURI, imgErr := provideraws.GetServiceImage(ctx, svcName, svc, infra.BuildInfra, pluginID, pulumi.Parent(svcComp))
 		if imgErr != nil {
-			return pulumi.StringOutput{}, nil, nil, nil, fmt.Errorf("resolving image for %s: %w", svcName, imgErr)
+			return nil, fmt.Errorf("resolving image for %s: %w", svcName, imgErr)
 		}
 		args := &provideraws.ECSServiceArgs{
 			Infra:              infra,
@@ -372,14 +471,15 @@ func newService(
 			Networks:           networks,
 			WaitForSteadyState: waitForSteadyState,
 			Sidecars:           sidecars,
+			ObjectStoreArns:    objectStoreArns,
 		}
 		if err = createECSService(ctx, svcComp, configProvider, svcName, svc, args, deps); err == nil {
-			endpoint = pulumi.StringOutput(svcComp.Endpoint)
-			dependency = svcComp.Dependency
+			res.Endpoint = pulumi.StringOutput(svcComp.Endpoint)
+			res.Dependency = svcComp.Dependency
 		}
 	}
 	if err != nil {
-		return pulumi.StringOutput{}, nil, nil, nil, err
+		return nil, err
 	}
-	return endpoint, dependency, svcComp, datastoreID, nil
+	return res, nil
 }

--- a/provider/defangaws/project.go
+++ b/provider/defangaws/project.go
@@ -3,6 +3,7 @@ package defangaws
 import (
 	"errors"
 	"fmt"
+	"maps"
 
 	"github.com/DefangLabs/pulumi-defang/provider/common"
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
@@ -227,22 +228,14 @@ func buildProject(
 	// ingress port. Otherwise the apex is left unbound (ALB default action).
 	infra.ApexServiceName = apexServiceName(standalone)
 
-	// Pre-compute which services need waitForSteadyState: true if any other
-	// service depends on them with condition: service_healthy (matches TS tenant_stack.ts)
-	waitForSteady := map[string]bool{}
-	for _, other := range standalone {
-		for dep, val := range other.DependsOn {
-			if val.Condition == "service_healthy" {
-				waitForSteady[dep] = true
-			}
-		}
-	}
+	waitForSteady := servicesNeedingSteadyState(standalone)
 
-	sortedNames := common.TopologicalSort(standalone)
+	depGraph := foldSidecarDeps(standalone, sidecars)
+	sortedNames := common.TopologicalSort(depGraph)
 	for _, svcName := range sortedNames {
 		svc := standalone[svcName]
 
-		deps, err := collectDeps(svcName, svc, sidecars[svcName], dependencies)
+		deps, err := collectDeps(svcName, depGraph[svcName], sidecars[svcName], dependencies)
 		if err != nil {
 			return nil, err
 		}
@@ -250,7 +243,7 @@ func buildProject(
 		waitForHealthy := waitForSteady[svcName] || args.WaitForSteadyState
 		res, err := newService(
 			ctx, configProvider, svcName, svc, args.Networks, infra, sidecars[svcName], waitForHealthy, deps,
-			objectStoreGrants(svc, sidecars[svcName], objectStoreArns), pluginID, parentOpt)
+			objectStoreGrants(depGraph[svcName], objectStoreArns), pluginID, parentOpt)
 		if err != nil {
 			return nil, fmt.Errorf("building service %s: %w", svcName, err)
 		}
@@ -320,6 +313,21 @@ func apexServiceName(services compose.Services) string {
 	return owner
 }
 
+// servicesNeedingSteadyState returns the services another service depends on
+// with condition: service_healthy — those deployments must wait until the
+// service is steady (matches TS tenant_stack.ts).
+func servicesNeedingSteadyState(services compose.Services) map[string]bool {
+	waitForSteady := map[string]bool{}
+	for _, svc := range services {
+		for dep, val := range svc.DependsOn {
+			if val.Condition == "service_healthy" {
+				waitForSteady[dep] = true
+			}
+		}
+	}
+	return waitForSteady
+}
+
 // collectDeps returns the resources svc must be created after: the dependency
 // handles of the services it names in depends_on. Entries naming svc's own
 // sidecars are skipped — those are container dependencies inside the shared
@@ -345,37 +353,75 @@ func collectDeps(
 }
 
 // objectStoreGrants returns the bucket ARNs of the x-defang-s3 services that
-// svc — or one of its sidecars, which share svc's task role — names in
-// depends_on. depends_on is the wiring contract: the CLI injects <STORE>_BUCKET
-// and <STORE>_REGION into a service off that same edge, so a service that can
-// see a bucket name is exactly the one whose task role must reach the bucket.
-// Returns nil when the service depends on no store.
+// svc names in depends_on. depends_on is the wiring contract: the CLI injects
+// <STORE>_BUCKET and <STORE>_REGION into a service off that same edge, so a
+// service that can see a bucket name is exactly the one whose task role must
+// reach the bucket. Returns nil when the service depends on no store.
+//
+// Call it with a service from foldSidecarDeps' graph, so a sidecar's
+// depends_on grants the parent whose task role it shares.
 func objectStoreGrants(
 	svc compose.ServiceConfig,
-	sidecars map[string]compose.ServiceConfig,
 	stores map[string]pulumi.StringInput,
 ) map[string]pulumi.StringInput {
 	if len(stores) == 0 {
 		return nil
 	}
 	var grants map[string]pulumi.StringInput
-	collect := func(dependsOn compose.DependsOnConfig) {
-		for dep := range dependsOn {
-			arn, ok := stores[dep]
-			if !ok {
-				continue
-			}
-			if grants == nil {
-				grants = map[string]pulumi.StringInput{}
-			}
-			grants[dep] = arn
+	for dep := range svc.DependsOn {
+		arn, ok := stores[dep]
+		if !ok {
+			continue
 		}
-	}
-	collect(svc.DependsOn)
-	for _, sidecar := range sidecars {
-		collect(sidecar.DependsOn)
+		if grants == nil {
+			grants = map[string]pulumi.StringInput{}
+		}
+		grants[dep] = arn
 	}
 	return grants
+}
+
+// foldSidecarDeps returns the standalone services with each sidecar's
+// depends_on folded into its parent's. A sidecar ships inside its parent's
+// task definition and shares its task role, so its dependencies are the
+// parent's: they decide the order the parent is created in, and which buckets
+// the parent's task role is granted. Without this, a parent whose only edge to
+// a store comes from a sidecar could be dispatched before the store exists,
+// and the grant would be silently skipped.
+//
+// Edges back into the group — a sidecar naming its parent or a sibling — are
+// dropped: those are container dependencies inside the one task definition,
+// not resources to order against.
+func foldSidecarDeps(
+	standalone compose.Services,
+	sidecars map[string]map[string]compose.ServiceConfig,
+) compose.Services {
+	if len(sidecars) == 0 {
+		return standalone
+	}
+	graph := make(compose.Services, len(standalone))
+	maps.Copy(graph, standalone)
+	for parent, group := range sidecars {
+		svc, ok := graph[parent]
+		if !ok {
+			continue // partitionSidecars rejects an unknown parent
+		}
+		merged := make(compose.DependsOnConfig, len(svc.DependsOn))
+		maps.Copy(merged, svc.DependsOn)
+		for _, sidecar := range group {
+			for dep, val := range sidecar.DependsOn {
+				if _, inGroup := group[dep]; inGroup || dep == parent {
+					continue
+				}
+				if _, dup := merged[dep]; !dup {
+					merged[dep] = val
+				}
+			}
+		}
+		svc.DependsOn = merged
+		graph[parent] = svc
+	}
+	return graph
 }
 
 // serviceResult is what dispatching one compose service yields: its endpoint,

--- a/provider/defangaws/project_test.go
+++ b/provider/defangaws/project_test.go
@@ -1,7 +1,12 @@
 package defangaws
 
 import (
+	"maps"
+	"slices"
 	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
 )
@@ -74,6 +79,75 @@ func TestApexServiceName(t *testing.T) {
 			if got := apexServiceName(tt.services); got != tt.want {
 				t.Errorf("apexServiceName() = %q, want %q", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestObjectStoreGrants(t *testing.T) {
+	const uploads, backups = "uploads", "backups"
+	stores := map[string]pulumi.StringInput{
+		uploads: pulumi.String("arn:aws:s3:::proj-uploads"),
+		backups: pulumi.String("arn:aws:s3:::proj-backups"),
+	}
+	dependsOn := func(names ...string) compose.DependsOnConfig {
+		cfg := compose.DependsOnConfig{}
+		for _, name := range names {
+			cfg[name] = compose.ServiceDependency{Required: true}
+		}
+		return cfg
+	}
+
+	tests := []struct {
+		name     string
+		svc      compose.ServiceConfig
+		sidecars map[string]compose.ServiceConfig
+		stores   map[string]pulumi.StringInput
+		want     []string
+	}{
+		{
+			name: "no stores in the project",
+			svc:  compose.ServiceConfig{DependsOn: dependsOn(uploads)},
+			want: nil,
+		},
+		{
+			name:   "no depends_on",
+			svc:    compose.ServiceConfig{},
+			stores: stores,
+			want:   nil,
+		},
+		{
+			name:   "depends_on a store",
+			svc:    compose.ServiceConfig{DependsOn: dependsOn(uploads)},
+			stores: stores,
+			want:   []string{uploads},
+		},
+		{
+			name:   "depends_on a plain service is not a grant",
+			svc:    compose.ServiceConfig{DependsOn: dependsOn("db")},
+			stores: stores,
+			want:   nil,
+		},
+		{
+			name:   "depends_on two stores",
+			svc:    compose.ServiceConfig{DependsOn: dependsOn(uploads, backups, "db")},
+			stores: stores,
+			want:   []string{backups, uploads},
+		},
+		{
+			// A sidecar shares its parent's task role, so its depends_on has
+			// to grant the parent.
+			name:     "sidecar depends_on a store",
+			svc:      compose.ServiceConfig{},
+			sidecars: map[string]compose.ServiceConfig{"log": {DependsOn: dependsOn(backups)}},
+			stores:   stores,
+			want:     []string{backups},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := objectStoreGrants(tt.svc, tt.sidecars, tt.stores)
+			assert.ElementsMatch(t, tt.want, slices.Sorted(maps.Keys(got)))
 		})
 	}
 }

--- a/provider/defangaws/project_test.go
+++ b/provider/defangaws/project_test.go
@@ -98,11 +98,10 @@ func TestObjectStoreGrants(t *testing.T) {
 	}
 
 	tests := []struct {
-		name     string
-		svc      compose.ServiceConfig
-		sidecars map[string]compose.ServiceConfig
-		stores   map[string]pulumi.StringInput
-		want     []string
+		name   string
+		svc    compose.ServiceConfig
+		stores map[string]pulumi.StringInput
+		want   []string
 	}{
 		{
 			name: "no stores in the project",
@@ -133,21 +132,41 @@ func TestObjectStoreGrants(t *testing.T) {
 			stores: stores,
 			want:   []string{backups, uploads},
 		},
-		{
-			// A sidecar shares its parent's task role, so its depends_on has
-			// to grant the parent.
-			name:     "sidecar depends_on a store",
-			svc:      compose.ServiceConfig{},
-			sidecars: map[string]compose.ServiceConfig{"log": {DependsOn: dependsOn(backups)}},
-			stores:   stores,
-			want:     []string{backups},
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := objectStoreGrants(tt.svc, tt.sidecars, tt.stores)
+			got := objectStoreGrants(tt.svc, tt.stores)
 			assert.ElementsMatch(t, tt.want, slices.Sorted(maps.Keys(got)))
 		})
 	}
+}
+
+// A sidecar shares its parent's task definition and task role, so its
+// depends_on is the parent's: it decides when the parent is created and which
+// buckets the parent's task role reaches. Edges back into the sidecar group
+// are container-level, not resources to order against.
+func TestFoldSidecarDeps(t *testing.T) {
+	const app, store, db = "app", "uploads", "db"
+	dep := compose.ServiceDependency{Required: true}
+
+	standalone := compose.Services{
+		app:   {DependsOn: compose.DependsOnConfig{db: dep}},
+		store: {ObjectStore: &compose.ObjectStoreConfig{Bucket: "proj-uploads"}},
+		db:    {Postgres: &compose.PostgresConfig{}},
+	}
+	sidecars := map[string]map[string]compose.ServiceConfig{
+		app: {
+			"log":  {DependsOn: compose.DependsOnConfig{store: dep, app: dep}},
+			"prox": {DependsOn: compose.DependsOnConfig{"log": dep}},
+		},
+	}
+
+	graph := foldSidecarDeps(standalone, sidecars)
+	assert.ElementsMatch(t, []string{db, store}, slices.Sorted(maps.Keys(graph[app].DependsOn)))
+	// The input map is left alone: the loop still dispatches the original
+	// service config.
+	assert.ElementsMatch(t, []string{db}, slices.Sorted(maps.Keys(standalone[app].DependsOn)))
+	// No sidecars, no copy.
+	assert.Nil(t, foldSidecarDeps(standalone, nil)[store].DependsOn)
 }

--- a/tests/aws/objectstore_test.go
+++ b/tests/aws/objectstore_test.go
@@ -5,9 +5,13 @@ package aws
 // outputs for a declared bucket name.
 
 import (
+	"encoding/json"
+	"slices"
+	"sync"
 	"testing"
 
 	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -59,4 +63,131 @@ func TestConstructAwsObjectStoreNoInfra(t *testing.T) {
 		}),
 	})
 	require.NoError(t, err)
+}
+
+// bucketArnMock echoes inputs back like the default mock, but synthesizes the
+// `arn` output for S3 buckets — the ObjectStore hands that ARN to the task-role
+// grant, so without it the policy document would never resolve — and records
+// every inline role policy the project creates.
+type bucketArnMock struct {
+	mu       sync.Mutex
+	policies map[string]string // resource name -> policy document JSON
+	ecsNames []string
+}
+
+func newBucketArnMock() (*bucketArnMock, *integration.MockResourceMonitor) {
+	m := &bucketArnMock{policies: map[string]string{}}
+	return m, &integration.MockResourceMonitor{
+		NewResourceF: func(args integration.MockResourceArgs) (string, property.Map, error) {
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			switch string(args.TypeToken) {
+			case "aws:s3/bucket:Bucket":
+				bucket := args.Inputs.Get("bucket").AsString()
+				return args.Name, args.Inputs.Set("arn", property.New("arn:aws:s3:::"+bucket)), nil
+			case "aws:iam/rolePolicy:RolePolicy":
+				if policy, ok := args.Inputs.GetOk("policy"); ok && policy.IsString() {
+					m.policies[args.Name] = policy.AsString()
+				}
+			case "aws:ecs/service:Service":
+				m.ecsNames = append(m.ecsNames, args.Name)
+			}
+			return args.Name, args.Inputs, nil
+		},
+	}
+}
+
+func (m *bucketArnMock) policy(name string) (string, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	doc, ok := m.policies[name]
+	return doc, ok
+}
+
+func (m *bucketArnMock) services() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return slices.Clone(m.ecsNames)
+}
+
+// objectStoreProject is a project with one x-defang-s3 service and one
+// container service that declares depends_on it (or not, per dependsOn).
+func objectStoreProject(dependsOn bool) property.Map {
+	app := map[string]property.Value{"image": property.New("myapp:latest")}
+	if dependsOn {
+		app["dependsOn"] = property.New(property.NewMap(map[string]property.Value{
+			"uploads": property.New(property.NewMap(map[string]property.Value{
+				"required": property.New(true),
+			})),
+		}))
+	}
+	return testutil.ServicesMap(map[string]property.Value{
+		"uploads": property.New(property.NewMap(map[string]property.Value{
+			"image": property.New("minio/minio"),
+			"objectStore": property.New(property.NewMap(map[string]property.Value{
+				"bucket": property.New("myproject-uploads"),
+			})),
+		})),
+		"app": property.New(property.NewMap(app)),
+	})
+}
+
+// A service that depends_on an x-defang-s3 store gets an inline task-role
+// policy for that bucket. The bucket-level half matters as much as the object
+// half: HeadBucket — the credential probe many S3 clients run at startup — is
+// authorized by s3:ListBucket on the bucket ARN, not by any object action.
+func TestConstructAwsProjectObjectStoreGrant(t *testing.T) {
+	m, mock := newBucketArnMock()
+	server := testutil.MakeAwsTestServer(integration.WithMocks(mock))
+
+	_, err := server.Construct(p.ConstructRequest{
+		Urn:    testutil.AwsURN("Project"),
+		Inputs: objectStoreProject(true),
+	})
+	require.NoError(t, err)
+
+	doc, ok := m.policy("app-objectstore-uploads")
+	require.True(t, ok, "no object-store policy attached to the app task role")
+
+	var policy struct {
+		Statement []struct {
+			Sid      string   `json:"Sid"`
+			Effect   string   `json:"Effect"`
+			Action   []string `json:"Action"`
+			Resource string   `json:"Resource"`
+		} `json:"Statement"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(doc), &policy))
+	require.Len(t, policy.Statement, 2)
+
+	bucket, objects := policy.Statement[0], policy.Statement[1]
+	assert.Equal(t, "arn:aws:s3:::myproject-uploads", bucket.Resource)
+	assert.Contains(t, bucket.Action, "s3:ListBucket")
+	assert.Contains(t, bucket.Action, "s3:GetBucketLocation")
+	assert.Equal(t, "arn:aws:s3:::myproject-uploads/*", objects.Resource)
+	assert.Contains(t, objects.Action, "s3:GetObject")
+	assert.Contains(t, objects.Action, "s3:PutObject")
+	for _, stmt := range policy.Statement {
+		assert.Equal(t, "Allow", stmt.Effect)
+	}
+
+	// The store itself is a bucket, not a task: it must not reach ECS even
+	// though the compose service carries a minio image anchor.
+	assert.Equal(t, []string{"app"}, m.services())
+}
+
+// depends_on is the wiring contract — it is what the CLI injects
+// <STORE>_BUCKET off — so a service that does not declare it gets no grant.
+func TestConstructAwsProjectObjectStoreNoGrantWithoutDependsOn(t *testing.T) {
+	m, mock := newBucketArnMock()
+	server := testutil.MakeAwsTestServer(integration.WithMocks(mock))
+
+	_, err := server.Construct(p.ConstructRequest{
+		Urn:    testutil.AwsURN("Project"),
+		Inputs: objectStoreProject(false),
+	})
+	require.NoError(t, err)
+
+	_, ok := m.policy("app-objectstore-uploads")
+	assert.False(t, ok, "granted bucket access to a service that does not depend on the store")
 }


### PR DESCRIPTION
## Summary

The follow-up flagged in #503: the ObjectStore component exists, but nothing in a compose project reaches it and no task role can touch the bucket. This PR closes both gaps — AWS Phase 2 of #480 is functionally complete with it.

- **Dispatcher** — `provider/defangaws/project.go` sends `svc.ObjectStore != nil` to `createObjectStore`, alongside the `svc.Postgres`/`svc.Redis` cases. An `x-defang-s3` service now provisions a bucket instead of an ECS task (the `minio` image in the compose file is an anchor, never a container). The bucket name is surfaced through `serviceIds`, the way the RDS instance identifier and the ElastiCache cluster ID already are, and the store joins the managed-service set for the apex-domain and sidecar-parent checks.
- **IAM** — every service that names a store in `depends_on` gets an inline policy on its task role for that one bucket. The ECS service waits on the attachment, so a task cannot start before its credentials are usable.
- **CD wiring** — `cd/program/aws.go` now carries `ObjectStore` into the provider args. Its converter copies a compose service field by field and had never copied this one, so the extension died at the CD boundary and the store deployed as a MinIO ECS task. The dispatcher above could not fire in a real deploy until this was fixed; the first end-to-end run is what found it. Nine more fields the same converter drops are audited in #519.
- **`newService` returns a struct** rather than five positional values. Adding the bucket ARN as a sixth was past the point where the call site could be read.

### Why the grant covers the bucket ARN, not just objects

`HeadBucket` — the probe many S3 clients run at startup to check their credentials — is authorized by `s3:ListBucket` on the **bucket** ARN. No object-level action covers it. A policy holding only `s3:GetObject`/`s3:PutObject` therefore lets every real read and write succeed while the startup probe returns 403, and a client that treats that probe as fatal disables storage for the life of the process and never retries. The failure presents as "the bucket is missing", not as a missing permission, so it is expensive to diagnose. This is the gap recorded at https://github.com/DefangLabs/pulumi-defang/pull/503#issuecomment-5518306448.

What each service that depends on a store receives:

| Resource | Actions |
| --- | --- |
| `arn:aws:s3:::<bucket>` | `s3:ListBucket`, `s3:GetBucketLocation`, `s3:ListBucketMultipartUploads` |
| `arn:aws:s3:::<bucket>/*` | `s3:GetObject`, `s3:PutObject`, `s3:DeleteObject`, `s3:AbortMultipartUpload`, `s3:ListMultipartUploadParts` |

`GetBucketLocation` is there for the SDKs that resolve a region before their first call; the multipart pair for writers that upload large objects.

### Why `depends_on` is the trigger

`depends_on` is already the wiring contract on the CLI side: DefangLabs/defang#2239 injects `<STORE>_BUCKET` and `<STORE>_REGION` into a service off that same edge. So the service that can see a bucket name is exactly the service whose task role must reach the bucket — no second knob, and no project-wide grant. A sidecar's `depends_on` grants its parent, since a sidecar shares the parent's task role.

An externally supplied `taskRoleArn` is left alone, matching how the route53, bedrock and `x-defang-policies` attachments already behave: the caller owns that role's policies.

## Still out of scope

- **Azure (Phase 3)** and **GCP (Phase 4)** — no dispatch, no grant. `common.IsManagedService` is deliberately untouched for that reason; the AWS provider uses a local `isManagedService`.
- **Retain/adopt on `compose down`** — recipe-driven, per the design discussion on #480.
- **Multiple buckets per extension.**

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt` clean
- [x] `go test ./provider/...` — new `TestObjectStoreGrants` covers the depends_on/sidecar/no-store cases
- [x] `(cd tests && go test -short ./...)` — new project-level tests assert the rendered policy document carries **both** ARN statements, and that the store never reaches ECS
- [x] `make schema` — no drift (no schema-visible change)
- [x] End-to-end `defang compose up` on the AWS Lab account, CD image built from this branch, CLI from #2239's branch — bucket provisioned, task-role grant attached, and a probe container did head-bucket/put/list/get/delete with nothing but its task role. Two comments below carry the logs.

Refs #480, #503, DefangLabs/defang#2239.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3WmpdY3zc555sNdkY9dzQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for managed S3 object stores in AWS projects.
  * Services can declare object-store dependencies and automatically receive the required bucket and object access permissions.
  * S3 object stores provide endpoints, identifiers, and resource references to dependent services.
  * Object stores are included in service dependency and managed-resource validation.
  * Services without an object-store dependency do not receive unnecessary access permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
