### PR TITLE
fix(cd): stop freezing CodeBuild's credential endpoint into the self-destruct trigger

### DIFF
--- a/cd/program/ttl.go
+++ b/cd/program/ttl.go
@@ -87,12 +87,25 @@ var selfDestructEnvExclude = map[string]bool{
 	"AZURE_FEDERATED_TOKEN_FILE": true,
 	// Credentials must never be frozen into a trigger resource; the scheduled
 	// run authenticates with the ambient (managed) identity instead.
-	"AWS_ACCESS_KEY_ID":                 true,
-	"AWS_SECRET_ACCESS_KEY":             true,
-	"AWS_SESSION_TOKEN":                 true,
-	"AZURE_CLIENT_SECRET":               true,
-	"AZURE_CLIENT_CERTIFICATE_PATH":     true,
-	"AZURE_CLIENT_CERTIFICATE_PASSWORD": true,
+	"AWS_ACCESS_KEY_ID":     true,
+	"AWS_SECRET_ACCESS_KEY": true,
+	"AWS_SESSION_TOKEN":     true,
+	// Not credentials themselves, but where to fetch them: CodeBuild points
+	// the SDK's container-credential provider at a path minted for THIS
+	// build. Freezing it makes the scheduled down ask for a build identity
+	// that no longer exists, and the SDK fails before it reads a single
+	// resource:
+	//   error: read ".pulumi/meta.yaml": ... get credentials:
+	//   InvalidIdInRequest: CredentialsV2Request: Credentials not found
+	// Dropped, so CodeBuild's own value for the new build survives instead of
+	// being overwritten by the environment override.
+	"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": true,
+	"AWS_CONTAINER_CREDENTIALS_FULL_URI":     true,
+	"AWS_CONTAINER_AUTHORIZATION_TOKEN":      true,
+	"AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE": true,
+	"AZURE_CLIENT_SECRET":                    true,
+	"AZURE_CLIENT_CERTIFICATE_PATH":          true,
+	"AZURE_CLIENT_CERTIFICATE_PASSWORD":      true,
 }
 
 // selfDestructEnvPrefixes selects the config-carrying variables. The same

--- a/cd/program/ttl_test.go
+++ b/cd/program/ttl_test.go
@@ -76,6 +76,7 @@ func TestSelfDestructEnv(t *testing.T) {
 		"PULUMI_CONFIG_PASSPHRASE=hunter2",
 		"AZURE_SUBSCRIPTION_ID=sub",
 		"AZURE_LOCATION=westus",
+		"AWS_REGION=us-west-2",
 		// dropped: per-run / runtime / credentials
 		"DEFANG_ETAG=abc123",
 		"DEFANG_TTL=12h",
@@ -89,6 +90,13 @@ func TestSelfDestructEnv(t *testing.T) {
 		"AWS_ACCESS_KEY_ID=AKIA",
 		"AWS_SECRET_ACCESS_KEY=shh",
 		"AWS_SESSION_TOKEN=shh",
+		// Where CodeBuild's credential provider fetches THIS build's identity;
+		// frozen into the schedule it makes the down run ask for a build that
+		// no longer exists.
+		"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI=/v2/credentials/2b0e0f5e-dead-beef",
+		"AWS_CONTAINER_CREDENTIALS_FULL_URI=http://169.254.170.2/v2/credentials/x",
+		"AWS_CONTAINER_AUTHORIZATION_TOKEN=shh",
+		"AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE=/tmp/token",
 		"PATH=/usr/bin",
 		"HOSTNAME=aca-abc",
 		"CONTAINER_APP_JOB_NAME=defang-cd",
@@ -109,6 +117,7 @@ func TestSelfDestructEnv(t *testing.T) {
 		"PULUMI_CONFIG_PASSPHRASE":   "hunter2",
 		"AZURE_SUBSCRIPTION_ID":      "sub",
 		"AZURE_LOCATION":             "westus",
+		"AWS_REGION":                 "us-west-2",
 	}
 	got := SelfDestructEnv(environ)
 	if !reflect.DeepEqual(got, want) {


### PR DESCRIPTION
## The bug

A stack deployed with a TTL is never torn down on AWS. The trigger fires on time, and the `down` build dies before it reads anything:

```
[Container] Running command mkdir -p /app && cd /app && /app/cd down
error: read ".pulumi/meta.yaml": blob (key ".pulumi/meta.yaml") (code=Unknown):
  operation error S3: GetObject, get identity: get credentials:
  failed to refresh cached credentials, failed to load credentials,
  InvalidIdInRequest: CredentialsV2Request: Credentials not found
```

`SelfDestructEnv` keeps every `AWS_`-prefixed variable. That sweeps up `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`, which CodeBuild mints **per build** and which the SDK's container-credential provider uses to fetch credentials. The schedule's `EnvironmentVariablesOverride` then hands that dead path to the down run — overriding the value CodeBuild sets for the *new* build — so the run has no way to authenticate.

The block right above it already says credentials must never be frozen into the trigger. This is the same hazard one level of indirection out: not the credentials, but where to get them.

## The fix

Exclude the four container-credential variables, so each build resolves its own identity:

- `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`
- `AWS_CONTAINER_CREDENTIALS_FULL_URI`
- `AWS_CONTAINER_AUTHORIZATION_TOKEN`
- `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`

`TestSelfDestructEnv` gains them on the dropped side, plus a kept `AWS_REGION` so the prefix rule is still exercised rather than accidentally inverted.

## How it was found

A live deploy on the AWS Lab account (a `new-provider-sanity` run for #518). The schedule fired at 02:24:20Z, the down build failed 29 seconds later, and the ECS services, ALB and bucket were all still standing afterwards. The trigger resource itself was created correctly — description, one-time `at(...)` expression, role and target all as intended — so this is the last step of that feature rather than a design problem with it.

Worth knowing that the TTL is what the smoketest harness relies on to clean up after a job that dies mid-deploy, which is currently every AWS sanity run (#331). Until this lands, a timed-out run leaves its stack up.

## Test plan

- [x] `(cd cd && go build ./... && go vet ./... && go test ./...)`
- [ ] End-to-end: a deploy with `--ttl 1h` whose trigger fires and leaves nothing behind. Needs a CD image built from this branch; I can run it through the sanity harness on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3WmpdY3zc555sNdkY9dzQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduled self-destruct runs to use the intended execution credentials, avoiding interference from deployment-specific AWS credential settings.
  * Preserved the AWS region while excluding container credential and authorization variables that could override the execution environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->