### PR TITLE
fix(aws): forward ECS lifecycle events to CloudWatch so `compose up` completes

### DIFF
--- a/cd/ecs_events_contract_test.go
+++ b/cd/ecs_events_contract_test.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"encoding/json"
-	"strings"
 	"testing"
 
 	"github.com/DefangLabs/defang/src/pkg/clouds/aws/ecs"
+	"github.com/DefangLabs/defang/src/pkg/stackpath"
 	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
 	awsprov "github.com/DefangLabs/pulumi-defang/provider/defangaws/aws"
 	"github.com/stretchr/testify/assert"
@@ -28,19 +28,23 @@ const (
 	contractClusterArn = "arn:aws:ecs:us-west-2:123401343364:cluster/Defang-myproject-beta-cluster-4a858f2"
 )
 
-// TestECSEventsLogGroupMatchesCLI pins the log group name against the CLI's
-// ByocBaseClient.StackDir(project, "ecs"), which is
-// strings.Join([]string{"", prefix, project, stack, name}, "/"). Only a group
-// whose name ends in "/ecs" reaches parseECSSubscribeEvent.
+// TestECSEventsLogGroupMatchesCLI pins the log group name the provider builds.
+// Since DefangLabs/defang#2245 both sides call stackpath.StackDir — the
+// provider through its own stackDir helper, the CLI through
+// ByocBaseClient.StackDir — so the two can no longer disagree by construction.
+// What is still worth pinning is the literal: this exact string is what
+// deployed stacks already carry and what the CLI subscribes to, and only a
+// group whose name ends in "/ecs" reaches parseECSSubscribeEvent.
 //
-// (Spelled out rather than imported: pulling the CLI's byoc package into this
-// module drags its whole compose/UI dependency tree into the cd build.)
+// The import is cheap because stackpath is a stdlib-only leaf; the CLI's byoc
+// package would have dragged its whole compose/UI tree into the cd build,
+// which is why this shape used to be spelled out here instead.
 func TestECSEventsLogGroupMatchesCLI(t *testing.T) {
-	provider := awsprov.StackDir(
-		contractPrefix, contractProject, contractStack, awsprov.ECSEventsLogGroupSuffix)
+	logGroup := stackpath.StackDir(
+		contractPrefix, contractProject, contractStack, stackpath.LogGroupECS)
 
-	assert.Equal(t, "/Defang/myproject/beta/ecs", provider)
-	assert.True(t, strings.HasSuffix(provider, "/ecs"))
+	assert.Equal(t, "/Defang/myproject/beta/ecs", logGroup)
+	assert.True(t, stackpath.IsLogGroup(logGroup, stackpath.LogGroupECS))
 }
 
 // taskStateChangeEvent is an ECS Task State Change as EventBridge delivers it,

--- a/cd/ecs_events_contract_test.go
+++ b/cd/ecs_events_contract_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/DefangLabs/defang/src/pkg/clouds/aws/ecs"
+	defangv1 "github.com/DefangLabs/defang/src/protos/io/defang/v1"
+	awsprov "github.com/DefangLabs/pulumi-defang/provider/defangaws/aws"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The names this provider gives AWS resources are a wire format read by the
+// Defang CLI: `defang compose up` derives service state on AWS only from ECS
+// lifecycle events forwarded into a CloudWatch log group, and every step of
+// that path parses a name. These tests drive the provider's naming helpers
+// through the CLI's own parsers, so a change on either side fails here instead
+// of hanging a deploy. See DefangLabs/pulumi-defang#331.
+const (
+	contractPrefix     = "Defang"
+	contractProject    = "myproject"
+	contractStack      = "beta"
+	contractService    = "app"
+	contractEtag       = "kg7lqwrfnfxa"
+	contractDeployment = "ecs-svc/1234567890123456789"
+	contractClusterArn = "arn:aws:ecs:us-west-2:123401343364:cluster/Defang-myproject-beta-cluster-4a858f2"
+)
+
+// TestECSEventsLogGroupMatchesCLI pins the log group name against the CLI's
+// ByocBaseClient.StackDir(project, "ecs"), which is
+// strings.Join([]string{"", prefix, project, stack, name}, "/"). Only a group
+// whose name ends in "/ecs" reaches parseECSSubscribeEvent.
+//
+// (Spelled out rather than imported: pulling the CLI's byoc package into this
+// module drags its whole compose/UI dependency tree into the cd build.)
+func TestECSEventsLogGroupMatchesCLI(t *testing.T) {
+	provider := awsprov.StackDir(
+		contractPrefix, contractProject, contractStack, awsprov.ECSEventsLogGroupSuffix)
+
+	assert.Equal(t, "/Defang/myproject/beta/ecs", provider)
+	assert.True(t, strings.HasSuffix(provider, "/ecs"))
+}
+
+// taskStateChangeEvent is an ECS Task State Change as EventBridge delivers it,
+// trimmed to the fields the CLI reads.
+func taskStateChangeEvent(t *testing.T, containerName, lastStatus string) []byte {
+	t.Helper()
+	b, err := json.Marshal(map[string]any{
+		"detail-type": "ECS Task State Change",
+		"source":      "aws.ecs",
+		"resources":   []string{"arn:aws:ecs:us-west-2:123401343364:task/x/y"},
+		"detail": map[string]any{
+			"clusterArn":    contractClusterArn,
+			"lastStatus":    lastStatus,
+			"desiredStatus": "RUNNING",
+			"startedBy":     contractDeployment,
+			"taskArn":       "arn:aws:ecs:us-west-2:123401343364:task/x/y",
+			"containers":    []any{map[string]any{"name": containerName}},
+			"overrides": map[string]any{
+				"containerOverrides": []any{map[string]any{"name": containerName}},
+			},
+		},
+	})
+	require.NoError(t, err)
+	return b
+}
+
+// deploymentStateChangeEvent is an ECS Deployment State Change. Note it carries
+// no detail.clusterArn — only the service ARN in resources — which is why the
+// EventBridge rule needs the service-ARN prefix clause.
+func deploymentStateChangeEvent(t *testing.T, serviceArn, eventName string) []byte {
+	t.Helper()
+	b, err := json.Marshal(map[string]any{
+		"detail-type": "ECS Deployment State Change",
+		"source":      "aws.ecs",
+		"resources":   []string{serviceArn},
+		"detail": map[string]any{
+			"eventType":    "INFO",
+			"eventName":    eventName,
+			"deploymentId": contractDeployment,
+		},
+	})
+	require.NoError(t, err)
+	return b
+}
+
+// serviceArn is the ECS service ARN AWS derives from the provider's logical
+// name: autonaming appends "-<hex>" to it.
+func serviceArn(logicalName string) string {
+	return "arn:aws:ecs:us-west-2:123401343364:service/" +
+		"Defang-myproject-beta-cluster-4a858f2/" + logicalName + "-5336ddf"
+}
+
+// TestTaskStateChangeCarriesServiceAndEtag: the CLI reads both the service and
+// the deployment etag out of the CONTAINER name. An unqualified name yields an
+// empty etag, which parseECSSubscribeEvent drops.
+func TestTaskStateChangeCarriesServiceAndEtag(t *testing.T) {
+	containerName := awsprov.QualifiedContainerName(contractService, contractEtag)
+	require.Equal(t, "app_kg7lqwrfnfxa", containerName)
+
+	evt, err := ecs.ParseECSEvent(taskStateChangeEvent(t, containerName, "RUNNING"))
+	require.NoError(t, err)
+
+	assert.Equal(t, contractService, evt.Service())
+	assert.Equal(t, contractEtag, evt.Etag())
+	assert.Equal(t, defangv1.ServiceState_DEPLOYMENT_PENDING, evt.State())
+
+	// Without the etag suffix the CLI recovers neither, and drops the event.
+	bare, err := ecs.ParseECSEvent(taskStateChangeEvent(t, contractService, "RUNNING"))
+	require.NoError(t, err)
+	assert.Empty(t, bare.Etag(), "a bare container name is what makes the CLI drop task events")
+	assert.Empty(t, bare.Service())
+}
+
+// TestDeploymentStateChangeCompletesTheService is the assertion that matters
+// most: DEPLOYMENT_COMPLETED is the state `defang compose up` waits for, and it
+// arrives only on this event, attributed by the ECS SERVICE name and etagged
+// from the cache the task events above populate.
+func TestDeploymentStateChangeCompletesTheService(t *testing.T) {
+	// A task event first: it is what puts deploymentId → etag in the cache.
+	containerName := awsprov.QualifiedContainerName(contractService, contractEtag)
+	_, err := ecs.ParseECSEvent(taskStateChangeEvent(t, containerName, "RUNNING"))
+	require.NoError(t, err)
+
+	logicalName := awsprov.ECSServiceResourceName(contractProject, contractService)
+	require.Equal(t, "myproject_app", logicalName)
+
+	evt, err := ecs.ParseECSEvent(deploymentStateChangeEvent(
+		t, serviceArn(logicalName), "SERVICE_DEPLOYMENT_COMPLETED"))
+	require.NoError(t, err)
+
+	assert.Equal(t, contractService, evt.Service(),
+		"the compose service name must be recoverable from the ECS service ARN")
+	assert.Equal(t, contractEtag, evt.Etag())
+	assert.Equal(t, defangv1.ServiceState_DEPLOYMENT_COMPLETED, evt.State())
+
+	// An unqualified ECS service name (what this provider produced before
+	// #331) leaves the CLI with no service to attribute the event to, so
+	// WaitServiceState never marks anything complete.
+	bare, err := ecs.ParseECSEvent(deploymentStateChangeEvent(
+		t, serviceArn(contractService), "SERVICE_DEPLOYMENT_COMPLETED"))
+	require.NoError(t, err)
+	assert.Empty(t, bare.Service(),
+		"an unqualified ECS service name is what makes `up` hang")
+}
+
+// TestServiceNameSurvivesHyphens: both the project and the service may contain
+// hyphens, and the CLI splits on the first "_" and the last "-".
+func TestServiceNameSurvivesHyphens(t *testing.T) {
+	logicalName := awsprov.ECSServiceResourceName("html-css-js", "s3-probe")
+	evt, err := ecs.ParseECSEvent(deploymentStateChangeEvent(
+		t, serviceArn(logicalName), "SERVICE_DEPLOYMENT_COMPLETED"))
+	require.NoError(t, err)
+	assert.Equal(t, "s3-probe", evt.Service())
+}

--- a/cd/go.mod
+++ b/cd/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers/v3 v3.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.8.0
-	github.com/DefangLabs/defang/src v0.0.0-20260817030354-aeff9113de91
+	github.com/DefangLabs/defang/src v0.0.0-20260903213614-b3aaa2b11a9e
 	github.com/DefangLabs/pulumi-defang v0.0.0-00010101000000-000000000000
 	github.com/DefangLabs/pulumi-defang/sdk/v2/go/defang-aws v0.0.0-00010101000000-000000000000
 	github.com/DefangLabs/pulumi-defang/sdk/v2/go/defang-azure v0.0.0-00010101000000-000000000000

--- a/cd/go.sum
+++ b/cd/go.sum
@@ -66,8 +66,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 h1:RHK7bS+HQMs
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/DefangLabs/defang/src v0.0.0-20260817030354-aeff9113de91 h1:bC6E1+NmjL9rThSb/ajpg7XrsV1XHxjPBd6ocXeDlbI=
-github.com/DefangLabs/defang/src v0.0.0-20260817030354-aeff9113de91/go.mod h1:p3MIVWBg/mFqXf0W3jZtzr8sK1ESQNKlAGhi+3K7gsc=
+github.com/DefangLabs/defang/src v0.0.0-20260903213614-b3aaa2b11a9e h1:nZZ0haAHjcdqL9ieTiH6lZmNPZjVWn1b5baOwFIYCwU=
+github.com/DefangLabs/defang/src v0.0.0-20260903213614-b3aaa2b11a9e/go.mod h1:UMAzJHokHf6SPWkRiYsWYun6B6c8hPEYFboPqseNm3k=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.33.0 h1:l7+6kwRMJNwdCvYdDl7Eax+wzEYHSnNY7zrrfbhDdTA=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.33.0/go.mod h1:pJTkW8hEUIIi3Pf65lPZOnn4Y81yCllX6IWk2jNXdkM=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.57.0 h1:jLdiS1vO+XJFyDSWRHBx56r4s/NNtcl5J6KyCcWUX/w=

--- a/cd/program/azure.go
+++ b/cd/program/azure.go
@@ -279,7 +279,13 @@ func provisionCerts(pctx *pulumi.Context, jobs []certJob, subscriptionID, resour
 			svcCtx, cancel := context.WithTimeout(ctx, perServiceCertTimeout)
 			defer cancel()
 			_ = pctx.Log.Info(fmt.Sprintf("Issuing managed cert for %s at %s", job.service, job.hostname), nil)
-			if err := aca.IssueCert(svcCtx, cred, subscriptionID, resourceGroup, job.service, job.hostname, dns.DirectResolverAt); err != nil {
+			// IssueCert defaults to term.Infof, which writes to the CD task's
+			// stdout; route its progress through the Pulumi log like the rest
+			// of this function.
+			certLog := func(format string, args ...any) {
+				_ = pctx.Log.Info(fmt.Sprintf(format, args...), nil)
+			}
+			if err := aca.IssueCert(svcCtx, cred, subscriptionID, resourceGroup, job.service, job.hostname, dns.DirectResolverAt, certLog); err != nil {
 				_ = pctx.Log.Warn(fmt.Sprintf("managed cert: issuance for %s failed: %v", job.hostname, err), nil)
 			}
 			// Errors are logged, not returned: one job's failure must not cancel

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.5.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.8.0
+	github.com/DefangLabs/defang/src v0.0.0-20260903213614-b3aaa2b11a9e
 	github.com/aws/aws-sdk-go-v2/config v1.32.39
 	github.com/aws/aws-sdk-go-v2/service/codebuild v1.73.0
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.90.4
@@ -156,15 +157,14 @@ require (
 	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/segmentio/encoding v0.3.6 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect
-	github.com/sirupsen/logrus v1.9.3 // indirect
+	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
-	github.com/spf13/cast v1.5.0 // indirect
+	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
-	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xo/terminfo v1.0.0 // indirect
 	github.com/zalando/go-keyring v0.2.8 // indirect
 	github.com/zclconf/go-cty v1.16.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 h1:RHK7bS+HQMs
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/DefangLabs/defang/src v0.0.0-20260903213614-b3aaa2b11a9e h1:nZZ0haAHjcdqL9ieTiH6lZmNPZjVWn1b5baOwFIYCwU=
+github.com/DefangLabs/defang/src v0.0.0-20260903213614-b3aaa2b11a9e/go.mod h1:UMAzJHokHf6SPWkRiYsWYun6B6c8hPEYFboPqseNm3k=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.35.0 h1:bN1gA3of5bXtbnLsRPrwfmbbe7A5UWFlcTHseujLnpc=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.35.0/go.mod h1:Yj5vHEz/aAepZGliRJsA6uvHAVAQyEwajq9ORCHPxzM=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.59.0 h1:c/Ivw7FuawPLfrr+zB0LZKeCchO2cAHQpF2qZ6OV7rQ=
@@ -436,12 +438,12 @@ github.com/segmentio/encoding v0.3.6 h1:E6lVLyDPseWEulBmCmAKPanDd3jiyGDo5gMcugCR
 github.com/segmentio/encoding v0.3.6/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=
 github.com/sergi/go-diff v1.4.0/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
-github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
-github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
+github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=
 github.com/spf13/afero v1.15.0/go.mod h1:NC2ByUVxtQs4b3sIUphxK0NioZnmxgyCrfzeuq8lxMg=
-github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=
-github.com/spf13/cast v1.5.0/go.mod h1:SpXXQ5YoyJw6s3/6cMTQuxvgRl3PCJiyaX9p6b155UU=
+github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
+github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
@@ -456,7 +458,6 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=
 github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
 github.com/texttheater/golang-levenshtein v1.0.1 h1:+cRNoVrfiwufQPhoMzB6N0Yf/Mqajr6t1lOv8GyGE2U=
@@ -582,7 +583,6 @@ golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211110154304-99a53858aa08/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/provider/defangaws/aws/ecs.go
+++ b/provider/defangaws/aws/ecs.go
@@ -81,6 +81,10 @@ type SharedInfra struct {
 	// Etag is the deployment ID supplied by the CD program; empty for
 	// standalone Service callers.
 	Etag string
+	// ProjectName is the compose project name; empty for standalone Service
+	// callers. It qualifies the ECS service name so the CLI can attribute
+	// lifecycle events to a service (see ecsServiceResourceName).
+	ProjectName string
 	Policies
 
 	// Schema-exposed handles to pre-existing infrastructure, for standalone
@@ -294,12 +298,12 @@ func buildMountPoints(volumes []compose.ServiceVolumeConfig) []MountPoint {
 
 // buildVolumesFrom converts compose volumes_from entries to ECS volumesFrom,
 // resolving service names to their container names via the sidecar map.
-func buildVolumesFrom(refs []string, sidecars map[string]compose.ServiceConfig) []VolumeFrom {
+func buildVolumesFrom(refs []string, sidecars map[string]compose.ServiceConfig, etag string) []VolumeFrom {
 	volumesFrom := make([]VolumeFrom, 0, len(refs))
 	for _, ref := range refs {
 		source, readOnly := parseVolumesFrom(ref)
 		if sc, ok := sidecars[source]; ok {
-			source = sc.GetContainerName(source)
+			source = QualifiedContainerName(sc.GetContainerName(source), etag)
 		}
 		volumesFrom = append(volumesFrom, VolumeFrom{
 			SourceContainer: ptr.String(source),
@@ -352,7 +356,7 @@ var composeToEcsConditions = map[string]awsecs.ContainerCondition{
 // dependencies. Only dependencies on sidecar containers in the same task are
 // supported; others are dropped (matches the TS behaviour).
 func buildDependsOn(
-	dependsOn compose.DependsOnConfig, sidecars map[string]compose.ServiceConfig,
+	dependsOn compose.DependsOnConfig, sidecars map[string]compose.ServiceConfig, etag string,
 ) []ContainerDependency {
 	deps := make([]ContainerDependency, 0, len(dependsOn))
 	for depName, dep := range common.Sorted(dependsOn) {
@@ -365,7 +369,7 @@ func buildDependsOn(
 			condition = awsecs.ContainerConditionStart
 		}
 		deps = append(deps, ContainerDependency{
-			ContainerName: ptr.String(sc.GetContainerName(depName)),
+			ContainerName: ptr.String(QualifiedContainerName(sc.GetContainerName(depName), etag)),
 			Condition:     condition,
 		})
 	}
@@ -597,7 +601,7 @@ func CreateECSService(
 	// definitions JSON. The ECS ContainerDefinitions field is a plain JSON string,
 	// so all values must be concrete before marshaling. Each optional input's
 	// index into allInputs is tracked explicitly.
-	containerName := svc.GetContainerName(serviceName)
+	containerName := QualifiedContainerName(svc.GetContainerName(serviceName), infra.Etag)
 
 	allInputs := []interface{}{args.ImageURI}
 	logGroupIdx := -1
@@ -737,7 +741,7 @@ func CreateECSService(
 			Secrets:          mainSecrets,
 			Command:          svc.Command,
 			EntryPoint:       svc.Entrypoint,
-			DependsOn:        buildDependsOn(svc.DependsOn, args.Sidecars),
+			DependsOn:        buildDependsOn(svc.DependsOn, args.Sidecars, infra.Etag),
 			HealthCheck:      healthCheck,
 			Image:            imageUri,
 			LogConfiguration: logConfiguration,
@@ -746,7 +750,7 @@ func CreateECSService(
 			// AWS normalizes these to [] on read; use empty slices to avoid null vs [] diffs
 			MountPoints:    buildMountPoints(svc.Volumes),
 			SystemControls: []SystemControl{},
-			VolumesFrom:    buildVolumesFrom(svc.VolumesFrom, args.Sidecars),
+			VolumesFrom:    buildVolumesFrom(svc.VolumesFrom, args.Sidecars, infra.Etag),
 		}}
 
 		for _, sd := range sidecarDatas {
@@ -757,7 +761,7 @@ func CreateECSService(
 			slices.SortFunc(scEnvVars, func(a, b KeyValuePair) int {
 				return cmp.Compare(a.Name, b.Name)
 			})
-			scContainerName := sd.cfg.GetContainerName(sd.name)
+			scContainerName := QualifiedContainerName(sd.cfg.GetContainerName(sd.name), infra.Etag)
 			containerDefs = append(containerDefs, ContainerDefinition{
 				Name:             scContainerName,
 				Essential:        ptr.Bool(sd.cfg.Restart != "no"),
@@ -766,7 +770,7 @@ func CreateECSService(
 				Secrets:          sd.secrets,
 				Command:          sd.cfg.Command,
 				EntryPoint:       sd.cfg.Entrypoint,
-				DependsOn:        buildDependsOn(sd.cfg.DependsOn, args.Sidecars),
+				DependsOn:        buildDependsOn(sd.cfg.DependsOn, args.Sidecars, infra.Etag),
 				HealthCheck:      buildHealthCheck(sd.cfg.HealthCheck),
 				Image:            all[sd.imageIdx].(string),
 				LogConfiguration: logConfigurationFor(scContainerName),
@@ -774,7 +778,7 @@ func CreateECSService(
 				WorkingDirectory: sd.cfg.WorkingDir,
 				MountPoints:      buildMountPoints(sd.cfg.Volumes),
 				SystemControls:   []SystemControl{},
-				VolumesFrom:      buildVolumesFrom(sd.cfg.VolumesFrom, args.Sidecars),
+				VolumesFrom:      buildVolumesFrom(sd.cfg.VolumesFrom, args.Sidecars, infra.Etag),
 			})
 		}
 
@@ -1006,7 +1010,7 @@ func CreateECSService(
 
 	ecsService, err := ecs.NewService(
 		ctx,
-		serviceName,
+		ECSServiceResourceName(infra.ProjectName, serviceName),
 		ecsServiceArgs,
 		parentOpt,
 		pulumi.DependsOn(lbDependsOn),

--- a/provider/defangaws/aws/events.go
+++ b/provider/defangaws/aws/events.go
@@ -123,10 +123,14 @@ func createECSLifecycleToCWLogs(
 		return string(b), err
 	}).(pulumi.StringOutput)
 
-	// A log resource policy is account+region scoped by name, so it must not
-	// collide with another project's; keep the stack-qualified log group name.
+	// Resource policies are account+region scoped by name, so the name must be
+	// stack-qualified — two projects in one account would otherwise overwrite
+	// each other's policy, and tearing either down would revoke the other's.
+	// NOTE: CloudWatch Logs allows only 10 resource policies per account per
+	// region, so a single account cannot hold more than 10 Defang stacks in a
+	// region. The TS stack had the same per-project policy and the same limit.
 	_, err = cloudwatch.NewLogResourcePolicy(ctx, "ecs-events", &cloudwatch.LogResourcePolicyArgs{
-		PolicyName:     logGroup.Name,
+		PolicyName:     pulumi.String(common.AutonamingPrefix(ctx, "ecs-log-policy")),
 		PolicyDocument: policyDocument,
 	}, opt)
 	if err != nil {

--- a/provider/defangaws/aws/events.go
+++ b/provider/defangaws/aws/events.go
@@ -128,7 +128,7 @@ func createECSLifecycleToCWLogs(
 	// Logs caps account-scoped policies at 10 per region — which the TS stack's
 	// per-project PolicyName would have hit at the 11th stack in an account.
 	// Resource-scoped policies have no such cap, and one attaches per log group.
-	_, err = cloudwatch.NewLogResourcePolicy(ctx, "ecs-events", &cloudwatch.LogResourcePolicyArgs{
+	policy, err := cloudwatch.NewLogResourcePolicy(ctx, "ecs-events", &cloudwatch.LogResourcePolicyArgs{
 		ResourceArn:    logGroup.Arn,
 		PolicyDocument: policyDocument,
 	}, opt)
@@ -146,10 +146,14 @@ func createECSLifecycleToCWLogs(
 		return nil, fmt.Errorf("creating ECS lifecycle event rule: %w", err)
 	}
 
+	// The target is what starts delivery, and EventBridge can only write once
+	// the resource policy exists — neither the rule nor the target references
+	// it, so order them explicitly rather than letting the engine run them in
+	// parallel and drop the events in between.
 	_, err = cloudwatch.NewEventTarget(ctx, "ecs-lifecycle-cw", &cloudwatch.EventTargetArgs{
 		Arn:  logGroup.Arn,
 		Rule: rule.Name,
-	}, opt)
+	}, opt, pulumi.DependsOn([]pulumi.Resource{policy}))
 	if err != nil {
 		return nil, fmt.Errorf("creating ECS lifecycle event target: %w", err)
 	}

--- a/provider/defangaws/aws/events.go
+++ b/provider/defangaws/aws/events.go
@@ -91,14 +91,14 @@ func createECSLifecycleToCWLogs(
 	projectName string,
 	cluster *ecs.Cluster,
 	opt pulumi.ResourceOrInvokeOption,
-) (*cloudwatch.LogGroup, error) {
+) error {
 	logGroup, err := cloudwatch.NewLogGroup(ctx, "ecs-events", &cloudwatch.LogGroupArgs{
 		// Explicit name, not autonaming: the CLI derives this exact string.
 		Name:            pulumi.String(stackDir(ctx, projectName, ECSEventsLogGroupSuffix)),
 		RetentionInDays: pulumi.Int(LogRetentionDays.Get(ctx)),
 	}, opt)
 	if err != nil {
-		return nil, fmt.Errorf("creating ECS events log group: %w", err)
+		return fmt.Errorf("creating ECS events log group: %w", err)
 	}
 
 	// EventBridge writes to a log group through a resource policy on the group,
@@ -133,7 +133,7 @@ func createECSLifecycleToCWLogs(
 		PolicyDocument: policyDocument,
 	}, opt)
 	if err != nil {
-		return nil, fmt.Errorf("creating ECS events log resource policy: %w", err)
+		return fmt.Errorf("creating ECS events log resource policy: %w", err)
 	}
 
 	eventPattern := cluster.Arn.ApplyT(ecsEventPattern).(pulumi.StringOutput)
@@ -143,7 +143,7 @@ func createECSLifecycleToCWLogs(
 		EventPattern: eventPattern,
 	}, opt)
 	if err != nil {
-		return nil, fmt.Errorf("creating ECS lifecycle event rule: %w", err)
+		return fmt.Errorf("creating ECS lifecycle event rule: %w", err)
 	}
 
 	// The target is what starts delivery, and EventBridge can only write once
@@ -155,8 +155,8 @@ func createECSLifecycleToCWLogs(
 		Rule: rule.Name,
 	}, opt, pulumi.DependsOn([]pulumi.Resource{policy}))
 	if err != nil {
-		return nil, fmt.Errorf("creating ECS lifecycle event target: %w", err)
+		return fmt.Errorf("creating ECS lifecycle event target: %w", err)
 	}
 
-	return logGroup, nil
+	return nil
 }

--- a/provider/defangaws/aws/events.go
+++ b/provider/defangaws/aws/events.go
@@ -123,14 +123,13 @@ func createECSLifecycleToCWLogs(
 		return string(b), err
 	}).(pulumi.StringOutput)
 
-	// Resource policies are account+region scoped by name, so the name must be
-	// stack-qualified — two projects in one account would otherwise overwrite
-	// each other's policy, and tearing either down would revoke the other's.
-	// NOTE: CloudWatch Logs allows only 10 resource policies per account per
-	// region, so a single account cannot hold more than 10 Defang stacks in a
-	// region. The TS stack had the same per-project policy and the same limit.
+	// Scope the policy to this log group (ResourceArn) rather than to the
+	// account (PolicyName): exactly one of the two may be set, and CloudWatch
+	// Logs caps account-scoped policies at 10 per region — which the TS stack's
+	// per-project PolicyName would have hit at the 11th stack in an account.
+	// Resource-scoped policies have no such cap, and one attaches per log group.
 	_, err = cloudwatch.NewLogResourcePolicy(ctx, "ecs-events", &cloudwatch.LogResourcePolicyArgs{
-		PolicyName:     pulumi.String(common.AutonamingPrefix(ctx, "ecs-log-policy")),
+		ResourceArn:    logGroup.Arn,
 		PolicyDocument: policyDocument,
 	}, opt)
 	if err != nil {

--- a/provider/defangaws/aws/events.go
+++ b/provider/defangaws/aws/events.go
@@ -5,32 +5,21 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/DefangLabs/defang/src/pkg/stackpath"
 	"github.com/DefangLabs/pulumi-defang/provider/common"
 	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/cloudwatch"
 	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/ecs"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-// ECSEventsLogGroupSuffix is the last path segment of the log group the Defang
-// CLI tails for service state. ByocAws.getSubscribeLogGroupInputs subscribes to
-// StackDir(project, "ecs") and parseSubscribeEvent only routes an event to the
-// ECS parser when the log group name ends in "/ecs", so this suffix — and the
-// StackDir shape around it — is a wire contract with the CLI, not a label.
-const ECSEventsLogGroupSuffix = "ecs"
-
-// StackDir builds the "/<prefix>/<project>/<stack>/<name>" path shared with the
-// CLI (ByocBaseClient.StackDir) and the old TS stack (shared/config.ts stackDir).
-// An empty prefix drops its segment, as it does on both other sides.
-func StackDir(prefix, projectName, stack, name string) string {
-	segments := []string{""} // leading slash
-	if prefix != "" {
-		segments = append(segments, prefix)
-	}
-	return strings.Join(append(segments, projectName, stack, name), "/")
-}
-
+// stackDir builds the log group path the Defang CLI tails, using the CLI's own
+// definition of the shape (stackpath.StackDir, which ByocBaseClient.StackDir
+// also calls). Importing it rather than restating it is what keeps the two
+// sides from drifting: the CLI subscribes to stackpath.LogGroupECS and only
+// routes an event to its ECS parser when the log group name ends in "/ecs", so
+// this path is a wire contract, not a label.
 func stackDir(ctx *pulumi.Context, projectName, name string) string {
-	return StackDir(common.Prefix.Get(ctx), projectName, ctx.Stack(), name)
+	return stackpath.StackDir(common.Prefix.Get(ctx), projectName, ctx.Stack(), name)
 }
 
 // clusterServiceArnPrefix turns a cluster ARN into the prefix every ECS service
@@ -94,7 +83,7 @@ func createECSLifecycleToCWLogs(
 ) error {
 	logGroup, err := cloudwatch.NewLogGroup(ctx, "ecs-events", &cloudwatch.LogGroupArgs{
 		// Explicit name, not autonaming: the CLI derives this exact string.
-		Name:            pulumi.String(stackDir(ctx, projectName, ECSEventsLogGroupSuffix)),
+		Name:            pulumi.String(stackDir(ctx, projectName, stackpath.LogGroupECS)),
 		RetentionInDays: pulumi.Int(LogRetentionDays.Get(ctx)),
 	}, opt)
 	if err != nil {

--- a/provider/defangaws/aws/events.go
+++ b/provider/defangaws/aws/events.go
@@ -1,0 +1,155 @@
+package aws
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/DefangLabs/pulumi-defang/provider/common"
+	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/cloudwatch"
+	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/ecs"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// ECSEventsLogGroupSuffix is the last path segment of the log group the Defang
+// CLI tails for service state. ByocAws.getSubscribeLogGroupInputs subscribes to
+// StackDir(project, "ecs") and parseSubscribeEvent only routes an event to the
+// ECS parser when the log group name ends in "/ecs", so this suffix — and the
+// StackDir shape around it — is a wire contract with the CLI, not a label.
+const ECSEventsLogGroupSuffix = "ecs"
+
+// StackDir builds the "/<prefix>/<project>/<stack>/<name>" path shared with the
+// CLI (ByocBaseClient.StackDir) and the old TS stack (shared/config.ts stackDir).
+// An empty prefix drops its segment, as it does on both other sides.
+func StackDir(prefix, projectName, stack, name string) string {
+	segments := []string{""} // leading slash
+	if prefix != "" {
+		segments = append(segments, prefix)
+	}
+	return strings.Join(append(segments, projectName, stack, name), "/")
+}
+
+func stackDir(ctx *pulumi.Context, projectName, name string) string {
+	return StackDir(common.Prefix.Get(ctx), projectName, ctx.Stack(), name)
+}
+
+// clusterServiceArnPrefix turns a cluster ARN into the prefix every ECS service
+// ARN in that cluster starts with:
+//
+//	arn:aws:ecs:<region>:<account>:cluster/<name>
+//	arn:aws:ecs:<region>:<account>:service/<name>/
+//
+// The TS original derived this by stripping a trailing "cluster" from the
+// cluster name (shared/aws/common.ts clusterArnToServicePrefix), which worked
+// only because its clusters were named "…-cluster"/"…-gpucluster". This
+// provider autonames the cluster ("Defang-<project>-<stack>-cluster-<hex>"), so
+// that regex would fall through and produce a prefix matching nothing.
+func clusterServiceArnPrefix(clusterArn string) string {
+	prefix, name, ok := strings.Cut(clusterArn, ":cluster/")
+	if !ok {
+		return clusterArn // not a cluster ARN; a prefix that matches nothing beats a wrong one
+	}
+	return prefix + ":service/" + name + "/"
+}
+
+// ecsEventPattern is the EventBridge pattern forwarding ECS lifecycle events for
+// one cluster. It mirrors the TS createECSLifeCycleEventRule: "ECS Task State
+// Change" is what carries the container names the CLI reads the etag from, and
+// "ECS Deployment State Change" is the only source of DEPLOYMENT_COMPLETED.
+// Deployment events carry no detail.clusterArn (aws/containers-roadmap#1371),
+// so they are matched on the service-ARN prefix instead.
+func ecsEventPattern(clusterArn string) (string, error) {
+	pattern := map[string]any{
+		"source": []string{"aws.ecs"},
+		"detail-type": []string{
+			"ECS Task State Change",
+			"ECS Service Action",
+			"ECS Deployment State Change",
+		},
+		"$or": []any{
+			map[string]any{
+				"resources": []any{
+					map[string]any{"prefix": clusterServiceArnPrefix(clusterArn)},
+				},
+			},
+			map[string]any{
+				"detail": map[string]any{"clusterArn": []string{clusterArn}},
+			},
+		},
+	}
+	b, err := json.Marshal(pattern)
+	return string(b), err
+}
+
+// createECSLifecycleToCWLogs forwards the cluster's ECS lifecycle events into a
+// CloudWatch log group the Defang CLI subscribes to. Without it `defang compose
+// up` never observes DEPLOYMENT_COMPLETED and blocks until its wait timeout,
+// even though the deploy itself succeeded. Ported from the TS BYOC stack
+// (pulumi/cd/aws/byoc.ts createECSLifecycleToCWLogsEventBridgeRule).
+func createECSLifecycleToCWLogs(
+	ctx *pulumi.Context,
+	projectName string,
+	cluster *ecs.Cluster,
+	opt pulumi.ResourceOrInvokeOption,
+) (*cloudwatch.LogGroup, error) {
+	logGroup, err := cloudwatch.NewLogGroup(ctx, "ecs-events", &cloudwatch.LogGroupArgs{
+		// Explicit name, not autonaming: the CLI derives this exact string.
+		Name:            pulumi.String(stackDir(ctx, projectName, ECSEventsLogGroupSuffix)),
+		RetentionInDays: pulumi.Int(LogRetentionDays.Get(ctx)),
+	}, opt)
+	if err != nil {
+		return nil, fmt.Errorf("creating ECS events log group: %w", err)
+	}
+
+	// EventBridge writes to a log group through a resource policy on the group,
+	// not an IAM role. See DefangLabs/defang-mvp#1514 and
+	// https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-use-resource-based.html#eb-cloudwatchlogs-permissions
+	policyDocument := logGroup.Arn.ApplyT(func(arn string) (string, error) {
+		policy := PolicyDocument{
+			Version: "2012-10-17",
+			Statement: []PolicyStatement{
+				{
+					Sid:    "TrustEventsToStoreLogEvent",
+					Effect: "Allow",
+					Action: []string{"logs:CreateLogStream", "logs:PutLogEvents"},
+					Principal: map[string]any{
+						"Service": []string{"events.amazonaws.com", "delivery.logs.amazonaws.com"},
+					},
+					Resource: arn + ":*", // log stream ARN
+				},
+			},
+		}
+		b, err := json.Marshal(policy)
+		return string(b), err
+	}).(pulumi.StringOutput)
+
+	// A log resource policy is account+region scoped by name, so it must not
+	// collide with another project's; keep the stack-qualified log group name.
+	_, err = cloudwatch.NewLogResourcePolicy(ctx, "ecs-events", &cloudwatch.LogResourcePolicyArgs{
+		PolicyName:     logGroup.Name,
+		PolicyDocument: policyDocument,
+	}, opt)
+	if err != nil {
+		return nil, fmt.Errorf("creating ECS events log resource policy: %w", err)
+	}
+
+	eventPattern := cluster.Arn.ApplyT(ecsEventPattern).(pulumi.StringOutput)
+
+	rule, err := cloudwatch.NewEventRule(ctx, "ecs-lifecycle", &cloudwatch.EventRuleArgs{
+		Description:  pulumi.Sprintf("Capture ECS task lifecycle events of cluster %s", cluster.Arn),
+		EventPattern: eventPattern,
+	}, opt)
+	if err != nil {
+		return nil, fmt.Errorf("creating ECS lifecycle event rule: %w", err)
+	}
+
+	_, err = cloudwatch.NewEventTarget(ctx, "ecs-lifecycle-cw", &cloudwatch.EventTargetArgs{
+		Arn:  logGroup.Arn,
+		Rule: rule.Name,
+	}, opt)
+	if err != nil {
+		return nil, fmt.Errorf("creating ECS lifecycle event target: %w", err)
+	}
+
+	return logGroup, nil
+}

--- a/provider/defangaws/aws/events_test.go
+++ b/provider/defangaws/aws/events_test.go
@@ -120,8 +120,7 @@ func TestCreateECSLifecycleToCWLogsNames(t *testing.T) {
 		cluster, err := ecs.NewCluster(ctx, "cluster", &ecs.ClusterArgs{})
 		require.NoError(t, err)
 		// Version("") is a no-op option: the real caller passes the AWS provider.
-		_, err = createECSLifecycleToCWLogs(ctx, "myproject", cluster, pulumi.Version(""))
-		return err
+		return createECSLifecycleToCWLogs(ctx, "myproject", cluster, pulumi.Version(""))
 	},
 		pulumi.WithMocks("myproject", "beta", mocks),
 		withConfig(map[string]string{

--- a/provider/defangaws/aws/events_test.go
+++ b/provider/defangaws/aws/events_test.go
@@ -1,0 +1,72 @@
+package aws
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStackDir(t *testing.T) {
+	// Same shape as the CLI's ByocBaseClient.StackDir and the TS stackDir.
+	assert.Equal(t, "/Defang/myproject/beta/ecs", StackDir("Defang", "myproject", "beta", "ecs"))
+	assert.Equal(t, "/myproject/beta/ecs", StackDir("", "myproject", "beta", "ecs"))
+}
+
+func TestClusterServiceArnPrefix(t *testing.T) {
+	// The autonamed cluster of a real deploy; note it does NOT end in
+	// "cluster", which is why the TS regex could not be ported literally.
+	assert.Equal(t,
+		"arn:aws:ecs:us-west-2:123401343364:service/Defang-html-css-js-newprovideraws-cluster-4a858f2/",
+		clusterServiceArnPrefix(
+			"arn:aws:ecs:us-west-2:123401343364:cluster/Defang-html-css-js-newprovideraws-cluster-4a858f2"))
+
+	// A service ARN from that cluster must start with the prefix.
+	assert.Equal(t,
+		"arn:aws:ecs:us-west-2:123401343364:service/ecs-dev-cluster/",
+		clusterServiceArnPrefix("arn:aws:ecs:us-west-2:123401343364:cluster/ecs-dev-cluster"))
+
+	// Not a cluster ARN: pass through rather than emit a prefix that would
+	// match unrelated resources.
+	assert.Equal(t, "not-an-arn", clusterServiceArnPrefix("not-an-arn"))
+}
+
+func TestECSEventPattern(t *testing.T) {
+	const clusterArn = "arn:aws:ecs:us-west-2:123401343364:cluster/Defang-proj-beta-cluster-4a858f2"
+
+	raw, err := ecsEventPattern(clusterArn)
+	require.NoError(t, err)
+
+	var pattern struct {
+		Source     []string `json:"source"`
+		DetailType []string `json:"detail-type"`
+		Or         []struct {
+			Resources []struct {
+				Prefix string `json:"prefix"`
+			} `json:"resources"`
+			Detail struct {
+				ClusterArn []string `json:"clusterArn"`
+			} `json:"detail"`
+		} `json:"$or"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(raw), &pattern))
+
+	assert.Equal(t, []string{"aws.ecs"}, pattern.Source)
+	// "ECS Deployment State Change" is the only source of DEPLOYMENT_COMPLETED;
+	// "ECS Task State Change" is what carries the etag. Both are required.
+	assert.Equal(t, []string{
+		"ECS Task State Change",
+		"ECS Service Action",
+		"ECS Deployment State Change",
+	}, pattern.DetailType)
+
+	require.Len(t, pattern.Or, 2)
+	// Deployment state change events carry no detail.clusterArn, so they are
+	// matched on the service-ARN prefix.
+	require.Len(t, pattern.Or[0].Resources, 1)
+	assert.Equal(t,
+		"arn:aws:ecs:us-west-2:123401343364:service/Defang-proj-beta-cluster-4a858f2/",
+		pattern.Or[0].Resources[0].Prefix)
+	assert.Equal(t, []string{clusterArn}, pattern.Or[1].Detail.ClusterArn)
+}

--- a/provider/defangaws/aws/events_test.go
+++ b/provider/defangaws/aws/events_test.go
@@ -12,12 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestStackDir(t *testing.T) {
-	// Same shape as the CLI's ByocBaseClient.StackDir and the TS stackDir.
-	assert.Equal(t, "/Defang/myproject/beta/ecs", StackDir("Defang", "myproject", "beta", "ecs"))
-	assert.Equal(t, "/myproject/beta/ecs", StackDir("", "myproject", "beta", "ecs"))
-}
-
 func TestClusterServiceArnPrefix(t *testing.T) {
 	// The autonamed cluster of a real deploy; note it does NOT end in
 	// "cluster", which is why the TS regex could not be ported literally.

--- a/provider/defangaws/aws/events_test.go
+++ b/provider/defangaws/aws/events_test.go
@@ -2,8 +2,12 @@ package aws
 
 import (
 	"encoding/json"
+	"sync"
 	"testing"
 
+	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/ecs"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -69,4 +73,70 @@ func TestECSEventPattern(t *testing.T) {
 		"arn:aws:ecs:us-west-2:123401343364:service/Defang-proj-beta-cluster-4a858f2/",
 		pattern.Or[0].Resources[0].Prefix)
 	assert.Equal(t, []string{clusterArn}, pattern.Or[1].Detail.ClusterArn)
+}
+
+type eventsTestMocks struct {
+	mu     sync.Mutex
+	inputs map[string]resource.PropertyMap // "<type>/<name>" → inputs
+}
+
+func (m *eventsTestMocks) NewResource(
+	args pulumi.MockResourceArgs,
+) (string, resource.PropertyMap, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.inputs == nil {
+		m.inputs = map[string]resource.PropertyMap{}
+	}
+	m.inputs[args.TypeToken+"/"+args.Name] = args.Inputs
+
+	outputs := args.Inputs.Copy()
+	switch args.TypeToken {
+	case "aws:ecs/cluster:Cluster":
+		outputs["arn"] = resource.NewStringProperty(
+			"arn:aws:ecs:us-west-2:123401343364:cluster/Defang-myproject-beta-cluster-4a858f2")
+	case "aws:cloudwatch/logGroup:LogGroup":
+		outputs["arn"] = resource.NewStringProperty(
+			"arn:aws:logs:us-west-2:123401343364:log-group:/Defang/myproject/beta/ecs")
+	}
+	return args.Name + "_id", outputs, nil
+}
+
+func (m *eventsTestMocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
+	return args.Args, nil
+}
+
+func withConfig(cfg map[string]string) pulumi.RunOption {
+	return func(info *pulumi.RunInfo) { info.Config = cfg }
+}
+
+// TestCreateECSLifecycleToCWLogsNames checks the two names that must not
+// collide between stacks sharing an account: the log group (the CLI derives it
+// from the same prefix/project/stack) and the log resource policy (resource
+// policies are account+region scoped by name, so an unqualified name would let
+// one stack's teardown revoke another's EventBridge writes).
+func TestCreateECSLifecycleToCWLogsNames(t *testing.T) {
+	mocks := &eventsTestMocks{}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		cluster, err := ecs.NewCluster(ctx, "cluster", &ecs.ClusterArgs{})
+		require.NoError(t, err)
+		// Version("") is a no-op option: the real caller passes the AWS provider.
+		_, err = createECSLifecycleToCWLogs(ctx, "myproject", cluster, pulumi.Version(""))
+		return err
+	},
+		pulumi.WithMocks("myproject", "beta", mocks),
+		withConfig(map[string]string{
+			"defang:prefix":     "Defang",
+			"pulumi:autonaming": `{"pattern":"Defang-${project}-${stack}-${name}-${hex(7)}"}`,
+		}),
+	)
+	require.NoError(t, err)
+
+	logGroup, ok := mocks.inputs["aws:cloudwatch/logGroup:LogGroup/ecs-events"]
+	require.True(t, ok, "expected an ECS events log group")
+	assert.Equal(t, "/Defang/myproject/beta/ecs", logGroup["name"].StringValue())
+
+	policy, ok := mocks.inputs["aws:cloudwatch/logResourcePolicy:LogResourcePolicy/ecs-events"]
+	require.True(t, ok, "expected a log resource policy")
+	assert.Equal(t, "Defang-myproject-beta-ecs-log-policy", policy["policyName"].StringValue())
 }

--- a/provider/defangaws/aws/events_test.go
+++ b/provider/defangaws/aws/events_test.go
@@ -110,11 +110,10 @@ func withConfig(cfg map[string]string) pulumi.RunOption {
 	return func(info *pulumi.RunInfo) { info.Config = cfg }
 }
 
-// TestCreateECSLifecycleToCWLogsNames checks the two names that must not
-// collide between stacks sharing an account: the log group (the CLI derives it
-// from the same prefix/project/stack) and the log resource policy (resource
-// policies are account+region scoped by name, so an unqualified name would let
-// one stack's teardown revoke another's EventBridge writes).
+// TestCreateECSLifecycleToCWLogsNames checks the log group name the CLI derives
+// from prefix/project/stack, and that the resource policy is scoped to that log
+// group rather than to the account (account-scoped policies are capped at 10
+// per region, so a per-stack one would break the 11th stack in an account).
 func TestCreateECSLifecycleToCWLogsNames(t *testing.T) {
 	mocks := &eventsTestMocks{}
 	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
@@ -138,5 +137,9 @@ func TestCreateECSLifecycleToCWLogsNames(t *testing.T) {
 
 	policy, ok := mocks.inputs["aws:cloudwatch/logResourcePolicy:LogResourcePolicy/ecs-events"]
 	require.True(t, ok, "expected a log resource policy")
-	assert.Equal(t, "Defang-myproject-beta-ecs-log-policy", policy["policyName"].StringValue())
+	assert.False(t, policy.HasValue("policyName"),
+		"policyName would make the policy account-scoped; exactly one of the two may be set")
+	assert.Equal(t,
+		"arn:aws:logs:us-west-2:123401343364:log-group:/Defang/myproject/beta/ecs",
+		policy["resourceArn"].StringValue())
 }

--- a/provider/defangaws/aws/infra.go
+++ b/provider/defangaws/aws/infra.go
@@ -63,6 +63,13 @@ func CreateProjectInfra(
 		return nil, fmt.Errorf("creating log group: %w", err)
 	}
 
+	// Forward ECS lifecycle events into a CloudWatch log group the CLI tails;
+	// without it `defang compose up` never sees DEPLOYMENT_COMPLETED. Matches
+	// the TS createECSLifecycleToCWLogsEventBridgeRule call in cd/aws/byoc.ts.
+	if _, err := createECSLifecycleToCWLogs(ctx, projectName, cluster, opt); err != nil {
+		return nil, err
+	}
+
 	execRole, err := CreateExecutionRole(ctx, opt)
 	if err != nil {
 		return nil, fmt.Errorf("creating execution role: %w", err)
@@ -208,6 +215,7 @@ func CreateProjectInfra(
 		PrivateZoneID:    net.PrivateZone.ZoneId,
 		PrivateDomain:    net.PrivateDomain,
 		ProjectDomain:    projectDomain,
+		ProjectName:      projectName,
 		PrivateSgID:      privateSg.ID(),
 		AlarmTopicArn:    alarmTopicArn,
 		SkipNatGW:        !net.UseNatGW,

--- a/provider/defangaws/aws/infra.go
+++ b/provider/defangaws/aws/infra.go
@@ -66,7 +66,7 @@ func CreateProjectInfra(
 	// Forward ECS lifecycle events into a CloudWatch log group the CLI tails;
 	// without it `defang compose up` never sees DEPLOYMENT_COMPLETED. Matches
 	// the TS createECSLifecycleToCWLogsEventBridgeRule call in cd/aws/byoc.ts.
-	if _, err := createECSLifecycleToCWLogs(ctx, projectName, cluster, opt); err != nil {
+	if err := createECSLifecycleToCWLogs(ctx, projectName, cluster, opt); err != nil {
 		return nil, err
 	}
 

--- a/provider/defangaws/aws/naming.go
+++ b/provider/defangaws/aws/naming.go
@@ -32,3 +32,40 @@ func targetGroupName(
 
 	return service + suffix
 }
+
+// QualifiedContainerName suffixes a container name with the deployment etag,
+// as the old TS stack did (defang-mvp pulumi/cd/aws/defang_service.ts
+// qualifiedContainerName). This is a wire contract with the Defang CLI, not a
+// label: for every "ECS Task State Change" event the CLI splits the container
+// name on its last "_" and treats the tail as the deployment etag
+// (clouds/aws/ecs/event.go TaskStateChangeEvent.Etag). An unsuffixed name
+// yields an empty etag, which makes parseECSSubscribeEvent drop the event and
+// — worse — leaves the deployment-id → etag cache empty, so the
+// "ECS Deployment State Change" events that carry DEPLOYMENT_COMPLETED are
+// dropped too and `defang compose up` waits forever.
+//
+// The etag is empty for standalone Service callers (no CD deployment), in
+// which case the bare name is used.
+func QualifiedContainerName(name, etag string) string {
+	if etag == "" {
+		return name
+	}
+	return name + "_" + etag
+}
+
+// ECSServiceResourceName is the logical Pulumi name of an ECS service. The
+// physical name is autonamed from it as "<logical>-<hex>", and the Defang CLI
+// parses the compose service back out of the service ARN by taking the text
+// between the first "_" and the last "-" (byoc/aws/... serviceNameFromResources),
+// so the project qualifier is what makes DEPLOYMENT_COMPLETED attributable to a
+// service. Matches the TS `${projectName}_${service_name}` resource name
+// ("FQN but with underscore instead of dots, used by ECS events").
+//
+// projectName is empty for standalone Service callers, which no CLI subscribes
+// to; those keep the bare service name.
+func ECSServiceResourceName(projectName, serviceName string) string {
+	if projectName == "" {
+		return serviceName
+	}
+	return projectName + "_" + serviceName
+}

--- a/provider/defangaws/aws/naming_test.go
+++ b/provider/defangaws/aws/naming_test.go
@@ -1,0 +1,58 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/DefangLabs/pulumi-defang/provider/compose"
+	"github.com/aws/smithy-go/ptr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQualifiedContainerName(t *testing.T) {
+	// The CLI splits on the LAST "_" and treats the tail as the etag.
+	assert.Equal(t, "app_kg7lqwrfnfxa", QualifiedContainerName("app", "kg7lqwrfnfxa"))
+	// A compose container_name is qualified the same way.
+	assert.Equal(t, "sidecar_kg7lqwrfnfxa", QualifiedContainerName("sidecar", "kg7lqwrfnfxa"))
+	// Standalone Service callers have no deployment etag; leave the name bare.
+	assert.Equal(t, "app", QualifiedContainerName("app", ""))
+}
+
+func TestECSServiceResourceName(t *testing.T) {
+	// The CLI takes the text between the FIRST "_" and the LAST "-" of the
+	// autonamed physical name, so both the project and the service may
+	// themselves contain hyphens.
+	assert.Equal(t, "html-css-js_app", ECSServiceResourceName("html-css-js", "app"))
+	assert.Equal(t, "proj_my-service", ECSServiceResourceName("proj", "my-service"))
+	// Standalone Service callers: no project to qualify with.
+	assert.Equal(t, "app", ECSServiceResourceName("", "app"))
+}
+
+// TestBuildDependsOnQualifiesNames checks that an intra-task depends_on keeps
+// pointing at the container it names once container names carry the etag.
+func TestBuildDependsOnQualifiesNames(t *testing.T) {
+	sidecars := map[string]compose.ServiceConfig{
+		"helper": {},
+		"named":  {ContainerName: ptr.String("custom")},
+	}
+	deps := buildDependsOn(compose.DependsOnConfig{
+		"helper":  {Condition: "service_healthy"},
+		"named":   {Condition: "service_started"},
+		"outside": {Condition: "service_started"}, // not in this task; dropped
+	}, sidecars, "kg7lqwrfnfxa")
+
+	got := make([]string, 0, len(deps))
+	for _, d := range deps {
+		got = append(got, *d.ContainerName)
+	}
+	assert.ElementsMatch(t, []string{"helper_kg7lqwrfnfxa", "custom_kg7lqwrfnfxa"}, got)
+}
+
+// TestBuildVolumesFromQualifiesNames is the volumes_from counterpart.
+func TestBuildVolumesFromQualifiesNames(t *testing.T) {
+	sidecars := map[string]compose.ServiceConfig{"helper": {}}
+	vols := buildVolumesFrom([]string{"helper:ro"}, sidecars, "kg7lqwrfnfxa")
+	require.Len(t, vols, 1)
+	assert.Equal(t, "helper_kg7lqwrfnfxa", *vols[0].SourceContainer)
+	assert.True(t, *vols[0].ReadOnly)
+}

--- a/tests/aws/ecs_events_test.go
+++ b/tests/aws/ecs_events_test.go
@@ -1,0 +1,231 @@
+package aws
+
+import (
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/integration"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	awsprov "github.com/DefangLabs/pulumi-defang/provider/defangaws/aws"
+	"github.com/DefangLabs/pulumi-defang/tests/testutil"
+)
+
+// These tests pin the names and the event pattern the Defang CLI parses when it
+// reports service state during `defang compose up`. Every assertion here has a
+// counterpart in the CLI: see cd/ecs_events_cli_contract_test.go, which feeds
+// the same strings through the CLI's own parsers.
+const (
+	testEventsProject = "myproject"
+	testEventsStack   = "beta"
+	testEventsEtag    = "kg7lqwrfnfxa"
+	testClusterArn    = "arn:aws:ecs:us-west-2:123401343364:cluster/Defang-myproject-beta-cluster-4a858f2"
+	testLogGroupArn   = "arn:aws:logs:us-west-2:123401343364:log-group:/Defang/myproject/beta/ecs"
+)
+
+// capturedProject holds the registered resources of one Project construct.
+type capturedProject struct {
+	logGroups      map[string]property.Map // logical name → inputs
+	resourcePolicy property.Map
+	eventRule      property.Map
+	eventTarget    property.Map
+	ecsServices    []string // logical names
+	taskDefs       []property.Map
+}
+
+func constructProjectForEvents(t *testing.T, services map[string]property.Value) *capturedProject {
+	t.Helper()
+
+	captured := &capturedProject{logGroups: map[string]property.Map{}}
+	var mu sync.Mutex
+	mock := &integration.MockResourceMonitor{
+		NewResourceF: func(args integration.MockResourceArgs) (string, property.Map, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			outputs := args.Inputs
+			switch string(args.TypeToken) {
+			case "aws:ecs/cluster:Cluster":
+				// The pattern is built from the cluster ARN, so it has to be
+				// a realistic one rather than the mock's empty default.
+				outputs = withOutput(args.Inputs, "arn", testClusterArn)
+			case "aws:cloudwatch/logGroup:LogGroup":
+				captured.logGroups[args.Name] = args.Inputs
+				outputs = withOutput(args.Inputs, "arn", testLogGroupArn)
+			case "aws:cloudwatch/logResourcePolicy:LogResourcePolicy":
+				captured.resourcePolicy = args.Inputs
+			case "aws:cloudwatch/eventRule:EventRule":
+				captured.eventRule = args.Inputs
+			case "aws:cloudwatch/eventTarget:EventTarget":
+				captured.eventTarget = args.Inputs
+			case "aws:ecs/service:Service":
+				captured.ecsServices = append(captured.ecsServices, args.Name)
+			case "aws:ecs/taskDefinition:TaskDefinition":
+				captured.taskDefs = append(captured.taskDefs, args.Inputs)
+			default:
+			}
+			return args.Name, outputs, nil
+		},
+	}
+
+	server := testutil.MakeAwsTestServer(integration.WithMocks(mock))
+	_, err := server.Construct(p.ConstructRequest{
+		// The component name is the compose project name and the URN's stack
+		// is the Pulumi stack; both appear in the log group path.
+		Urn: resource.NewURN(
+			tokens.QName(testEventsStack), "proj", "",
+			tokens.Type("defang-aws:index:Project"), testEventsProject),
+		Inputs: property.NewMap(map[string]property.Value{
+			"etag":     property.New(testEventsEtag),
+			"services": property.New(property.NewMap(services)),
+		}),
+	})
+	require.NoError(t, err)
+	return captured
+}
+
+func withOutput(inputs property.Map, key, value string) property.Map {
+	m := inputs.AsMap()
+	m[key] = property.New(value)
+	return property.NewMap(m)
+}
+
+// TestAwsProjectCreatesECSEventsLogGroup pins the log group name the CLI
+// subscribes to. ByocAws.getSubscribeLogGroupInputs asks CloudWatch for
+// StackDir(project, "ecs"), and parseSubscribeEvent only routes an event to the
+// ECS parser when the group name ends in "/ecs" — a group under any other name
+// is silently never read.
+func TestAwsProjectCreatesECSEventsLogGroup(t *testing.T) {
+	captured := constructProjectForEvents(t, map[string]property.Value{
+		"app": testutil.ServiceWithImage("nginx:latest"),
+	})
+
+	ecsLogGroup, ok := captured.logGroups["ecs-events"]
+	require.True(t, ok, "expected an ECS events log group")
+	assert.Equal(t, "/Defang/myproject/beta/ecs", ecsLogGroup.Get("name").AsString())
+	assert.Equal(t,
+		awsprov.StackDir("Defang", testEventsProject, testEventsStack, awsprov.ECSEventsLogGroupSuffix),
+		ecsLogGroup.Get("name").AsString())
+
+	// EventBridge writes through a resource policy on the group, not a role.
+	require.NotEqual(t, 0, captured.resourcePolicy.Len(), "expected a log resource policy")
+	assert.Equal(t, "/Defang/myproject/beta/ecs", captured.resourcePolicy.Get("policyName").AsString())
+	var policy struct {
+		Statement []struct {
+			Action    []string `json:"Action"`
+			Effect    string   `json:"Effect"`
+			Principal struct {
+				Service []string `json:"Service"`
+			} `json:"Principal"`
+			Resource string `json:"Resource"`
+		} `json:"Statement"`
+	}
+	require.NoError(t, json.Unmarshal(
+		[]byte(captured.resourcePolicy.Get("policyDocument").AsString()), &policy))
+	require.Len(t, policy.Statement, 1)
+	assert.Equal(t, "Allow", policy.Statement[0].Effect)
+	assert.ElementsMatch(t,
+		[]string{"logs:CreateLogStream", "logs:PutLogEvents"}, policy.Statement[0].Action)
+	assert.ElementsMatch(t,
+		[]string{"events.amazonaws.com", "delivery.logs.amazonaws.com"},
+		policy.Statement[0].Principal.Service)
+	assert.Equal(t, testLogGroupArn+":*", policy.Statement[0].Resource)
+
+	// And the rule has to actually target that group.
+	require.NotEqual(t, 0, captured.eventTarget.Len(), "expected an event target")
+	assert.Equal(t, testLogGroupArn, captured.eventTarget.Get("arn").AsString())
+}
+
+// TestAwsProjectECSEventPattern pins the EventBridge pattern. Deployment state
+// change events (the only source of DEPLOYMENT_COMPLETED) carry no
+// detail.clusterArn, so they match on the service-ARN prefix instead; the
+// cluster of a real deploy does not end in "cluster", so that prefix cannot be
+// derived the way the TS stack derived it.
+func TestAwsProjectECSEventPattern(t *testing.T) {
+	captured := constructProjectForEvents(t, map[string]property.Value{
+		"app": testutil.ServiceWithImage("nginx:latest"),
+	})
+
+	require.NotEqual(t, 0, captured.eventRule.Len(), "expected an ECS lifecycle event rule")
+	raw := captured.eventRule.Get("eventPattern").AsString()
+
+	var pattern map[string]any
+	require.NoError(t, json.Unmarshal([]byte(raw), &pattern))
+	assert.Equal(t, []any{"aws.ecs"}, pattern["source"])
+	assert.Equal(t, []any{
+		"ECS Task State Change",
+		"ECS Service Action",
+		"ECS Deployment State Change",
+	}, pattern["detail-type"])
+
+	servicePrefix := "arn:aws:ecs:us-west-2:123401343364:service/Defang-myproject-beta-cluster-4a858f2/"
+	assert.Contains(t, raw, servicePrefix, "deployment events must match on the service-ARN prefix")
+	assert.Contains(t, raw, testClusterArn, "task events must match on detail.clusterArn")
+}
+
+// TestAwsProjectECSNamesAreCLIParseable pins the two names the CLI reads a
+// service and an etag out of. Both are wire format, not labels.
+func TestAwsProjectECSNamesAreCLIParseable(t *testing.T) {
+	captured := constructProjectForEvents(t, map[string]property.Value{
+		"app": testutil.ServiceWithImage("nginx:latest"),
+	})
+
+	// serviceNameFromResources takes the text between the first "_" and the
+	// last "-" of the autonamed physical name "<logical>-<hex>".
+	require.Len(t, captured.ecsServices, 1)
+	assert.Equal(t, "myproject_app", captured.ecsServices[0])
+
+	// TaskStateChangeEvent.Etag takes the text after the last "_" of the
+	// container name; an empty etag makes the CLI drop the event.
+	require.Len(t, captured.taskDefs, 1)
+	var defs []awsprov.ContainerDefinition
+	require.NoError(t, json.Unmarshal(
+		[]byte(captured.taskDefs[0].Get("containerDefinitions").AsString()), &defs))
+	require.Len(t, defs, 1)
+	assert.Equal(t, "app_"+testEventsEtag, defs[0].Name)
+	assert.Equal(t, testEventsEtag, defs[0].Name[strings.LastIndex(defs[0].Name, "_")+1:])
+}
+
+// TestAwsProjectSidecarContainerNamesQualified checks that intra-task
+// volumes_from references still resolve once container names carry the etag.
+// (depends_on on an own sidecar is covered by TestBuildDependsOnQualifiesNames;
+// it cannot be driven through Project — see the TopologicalSort note in the PR.)
+func TestAwsProjectSidecarContainerNamesQualified(t *testing.T) {
+	captured := constructProjectForEvents(t, map[string]property.Value{
+		"app": property.New(property.NewMap(map[string]property.Value{
+			"image":       property.New("myapp:latest"),
+			"volumesFrom": property.New(property.NewArray([]property.Value{property.New("helper")})),
+		})),
+		"helper": property.New(property.NewMap(map[string]property.Value{
+			"image":       property.New("helper:latest"),
+			"networkMode": property.New("service:app"),
+		})),
+	})
+
+	require.Len(t, captured.taskDefs, 1)
+	var defs []awsprov.ContainerDefinition
+	require.NoError(t, json.Unmarshal(
+		[]byte(captured.taskDefs[0].Get("containerDefinitions").AsString()), &defs))
+	require.Len(t, defs, 2)
+
+	names := map[string]awsprov.ContainerDefinition{}
+	for _, d := range defs {
+		names[d.Name] = d
+	}
+	require.Contains(t, names, "app_"+testEventsEtag)
+	require.Contains(t, names, "helper_"+testEventsEtag)
+
+	main := names["app_"+testEventsEtag]
+	require.Len(t, main.VolumesFrom, 1)
+	assert.Equal(t, "helper_"+testEventsEtag, *main.VolumesFrom[0].SourceContainer)
+
+	// The main container must stay first: TaskStateChangeEvent reads
+	// containerOverrides[0] to identify the service.
+	assert.Equal(t, "app_"+testEventsEtag, defs[0].Name)
+}

--- a/tests/aws/ecs_events_test.go
+++ b/tests/aws/ecs_events_test.go
@@ -115,9 +115,9 @@ func TestAwsProjectCreatesECSEventsLogGroup(t *testing.T) {
 
 	// EventBridge writes through a resource policy on the group, not a role.
 	require.NotEqual(t, 0, captured.resourcePolicy.Len(), "expected a log resource policy")
-	// Stack-qualified: two projects in one account must not overwrite each
-	// other's policy (resource policies are account+region scoped by name).
-	assert.Equal(t, "ecs-log-policy", captured.resourcePolicy.Get("policyName").AsString())
+	// Scoped to the log group, not the account: account-scoped policies are
+	// capped at 10 per region.
+	assert.Equal(t, testLogGroupArn, captured.resourcePolicy.Get("resourceArn").AsString())
 	var policy struct {
 		Statement []struct {
 			Action    []string `json:"Action"`

--- a/tests/aws/ecs_events_test.go
+++ b/tests/aws/ecs_events_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/DefangLabs/defang/src/pkg/stackpath"
 	awsprov "github.com/DefangLabs/pulumi-defang/provider/defangaws/aws"
 	"github.com/DefangLabs/pulumi-defang/tests/testutil"
 )
@@ -109,8 +110,9 @@ func TestAwsProjectCreatesECSEventsLogGroup(t *testing.T) {
 	ecsLogGroup, ok := captured.logGroups["ecs-events"]
 	require.True(t, ok, "expected an ECS events log group")
 	assert.Equal(t, "/Defang/myproject/beta/ecs", ecsLogGroup.Get("name").AsString())
+	// Same name the CLI derives, from the CLI's own definition of the shape.
 	assert.Equal(t,
-		awsprov.StackDir("Defang", testEventsProject, testEventsStack, awsprov.ECSEventsLogGroupSuffix),
+		stackpath.StackDir("Defang", testEventsProject, testEventsStack, stackpath.LogGroupECS),
 		ecsLogGroup.Get("name").AsString())
 
 	// EventBridge writes through a resource policy on the group, not a role.

--- a/tests/aws/ecs_events_test.go
+++ b/tests/aws/ecs_events_test.go
@@ -38,6 +38,7 @@ type capturedProject struct {
 	eventRule      property.Map
 	eventTarget    property.Map
 	ecsServices    []string // logical names
+	ecsServiceArgs []property.Map
 	taskDefs       []property.Map
 }
 
@@ -67,6 +68,7 @@ func constructProjectForEvents(t *testing.T, services map[string]property.Value)
 				captured.eventTarget = args.Inputs
 			case "aws:ecs/service:Service":
 				captured.ecsServices = append(captured.ecsServices, args.Name)
+				captured.ecsServiceArgs = append(captured.ecsServiceArgs, args.Inputs)
 			case "aws:ecs/taskDefinition:TaskDefinition":
 				captured.taskDefs = append(captured.taskDefs, args.Inputs)
 			default:
@@ -184,6 +186,15 @@ func TestAwsProjectECSNamesAreCLIParseable(t *testing.T) {
 	// last "-" of the autonamed physical name "<logical>-<hex>".
 	require.Len(t, captured.ecsServices, 1)
 	assert.Equal(t, "myproject_app", captured.ecsServices[0])
+
+	// The assertion above is only about the wire format because the service is
+	// autonamed: with no "name" input Pulumi derives the physical name from the
+	// logical one. Setting "name" explicitly would break that derivation while
+	// leaving the assertion green, so pin its absence.
+	require.Len(t, captured.ecsServiceArgs, 1)
+	_, hasName := captured.ecsServiceArgs[0].GetOk("name")
+	assert.False(t, hasName,
+		"ECS service must stay autonamed; an explicit name breaks the <logical>-<hex> shape the CLI parses")
 
 	// TaskStateChangeEvent.Etag takes the text after the last "_" of the
 	// container name; an empty etag makes the CLI drop the event.

--- a/tests/aws/ecs_events_test.go
+++ b/tests/aws/ecs_events_test.go
@@ -115,7 +115,9 @@ func TestAwsProjectCreatesECSEventsLogGroup(t *testing.T) {
 
 	// EventBridge writes through a resource policy on the group, not a role.
 	require.NotEqual(t, 0, captured.resourcePolicy.Len(), "expected a log resource policy")
-	assert.Equal(t, "/Defang/myproject/beta/ecs", captured.resourcePolicy.Get("policyName").AsString())
+	// Stack-qualified: two projects in one account must not overwrite each
+	// other's policy (resource policies are account+region scoped by name).
+	assert.Equal(t, "ecs-log-policy", captured.resourcePolicy.Get("policyName").AsString())
 	var policy struct {
 		Statement []struct {
 			Action    []string `json:"Action"`

--- a/tests/aws/objectstore_test.go
+++ b/tests/aws/objectstore_test.go
@@ -172,8 +172,10 @@ func TestConstructAwsProjectObjectStoreGrant(t *testing.T) {
 	}
 
 	// The store itself is a bucket, not a task: it must not reach ECS even
-	// though the compose service carries a minio image anchor.
-	assert.Equal(t, []string{"app"}, m.services())
+	// though the compose service carries a minio image anchor. The name is
+	// project-qualified ("<project>_<service>", and AwsURN names the component
+	// "name") because the CLI parses the service out of the ECS event.
+	assert.Equal(t, []string{"name_app"}, m.services())
 }
 
 // depends_on is the wiring contract — it is what the CLI injects


### PR DESCRIPTION
Closes #331.

The old TS BYOC stack unconditionally created an EventBridge rule forwarding ECS task lifecycle events for the cluster into an `ecs` CloudWatch log group. The Go port has no equivalent, and that is not a cosmetic parity gap: the Defang CLI has no other source of service state on AWS, so `defang compose up` **never completes** — it blocks in `WaitServiceState` until the wait timeout while every service is already healthy. It is also why every `new-provider-sanity` AWS run since August ends `cancelled` at the 30-minute job timeout.

## What the CLI actually requires

`ByocAws.Subscribe` tails CloudWatch and `parseSubscribeEvent` routes on the log-group name, reaching `parseECSSubscribeEvent` only for a group whose name ends in `/ecs`. `getSubscribeLogGroupInputs` subscribes to exactly `StackDir(project, "ecs")`. From there, `DEPLOYMENT_COMPLETED` arrives only on an `ECS Deployment State Change` event, and only if **both**:

1. `Etag()` is non-empty — for a deployment event the etag comes from `DeploymentEtags`, a cache populated only by `ECS Task State Change` events, whose etag is parsed out of the **container name** after its last `_`; and
2. `Name` matches a requested service — `serviceNameFromResources` parses the **ECS service ARN** as `<project>_<service>-<hex>`, taking the text between the first `_` and the last `-`.

The rule alone therefore would not have fixed the hang. All three had to be right.

## What this changes

**1. The rule (`provider/defangaws/aws/events.go`, new).** Log group named `/<prefix>/<project>/<stack>/ecs`, the `LogResourcePolicy` letting `events.amazonaws.com` + `delivery.logs.amazonaws.com` write to it (parity with the TS policy, DefangLabs/defang-mvp#1514), the cluster's `EventRule`, and the `EventTarget` joining them. Wired into `CreateProjectInfra` right after the cluster, as the TS wired it after `createCommon`.

**2. Container name → `<service>_<etag>`** (`<service>_<sidecar>_<etag>` shape preserved for sidecars), matching the TS `qualifiedContainerName`. Intra-task `depends_on` and `volumes_from` references are qualified with it so they keep resolving.

**3. ECS service logical name → `<project>_<service>`**, matching the TS `${projectName}_${service_name}` and its comment: *"FQN but with underscore instead of dots, used by ECS events"*.

Both (2) and (3) fall back to the bare name when the etag / project name is empty, i.e. for standalone `Service` callers, which no CLI subscribes to.

## How the match was verified

**Against the live AWS Lab account** (`org-readonly`, us-west-2), on the stack left over from the last sanity run (project `html-css-js`, stack `newprovideraws`) — this is what the provider produces today versus what the TS stack produced:

| | old TS BYOC (same account) | Go provider before this PR |
|---|---|---|
| log group | `/Defang/<project>/<stack>/ecs` | absent — only `Defang-html-css-js-newprovideraws-logs-edaf68b` |
| EventBridge rule | one per cluster | none; `aws events list-rules` returns only the unrelated `ecs-managed-capacity-provider-rule` |
| ECS service | `Defang-redis-js-beta-redis-js_app-<hex>` | `app-906bc63`, `s3probe-5336ddf` → `serviceNameFromResources` → `""` |
| container | `app_eyfqs3iizwq2` | `app`, `s3probe` → empty etag → every task event dropped, etag cache never populated |

**One more mismatch that a literal port would have introduced.** The TS derives the service-ARN prefix with `clusterArnToServicePrefix`, which strips a trailing `cluster` from the cluster name — it worked only because TS clusters were named `…-cluster`/`…-gpucluster`. This provider autonames the cluster `Defang-html-css-js-newprovideraws-cluster-4a858f2`, which does **not** end in `cluster`, so that regex falls through and yields a prefix matching nothing. Since `ECS Deployment State Change` carries no `detail.clusterArn` (aws/containers-roadmap#1371), that clause is the *only* thing matching the events that carry `DEPLOYMENT_COMPLETED` — a literal port would have reproduced the same silent hang with a rule present. The prefix is built from the cluster ARN directly instead (`:cluster/<name>` → `:service/<name>/`).

**In tests.** `cd/ecs_events_contract_test.go` builds synthetic ECS events from the provider's own naming helpers and feeds them through the CLI's real parsers (`clouds/aws/ecs.ParseECSEvent`), asserting a `SERVICE_DEPLOYMENT_COMPLETED` resolves to the compose service name, the deployment etag, and `ServiceState_DEPLOYMENT_COMPLETED` — and that the pre-PR unqualified names resolve to nothing. `tests/aws/ecs_events_test.go` pins what the provider registers: the log group name, the resource policy, the event target, the pattern's detail-types and both `$or` clauses, and the two names.

## End-to-end

Pending: a `new-provider-sanity` run on `ci/sanity-x-defang-s3` against `ghcr.io/defanglabs/cd:pr-<N>` from this PR, with `providers=aws`. A run that reaches `Down` instead of timing out at 30 minutes is the acceptance test, and would be the first green AWS sanity run. Result will be posted here.

## Blast radius

(2) and (3) change resource identity, so an existing Go-provider stack replaces its ECS services and task definitions on the next `up`. Unavoidable — the names *are* the wire format the CLI parses — and there are no GA consumers on this path yet. Callers migrating a pre-existing deployment can pin the old URNs through the existing `x-defang-aliases` mechanism.

## Out of scope, filed separately

- The CLI also subscribes to `/<prefix>/<project>/<stack>/builds` for CodeBuild progress; this provider does not create that group either. It costs build progress reporting only, not completion, so it does not block `up` — #523.
- `common.TopologicalSort` emits names that are not nodes, so a `depends_on` naming a service's own sidecar makes the dispatcher try to build a phantom service and fail with `no image or build config` — #524. It is why the sidecar test here exercises `volumes_from` rather than `depends_on` through `Project`.

## Checks

`go build ./...`, `go test ./provider/...`, `cd tests && go test -short ./...`, `cd cd && go test -race ./...`, `golangci-lint run --config=.golangci.yaml ./provider/...` (no new findings; the local 2.12.2 baseline noise is identical on `main`, and CI pins 2.11.4), and `make schema` — no drift, since `SharedInfra.ProjectName` is untagged and stays out of the schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added ECS lifecycle event forwarding to CloudWatch and EventBridge for task, service, and deployment events.
  - Added project-scoped ECS resource naming and CLI-compatible log-group paths.
  - Added deployment identifiers to container and dependency references for reliable event tracking and sidecar relationships.
  - Added resource-scoped permissions for ECS event logs.

- **Bug Fixes**
  - Improved handling of hyphenated service names and CLI parsing.
  - Deployment completion events are now correctly attributed to their associated service.
  - Certificate issuance progress is now routed through managed deployment logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->