### PR TITLE
fix(cd): carry the ten dropped compose fields into the provider args

### DIFF
--- a/cd/program/aws.go
+++ b/cd/program/aws.go
@@ -122,6 +122,20 @@ func toAWSServiceArgs(svc compose.ServiceConfig) awscompose.ServiceConfigArgs {
 		Environment: pulumi.ToStringMap(svc.ResolvedEnvironment()),
 		Command:     pulumi.ToStringArray(svc.Command),
 		Entrypoint:  pulumi.ToStringArray(svc.Entrypoint),
+
+		// Every field below is copied unconditionally, including the zero
+		// value: the compose types have no "unset" state for a bare bool or
+		// string, and a conditional write is how a field gets forgotten.
+		// See TestServiceArgsCopyEveryField.
+		Aliases:         pulumi.ToStringMap(svc.Aliases),
+		Autoscaling:     pulumi.Bool(svc.Autoscaling),
+		ContainerName:   pulumi.StringPtrFromPtr(svc.ContainerName),
+		NetworkMode:     pulumi.String(svc.NetworkMode),
+		Policies:        pulumi.ToStringArray(svc.Policies),
+		Restart:         pulumi.String(svc.Restart),
+		StopGracePeriod: pulumi.StringPtrFromPtr(svc.StopGracePeriod),
+		VolumesFrom:     pulumi.ToStringArray(svc.VolumesFrom),
+		WorkingDir:      pulumi.StringPtrFromPtr(svc.WorkingDir),
 	}
 	if svc.DomainName != "" {
 		args.DomainName = pulumi.String(svc.DomainName)
@@ -174,6 +188,11 @@ func toAWSServiceArgs(svc compose.ServiceConfig) awscompose.ServiceConfigArgs {
 			FromSnapshot:  pulumi.StringPtrFromPtr(svc.Redis.FromSnapshot),
 		}
 	}
+	if svc.ObjectStore != nil {
+		args.ObjectStore = awscompose.ObjectStoreConfigArgs{
+			Bucket: pulumi.String(svc.ObjectStore.Bucket),
+		}
+	}
 	if svc.HealthCheck != nil {
 		args.HealthCheck = awscompose.HealthCheckConfigArgs{
 			Test:               pulumi.ToStringArray(svc.HealthCheck.Test),
@@ -199,6 +218,17 @@ func toAWSServiceArgs(svc compose.ServiceConfig) awscompose.ServiceConfigArgs {
 	}
 	if svc.LLM != nil {
 		args.Llm = awscompose.LlmConfigArgs{}
+	}
+	if len(svc.Volumes) > 0 {
+		volumes := make(awscompose.ServiceVolumeConfigArray, 0, len(svc.Volumes))
+		for _, v := range svc.Volumes {
+			volumes = append(volumes, awscompose.ServiceVolumeConfigArgs{
+				Source:   pulumi.String(v.Source),
+				Target:   pulumi.String(v.Target),
+				ReadOnly: pulumi.Bool(v.ReadOnly),
+			})
+		}
+		args.Volumes = volumes
 	}
 	return args
 }

--- a/cd/program/azure.go
+++ b/cd/program/azure.go
@@ -327,6 +327,20 @@ func toAzureServiceArgs(svc compose.ServiceConfig) azurecompose.ServiceConfigArg
 		Environment: pulumi.ToStringMap(svc.ResolvedEnvironment()),
 		Command:     pulumi.ToStringArray(svc.Command),
 		Entrypoint:  pulumi.ToStringArray(svc.Entrypoint),
+
+		// Every field below is copied unconditionally, including the zero
+		// value: the compose types have no "unset" state for a bare bool or
+		// string, and a conditional write is how a field gets forgotten.
+		// See TestServiceArgsCopyEveryField.
+		Aliases:         pulumi.ToStringMap(svc.Aliases),
+		Autoscaling:     pulumi.Bool(svc.Autoscaling),
+		ContainerName:   pulumi.StringPtrFromPtr(svc.ContainerName),
+		NetworkMode:     pulumi.String(svc.NetworkMode),
+		Policies:        pulumi.ToStringArray(svc.Policies),
+		Restart:         pulumi.String(svc.Restart),
+		StopGracePeriod: pulumi.StringPtrFromPtr(svc.StopGracePeriod),
+		VolumesFrom:     pulumi.ToStringArray(svc.VolumesFrom),
+		WorkingDir:      pulumi.StringPtrFromPtr(svc.WorkingDir),
 	}
 	if svc.DomainName != "" {
 		args.DomainName = pulumi.StringPtr(svc.DomainName)
@@ -379,6 +393,11 @@ func toAzureServiceArgs(svc compose.ServiceConfig) azurecompose.ServiceConfigArg
 			FromSnapshot:  pulumi.StringPtrFromPtr(svc.Redis.FromSnapshot),
 		}
 	}
+	if svc.ObjectStore != nil {
+		args.ObjectStore = azurecompose.ObjectStoreConfigArgs{
+			Bucket: pulumi.String(svc.ObjectStore.Bucket),
+		}
+	}
 	if svc.HealthCheck != nil {
 		args.HealthCheck = azurecompose.HealthCheckConfigArgs{
 			Test:               pulumi.ToStringArray(svc.HealthCheck.Test),
@@ -404,6 +423,17 @@ func toAzureServiceArgs(svc compose.ServiceConfig) azurecompose.ServiceConfigArg
 	}
 	if svc.LLM != nil {
 		args.Llm = azurecompose.LlmConfigArgs{}
+	}
+	if len(svc.Volumes) > 0 {
+		volumes := make(azurecompose.ServiceVolumeConfigArray, 0, len(svc.Volumes))
+		for _, v := range svc.Volumes {
+			volumes = append(volumes, azurecompose.ServiceVolumeConfigArgs{
+				Source:   pulumi.String(v.Source),
+				Target:   pulumi.String(v.Target),
+				ReadOnly: pulumi.Bool(v.ReadOnly),
+			})
+		}
+		args.Volumes = volumes
 	}
 	return args
 }

--- a/cd/program/gcp.go
+++ b/cd/program/gcp.go
@@ -102,6 +102,20 @@ func toGCPServiceArgs(svc compose.ServiceConfig) gcpcompose.ServiceConfigArgs {
 		Environment: pulumi.ToStringMap(svc.ResolvedEnvironment()),
 		Command:     pulumi.ToStringArray(svc.Command),
 		Entrypoint:  pulumi.ToStringArray(svc.Entrypoint),
+
+		// Every field below is copied unconditionally, including the zero
+		// value: the compose types have no "unset" state for a bare bool or
+		// string, and a conditional write is how a field gets forgotten.
+		// See TestServiceArgsCopyEveryField.
+		Aliases:         pulumi.ToStringMap(svc.Aliases),
+		Autoscaling:     pulumi.Bool(svc.Autoscaling),
+		ContainerName:   pulumi.StringPtrFromPtr(svc.ContainerName),
+		NetworkMode:     pulumi.String(svc.NetworkMode),
+		Policies:        pulumi.ToStringArray(svc.Policies),
+		Restart:         pulumi.String(svc.Restart),
+		StopGracePeriod: pulumi.StringPtrFromPtr(svc.StopGracePeriod),
+		VolumesFrom:     pulumi.ToStringArray(svc.VolumesFrom),
+		WorkingDir:      pulumi.StringPtrFromPtr(svc.WorkingDir),
 	}
 	if svc.DomainName != "" {
 		args.DomainName = pulumi.StringPtr(svc.DomainName)
@@ -154,6 +168,11 @@ func toGCPServiceArgs(svc compose.ServiceConfig) gcpcompose.ServiceConfigArgs {
 			FromSnapshot:  pulumi.StringPtrFromPtr(svc.Redis.FromSnapshot),
 		}
 	}
+	if svc.ObjectStore != nil {
+		args.ObjectStore = gcpcompose.ObjectStoreConfigArgs{
+			Bucket: pulumi.String(svc.ObjectStore.Bucket),
+		}
+	}
 	if svc.HealthCheck != nil {
 		args.HealthCheck = gcpcompose.HealthCheckConfigArgs{
 			Test:               pulumi.ToStringArray(svc.HealthCheck.Test),
@@ -179,6 +198,17 @@ func toGCPServiceArgs(svc compose.ServiceConfig) gcpcompose.ServiceConfigArgs {
 	}
 	if svc.LLM != nil {
 		args.Llm = gcpcompose.LlmConfigArgs{}
+	}
+	if len(svc.Volumes) > 0 {
+		volumes := make(gcpcompose.ServiceVolumeConfigArray, 0, len(svc.Volumes))
+		for _, v := range svc.Volumes {
+			volumes = append(volumes, gcpcompose.ServiceVolumeConfigArgs{
+				Source:   pulumi.String(v.Source),
+				Target:   pulumi.String(v.Target),
+				ReadOnly: pulumi.Bool(v.ReadOnly),
+			})
+		}
+		args.Volumes = volumes
 	}
 	return args
 }

--- a/cd/program/serviceargs_test.go
+++ b/cd/program/serviceargs_test.go
@@ -1,0 +1,274 @@
+package program
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/DefangLabs/pulumi-defang/provider/compose"
+	awscompose "github.com/DefangLabs/pulumi-defang/sdk/v2/go/defang-aws/compose"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Each to<Cloud>ServiceArgs copies a parsed compose service into its generated
+// SDK args struct field by field. A field the copy forgets is dropped in
+// silence: the provider sees a service that never asked for the feature, the
+// deploy succeeds, and the feature is simply absent. Every unit and
+// provider-mock test still passes, because those build the component inputs
+// directly and never cross this boundary. That is how x-defang-s3 reached AWS
+// as a MinIO ECS task with no bucket on its first end-to-end run (#519).
+
+const (
+	cloudGCP   = "gcp"
+	cloudAzure = "azure"
+
+	// A pre-migration ElastiCache URN, the shape x-defang-aliases carries.
+	clusterURN = "urn:pulumi:prod::proj::aws:elasticache/cluster:Cluster::cache"
+	// A volumes_from entry: a container name with the optional mode suffix.
+	volumesFromRef = "sidecar:ro"
+)
+
+// fullService sets every field of compose.ServiceConfig to a distinctive
+// non-zero value, so that converting it and converting the zero service differ
+// in every field of the SDK args. It is deliberately not a service anyone would
+// deploy — Postgres, Redis and ObjectStore are all set at once, and no real
+// compose file does that. The converters validate nothing, so it is a legal
+// probe of the copy and nothing more.
+func fullService() compose.ServiceConfig {
+	return compose.ServiceConfig{
+		Aliases:       map[string]string{compose.AliasCluster: clusterURN},
+		Autoscaling:   true,
+		Build:         &compose.BuildConfig{Context: pulumi.String("./src"), Dockerfile: ptr("Dockerfile.prod")},
+		Command:       []string{"serve"},
+		ContainerName: ptr("app-main"),
+		DependsOn:     compose.DependsOnConfig{"db": {Condition: "service_healthy", Required: true}},
+		Deploy:        &compose.DeployConfig{Replicas: ptr(int32(3))},
+		DomainName:    "app.example.com",
+		Entrypoint:    []string{"/bin/sh", "-c"},
+		Environment:   compose.Environment{"LOG_LEVEL": pulumi.String("debug")},
+		HealthCheck:   &compose.HealthCheckConfig{Test: []string{"CMD", "true"}},
+		Image:         pulumi.String("nginx:alpine"),
+		LLM:           &compose.LlmConfig{},
+		NetworkMode:   "service:app",
+		Networks: map[compose.NetworkID]compose.ServiceNetworkConfig{
+			compose.DefaultNetwork: {Aliases: []string{"web"}},
+		},
+		ObjectStore:     &compose.ObjectStoreConfig{Bucket: "proj-uploads"},
+		Platform:        ptr("linux/arm64"),
+		Policies:        compose.PolicyList{"arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"},
+		Ports:           []compose.ServicePortConfig{{Target: 8080, Mode: compose.PortModeIngress}},
+		Postgres:        &compose.PostgresConfig{FromSnapshot: ptr("snap-1")},
+		Redis:           &compose.RedisConfig{FromSnapshot: ptr("snap-2")},
+		Restart:         "no",
+		StopGracePeriod: ptr("90s"),
+		Volumes:         []compose.ServiceVolumeConfig{{Source: "data", Target: "/var/lib/data", ReadOnly: true}},
+		VolumesFrom:     []string{volumesFromRef},
+		WorkingDir:      ptr("/srv"),
+	}
+}
+
+// TestServiceArgsCopyEveryField is the guard that makes the next added field
+// fail loudly instead of silently. It carries no list of fields to check: it
+// converts the maximal service above and the zero service, then compares the
+// two SDK args structs field by field. A field the converter never touches
+// comes out identical from both, and the test names it.
+//
+// So a field added to the SDK schema starts out uncopied, and therefore starts
+// out failing — nobody has to remember to extend this test. Adding the field to
+// fullService and to the converters is what makes it pass.
+func TestServiceArgsCopyEveryField(t *testing.T) {
+	full := fullService()
+	empty := compose.ServiceConfig{}
+	tests := []struct {
+		cloud     string
+		converter string
+		got       any
+		zero      any
+	}{
+		{"aws", "toAWSServiceArgs", toAWSServiceArgs(full), toAWSServiceArgs(empty)},
+		{cloudGCP, "toGCPServiceArgs", toGCPServiceArgs(full), toGCPServiceArgs(empty)},
+		{cloudAzure, "toAzureServiceArgs", toAzureServiceArgs(full), toAzureServiceArgs(empty)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.cloud, func(t *testing.T) {
+			got, zero := reflect.ValueOf(tt.got), reflect.ValueOf(tt.zero)
+			require.Positive(t, got.NumField())
+			for i := range got.NumField() {
+				assert.NotEqual(t, zero.Field(i).Interface(), got.Field(i).Interface(),
+					"ServiceConfigArgs.%s is not copied by %s: the compose field is dropped on "+
+						"the way to the provider, and the feature behind it is inert. Copy it "+
+						"there, and set it in fullService so this test can see it.",
+					got.Type().Field(i).Name, tt.converter)
+			}
+		})
+	}
+}
+
+// TestServiceArgsCopyValues pins what each field is copied *as*. The guard
+// above proves a field was touched; these prove it arrived intact, and record
+// the arg shape chosen for the fields where the compose type and the SDK type
+// disagree (bool vs *bool, string vs *string).
+func TestServiceArgsCopyValues(t *testing.T) {
+	tests := []struct {
+		name string
+		svc  compose.ServiceConfig
+		got  func(awscompose.ServiceConfigArgs) any
+		want any
+	}{
+		{
+			// x-defang-policies: attached to the task role by aws/ecs.go.
+			// Copied raw — every consumer calls compose.NormalizePolicies
+			// itself, because inputs also arrive from hand-written programs.
+			name: "policies",
+			svc:  compose.ServiceConfig{Policies: compose.PolicyList{"arn:aws:iam::aws:policy/ReadOnlyAccess", "Custom"}},
+			got:  func(a awscompose.ServiceConfigArgs) any { return a.Policies },
+			want: pulumi.ToStringArray([]string{"arn:aws:iam::aws:policy/ReadOnlyAccess", "Custom"}),
+		},
+		{
+			// EFS access points and mounts. ReadOnly is a plain bool in
+			// compose and a *bool in the SDK: written unconditionally,
+			// because false is the parsed value, not an absent one.
+			name: "volumes",
+			svc: compose.ServiceConfig{Volumes: []compose.ServiceVolumeConfig{
+				{Source: "data", Target: "/var/lib/data", ReadOnly: true},
+				{Source: "cache", Target: "/tmp/cache"},
+			}},
+			got: func(a awscompose.ServiceConfigArgs) any { return a.Volumes },
+			want: awscompose.ServiceVolumeConfigArray{
+				awscompose.ServiceVolumeConfigArgs{
+					Source: pulumi.String("data"), Target: pulumi.String("/var/lib/data"), ReadOnly: pulumi.Bool(true),
+				},
+				awscompose.ServiceVolumeConfigArgs{
+					Source: pulumi.String("cache"), Target: pulumi.String("/tmp/cache"), ReadOnly: pulumi.Bool(false),
+				},
+			},
+		},
+		{
+			name: "volumes_from",
+			svc:  compose.ServiceConfig{VolumesFrom: []string{volumesFromRef}},
+			got:  func(a awscompose.ServiceConfigArgs) any { return a.VolumesFrom },
+			want: pulumi.ToStringArray([]string{volumesFromRef}),
+		},
+		{
+			// network_mode is copied verbatim; the provider parses it with
+			// SidecarParent() and owns the errors for a bad parent.
+			name: "network_mode folds a sidecar into its parent",
+			svc:  compose.ServiceConfig{NetworkMode: "service:app"},
+			got:  func(a awscompose.ServiceConfigArgs) any { return a.NetworkMode },
+			want: pulumi.String("service:app"),
+		},
+		{
+			name: "restart",
+			svc:  compose.ServiceConfig{Restart: "no"},
+			got:  func(a awscompose.ServiceConfigArgs) any { return a.Restart },
+			want: pulumi.String("no"),
+		},
+		{
+			// x-defang-autoscaling: bool in compose, *bool in the SDK.
+			// Written unconditionally for the same reason as ReadOnly.
+			name: "autoscaling",
+			svc:  compose.ServiceConfig{Autoscaling: true},
+			got:  func(a awscompose.ServiceConfigArgs) any { return a.Autoscaling },
+			want: pulumi.Bool(true),
+		},
+		{
+			name: "working_dir",
+			svc:  compose.ServiceConfig{WorkingDir: ptr("/srv")},
+			got:  func(a awscompose.ServiceConfigArgs) any { return a.WorkingDir },
+			want: pulumi.StringPtr("/srv"),
+		},
+		{
+			// Read via GetContainerName: names the ECS container, and the
+			// container a depends_on condition and a volumes_from source
+			// resolve to.
+			name: "container_name",
+			svc:  compose.ServiceConfig{ContainerName: ptr("app-main")},
+			got:  func(a awscompose.ServiceConfigArgs) any { return a.ContainerName },
+			want: pulumi.StringPtr("app-main"),
+		},
+		{
+			// Read via GetStopGracePeriodSeconds: the ECS stopTimeout.
+			name: "stop_grace_period",
+			svc:  compose.ServiceConfig{StopGracePeriod: ptr("90s")},
+			got:  func(a awscompose.ServiceConfigArgs) any { return a.StopGracePeriod },
+			want: pulumi.StringPtr("90s"),
+		},
+		{
+			// x-defang-aliases: read via AliasOptions from aws/elasticache.go
+			// and aws/memorydb.go, so a migrated cluster is adopted rather
+			// than replaced. Dropped, the next up destroys it.
+			name: "aliases adopt a pre-migration cluster",
+			svc:  compose.ServiceConfig{Aliases: map[string]string{compose.AliasCluster: clusterURN}},
+			got:  func(a awscompose.ServiceConfigArgs) any { return a.Aliases },
+			want: pulumi.ToStringMap(map[string]string{compose.AliasCluster: clusterURN}),
+		},
+		{
+			// The drop that started #519: the store deployed as a MinIO ECS
+			// task because the provider never saw the extension.
+			name: "x-defang-s3",
+			svc:  compose.ServiceConfig{ObjectStore: &compose.ObjectStoreConfig{Bucket: "proj-uploads"}},
+			got:  func(a awscompose.ServiceConfigArgs) any { return a.ObjectStore },
+			want: awscompose.ObjectStoreConfigArgs{Bucket: pulumi.String("proj-uploads")},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.got(toAWSServiceArgs(tt.svc)))
+		})
+	}
+}
+
+// A service that asks for none of this must not grow inputs it never declared:
+// an empty ObjectStore would make the provider dispatch a bucket for an
+// ordinary container service.
+func TestServiceArgsLeaveUnsetExtensionsNil(t *testing.T) {
+	svc := compose.ServiceConfig{Image: pulumi.String("nginx")}
+
+	aws := toAWSServiceArgs(svc)
+	assert.Nil(t, aws.ObjectStore)
+	assert.Nil(t, aws.Postgres)
+	assert.Nil(t, aws.Redis)
+	assert.Nil(t, aws.Llm)
+	assert.Nil(t, aws.Volumes)
+	// Autoscaling is written even when off: compose has no "unset" bool, and
+	// an explicit false is what the provider's `if svc.Autoscaling` reads.
+	assert.Equal(t, pulumi.Bool(false), aws.Autoscaling)
+
+	gcp := toGCPServiceArgs(svc)
+	assert.Nil(t, gcp.ObjectStore)
+	assert.Nil(t, gcp.Volumes)
+
+	azure := toAzureServiceArgs(svc)
+	assert.Nil(t, azure.ObjectStore)
+	assert.Nil(t, azure.Volumes)
+}
+
+// The three converters are the same function over three generated packages.
+// Fixing one and not the others is exactly how #519 happened, so assert they
+// agree field for field on the same input.
+func TestServiceArgsAgreeAcrossClouds(t *testing.T) {
+	full := fullService()
+	aws := reflect.ValueOf(toAWSServiceArgs(full))
+	tests := []struct {
+		cloud string
+		args  any
+	}{
+		{cloudGCP, toGCPServiceArgs(full)},
+		{cloudAzure, toAzureServiceArgs(full)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.cloud, func(t *testing.T) {
+			other := reflect.ValueOf(tt.args)
+			require.Equal(t, aws.NumField(), other.NumField())
+			for i := range aws.NumField() {
+				name := aws.Type().Field(i).Name
+				require.Equal(t, name, other.Type().Field(i).Name)
+				// The values are same-shaped types in different packages, so
+				// compare whether each side set the field at all.
+				assert.Equal(t, aws.Field(i).IsZero(), other.Field(i).IsZero(),
+					"ServiceConfigArgs.%s is copied on aws but not on %s (or the reverse)", name, tt.cloud)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`toAWSServiceArgs`, `toGCPServiceArgs` and `toAzureServiceArgs` each copy a parsed compose service into their generated SDK args struct field by field, and each never copied ten of them. The provider then sees a service that never asked for the feature: the deploy succeeds, nothing warns, and the feature is inert. Every unit and provider-mock test still passes, because those build the component inputs directly and never cross this boundary.

That is not theoretical — it is how `x-defang-s3` reached AWS as a MinIO ECS task with no bucket on its first end-to-end run (#518, fixed for that one field in b5b6829). This copies the rest, on all three clouds, and adds a guard that makes the *next* added field fail loudly.

## What the drop costs, per cloud

| compose key | field | AWS | GCP | Azure |
| --- | --- | --- | --- | --- |
| `x-defang-policies` | `Policies` | task-role attachment (`aws/ecs.go:519`) | role grant (`defanggcp/service.go:271`) | rejected with "not supported yet" (`defangazure/service.go:153`) |
| `volumes` | `Volumes` | EFS access points + mounts (`aws/ecs.go:747`) | forces Compute Engine, `-v` flags (`gcp/compute.go:567`) | — |
| `volumes_from` | `VolumesFrom` | ECS `volumesFrom` (`aws/ecs.go:749`) | `--volumes-from` (`gcp/compute.go:575`) | — |
| `network_mode: service:<n>` | `NetworkMode` | `SidecarParent()` folds the service into its parent's task (`defangaws/project.go:31`) | — | — |
| `restart` | `Restart` | container `essential` (`aws/ecs.go:763`) | `Type=oneshot` for jobs (`gcp/compute.go:963`, `gcp/algo.go:35`) | — |
| `x-defang-autoscaling` | `Autoscaling` | app-autoscaling target + policy (`aws/ecs.go:1046`) | — | — |
| `working_dir` | `WorkingDir` | container `workingDirectory` (`aws/ecs.go:745`) | `-w` (`gcp/compute.go:586`) | — |
| `container_name` | `ContainerName` | container name, `depends_on` and `volumes_from` targets (`aws/ecs.go:600`, `:368`, `:302`) | container name (`gcp/compute.go:812`, `:952`) | — |
| `stop_grace_period` | `StopGracePeriod` | ECS `stopTimeout` (`aws/ecs.go:333`) | `docker stop -t` (`gcp/compute.go:766`) | — |
| `x-defang-aliases` | `Aliases` | child-resource adoption for ElastiCache/MemoryDB (`aws/elasticache.go`, `aws/memorydb.go`) | — | — |
| `x-defang-s3` | `ObjectStore` | bucket dispatch (#518) | — (Phase 4) | — (Phase 3) |

### The audit in #519 was wrong about three of these

It listed `container_name`, `stop_grace_period` and the top-level `aliases` as uncopied but unread, so costing nothing today. They are all read — through helper methods on `ServiceConfig`, which is exactly why a grep for the bare field name missed them:

- **`GetContainerName(fallback)`** names the ECS and docker container, and resolves the container that a `depends_on` condition and a `volumes_from` source point at. Dropped, a renamed container silently becomes the service name — and `volumes_from` between two renamed containers resolves to a container that does not exist.
- **`GetStopGracePeriodSeconds()`** is the ECS `stopTimeout` and the `docker stop -t` in the GCP unit file.
- **`AliasOptions(kind)`** is reached from `defangaws/project.go:354` → `createRedis` → `elasticache.go`/`memorydb.go`, so it is on the CD path and not just the standalone `Redis` component. This is the loudest failure in the set: `x-defang-aliases` exists to adopt a pre-migration cluster, and dropping it plans a **replace**, which destroys it.

So the sweep is all ten fields. Nothing is left behind.

## Why all three clouds, not just AWS

The three converters are one function written out three times, once per generated SDK package, and they drop the same ten fields. Fixing AWS alone would close the issue over an identical live bug in two more clouds, and the GCP column above is not empty — `volumes`, `volumes_from`, `working_dir`, `restart`, `container_name`, `stop_grace_period` and `x-defang-policies` all do work there.

`ObjectStore` is included on all three so the copy is total in one place. On AWS that is the same line #518 carries — identical text at the identical position, so the two merge without a conflict whichever lands first. On GCP and Azure nothing reads it yet, so it is inert there today and correct when Phases 3/4 land.

## Arg-shape decisions

**`Volumes`** follows the `Ports` precedent exactly: a `ServiceVolumeConfigArray` under a `len() > 0` guard, one `ServiceVolumeConfigArgs{Source, Target, ReadOnly}` per entry. `ReadOnly` is a plain `bool` in `compose.ServiceVolumeConfig` and a `BoolPtrInput` in the SDK, and it is written unconditionally as `pulumi.Bool(v.ReadOnly)` rather than only when true: the compose type has no "unset" state, so `false` *is* the parsed value, and an explicit false and an absent one mean the same thing to `buildMountPoints`. That is the same call `Ports` already makes for `Mode` and `Protocol`.

**`Autoscaling`** has the same shape mismatch and the same answer — `pulumi.Bool(svc.Autoscaling)`, always. `aws/ecs.go:1046` tests `if svc.Autoscaling`, so nil and false are indistinguishable downstream. Writing it always keeps the copy total, which is what the coverage guard can actually check; a conditional write would be a field the guard cannot see. The same reasoning covers `Restart` and `NetworkMode`, the two bare strings.

**`Policies`** is copied raw, not normalized. `NormalizePolicies` is idempotent and every consumer already calls it, precisely because inputs also arrive from hand-written Pulumi programs that bypass the YAML path. Normalizing in the CD too would be a second place to keep in step, for no gain.

**`NetworkMode`** is copied verbatim rather than re-rendered from `SidecarParent()`. The parse belongs to the provider, which also owns the error messages for a parent that is missing, is itself a sidecar, or is a managed service. The CD's job is to not lose the string.

## Two behaviour changes, both intended

Delivering a field that never arrived changes what the provider does with it:

- **`x-defang-policies` on Azure goes from silent to an error.** `defangazure/service.go:153` rejects a non-empty policy list with "not supported on Azure yet". It has never fired, because the CD never delivered the list. It will now. An explicit unsupported error beats a policy the user believes is attached, but it does turn a working deploy into a failing one for an Azure stack carrying AWS policy ARNs. Entries that normalize away (a `${EXTRA:-}` the stack leaves unset) still deploy, which is what that code path was written for.
- **`x-defang-aliases` on AWS Redis starts adopting.** That is the extension's whole purpose, but it means the next `up` on a stack that carries aliases plans an adopt where it previously planned a replace.

## Tests

New file `cd/program/serviceargs_test.go`, chosen so it does not collide with the `aws_test.go` #518 adds.

- **`TestServiceArgsCopyEveryField`** — the guard. It carries no list of fields to check: it converts a maximal service and the zero service, then compares the two args structs field by field by reflection. A field the converter never touches comes out identical from both, and the failure names it and says what to do. So a field added to the SDK schema **starts out uncopied, and therefore starts out failing** — nobody has to remember to extend a list. Verified by deleting the `Restart` copy from `aws.go`: `ServiceConfigArgs.Restart is not copied by toAWSServiceArgs…`.
- **`TestServiceArgsCopyValues`** — table-driven, one case per field, pinning what each is copied *as*. The guard proves a field was touched; these prove it arrived intact, and they document the two shape decisions above at the point they apply.
- **`TestServiceArgsAgreeAcrossClouds`** — asserts the three converters set the same fields on the same input. Fixing one converter and not the others is exactly how this bug reached three clouds.
- **`TestServiceArgsLeaveUnsetExtensionsNil`** — a plain container service must not grow inputs it never declared; an empty `ObjectStore` would make the provider dispatch a bucket for it.

The maximal fixture deliberately sets `Postgres`, `Redis` and `ObjectStore` at once, which no real compose file would do. The converters validate nothing, so it is a legal probe of the copy — noted in a comment so it does not read as an oversight.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt` clean
- [x] `go test ./provider/...`
- [x] `(cd tests && go test -short ./...)`
- [x] `(cd cd && go test ./...)`
- [x] `golangci-lint run` — clean on the changed files (CI lints `./provider/...`, which this does not touch)
- [x] `make schema` — no drift. Expected: the SDK already declared all ten fields, which is exactly why the drop was invisible.

Not covered: no end-to-end deploy for the nine fields beyond `ObjectStore`. #518's live run is what proved the class of bug and the `ObjectStore` fix; the rest are the same mechanical copy over the same boundary, verified at the unit level.

Fixes #519. Refs #518, DefangLabs/defang-mvp#3084.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197fecoxGCAfRuqfPQfXhaC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cloud deployments now consistently apply service settings across AWS, Azure, and GCP.
  * Service aliases, scaling, networking, restart behavior, policies, volumes, working directories, and object-store bucket settings are now preserved.
  * Previously configured values can be cleared reliably when reset.
  * Volume read-only options and other zero-value settings are handled consistently across cloud providers.

* **Tests**
  * Added comprehensive coverage to verify consistent service configuration across supported cloud platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->