### PR TITLE
fix(gcp): pass dockerfile, build args and target to Cloud Build

### DIFF
--- a/provider/defanggcp/gcp/image.go
+++ b/provider/defanggcp/gcp/image.go
@@ -103,9 +103,13 @@ func generateBuildSteps(build *compose.BuildConfig, dest pulumi.StringOutput) pu
 		buildArgs = append(buildArgs, "--target", target)
 	}
 	// Values travel in the step's env rather than on the command line, so they
-	// stay out of the Pulumi state that records these steps. Sorted for a
-	// stable ordering: a map walk would reshuffle the args every run and make
-	// the Build resource look changed when it isn't.
+	// do not show up in the docker invocation Cloud Build logs. They are not
+	// hidden from Pulumi state: env is part of the same steps YAML that becomes
+	// the Build resource's steps input. Compose build args are not a secret
+	// channel — Docker bakes them into image history — so that is acceptable
+	// here; anything genuinely secret belongs in a BuildKit secret mount, not
+	// in build args. Sorted for a stable ordering: a map walk would reshuffle
+	// the args every run and make the Build resource look changed when it isn't.
 	var buildEnv []string
 	for k, v := range common.Sorted(build.Args) {
 		buildArgs = append(buildArgs, "--build-arg", k)

--- a/provider/defanggcp/gcp/image.go
+++ b/provider/defanggcp/gcp/image.go
@@ -113,7 +113,11 @@ func generateBuildSteps(build *compose.BuildConfig, dest pulumi.StringOutput) pu
 	var buildEnv []string
 	for k, v := range common.Sorted(build.Args) {
 		buildArgs = append(buildArgs, "--build-arg", k)
-		buildEnv = append(buildEnv, k+"="+v)
+		// Cloud Build expands $VAR / ${VAR} substitutions in steps.env before
+		// running the step, so a literal $ in the value (e.g. an arg that
+		// happens to read "$PROJECT_ID") must be escaped to $$ to survive as
+		// the literal Compose value rather than being substituted away.
+		buildEnv = append(buildEnv, k+"="+strings.ReplaceAll(v, "$", "$$"))
 	}
 	for _, c := range build.CacheFrom {
 		buildArgs = append(buildArgs, "--cache-from="+c)

--- a/provider/defanggcp/gcp/image.go
+++ b/provider/defanggcp/gcp/image.go
@@ -81,6 +81,7 @@ type gcpBuildResource struct {
 type buildStep struct {
 	Name string   `yaml:"name"`
 	Args []string `yaml:"args"`
+	Env  []string `yaml:"env,omitempty"`
 }
 
 // generateBuildSteps returns a YAML-encoded Cloud Build step list that builds
@@ -97,6 +98,19 @@ func generateBuildSteps(build *compose.BuildConfig, dest pulumi.StringOutput) pu
 		platform = build.Platforms[0]
 	}
 	buildArgs := []string{"buildx", "build", "--platform", platform}
+	buildArgs = append(buildArgs, "-f", build.GetDockerfile())
+	if target := build.GetTarget(); target != "" {
+		buildArgs = append(buildArgs, "--target", target)
+	}
+	// Values travel in the step's env rather than on the command line, so they
+	// stay out of the Pulumi state that records these steps. Sorted for a
+	// stable ordering: a map walk would reshuffle the args every run and make
+	// the Build resource look changed when it isn't.
+	var buildEnv []string
+	for k, v := range common.Sorted(build.Args) {
+		buildArgs = append(buildArgs, "--build-arg", k)
+		buildEnv = append(buildEnv, k+"="+v)
+	}
 	for _, c := range build.CacheFrom {
 		buildArgs = append(buildArgs, "--cache-from="+c)
 	}
@@ -118,6 +132,7 @@ func generateBuildSteps(build *compose.BuildConfig, dest pulumi.StringOutput) pu
 			{
 				Name: "gcr.io/cloud-builders/docker",
 				Args: append(buildArgs, "-t", d, "--load", "."),
+				Env:  buildEnv,
 			},
 		}
 		b, err := yaml.Marshal(steps)

--- a/provider/defanggcp/gcp/image_test.go
+++ b/provider/defanggcp/gcp/image_test.go
@@ -532,7 +532,12 @@ func TestGenerateBuildStepsPassesBuildArgsInEnv(t *testing.T) {
 	})
 
 	assert.Equal(t, []string{"API_URL=https://example.invalid", "MODE=production"}, steps[1].Env)
-	assert.Subset(t, steps[1].Args, []string{"--build-arg", "MODE", "API_URL"})
+	assert.Equal(t, []string{
+		"buildx", "build", "--platform", "linux/amd64",
+		"-f", "Dockerfile",
+		"--build-arg", "API_URL", "--build-arg", "MODE",
+		"-t", "us-central1-docker.pkg.dev/my-project/my-repo/app:latest", "--load", ".",
+	}, steps[1].Args, "--build-arg flags must pair with their sorted keys, in order")
 	argsLine := strings.Join(steps[1].Args, " ")
 	assert.NotContains(t, argsLine, "production",
 		"build arg values must not appear on the command line")

--- a/provider/defanggcp/gcp/image_test.go
+++ b/provider/defanggcp/gcp/image_test.go
@@ -521,8 +521,10 @@ func TestGenerateBuildStepsDefaultsDockerfile(t *testing.T) {
 }
 
 // Build args reach the build as --build-arg KEY with the value in the step's
-// env, so values stay out of the Pulumi state that stores these steps.
-// Ordering is sorted so an unchanged build does not look changed.
+// env, so values are absent from the docker invocation in the Cloud Build log
+// (they are not hidden from Pulumi state: env is part of the same steps YAML
+// that becomes the Build resource's steps input). Ordering is sorted so an
+// unchanged build does not look changed.
 func TestGenerateBuildStepsPassesBuildArgsInEnv(t *testing.T) {
 	steps := renderBuildSteps(t, &compose.BuildConfig{
 		Context: pulumi.String("./app"),
@@ -531,8 +533,24 @@ func TestGenerateBuildStepsPassesBuildArgsInEnv(t *testing.T) {
 
 	assert.Equal(t, []string{"API_URL=https://example.invalid", "MODE=production"}, steps[1].Env)
 	assert.Subset(t, steps[1].Args, []string{"--build-arg", "MODE", "API_URL"})
-	assert.NotContains(t, strings.Join(steps[1].Args, " "), "production",
+	argsLine := strings.Join(steps[1].Args, " ")
+	assert.NotContains(t, argsLine, "production",
 		"build arg values must not appear on the command line")
+	assert.NotContains(t, argsLine, "https://example.invalid",
+		"build arg values must not appear on the command line")
+}
+
+// Cloud Build expands $VAR / ${VAR} substitutions in steps.env before running
+// the step, so a literal $ in a build arg value must be escaped to $$ or it
+// is silently replaced (e.g. by the actual project ID) rather than reaching
+// Docker as the Compose value.
+func TestGenerateBuildStepsEscapesDollarInBuildArgValues(t *testing.T) {
+	steps := renderBuildSteps(t, &compose.BuildConfig{
+		Context: pulumi.String("./app"),
+		Args:    map[string]string{"REF": "$PROJECT_ID"},
+	})
+
+	assert.Equal(t, []string{"REF=$$PROJECT_ID"}, steps[1].Env)
 }
 
 func TestGenerateBuildStepsPassesTarget(t *testing.T) {

--- a/provider/defanggcp/gcp/image_test.go
+++ b/provider/defanggcp/gcp/image_test.go
@@ -461,3 +461,93 @@ func TestBuildServiceImageDependsOnBucketIAMMember(t *testing.T) {
 	assert.True(t, hasBucketIAMDep,
 		"Build resource must depend on BucketIAMMember (got deps: %v)", spy.buildDeps)
 }
+
+// renderBuildSteps runs generateBuildSteps and returns the decoded step list.
+func renderBuildSteps(t *testing.T, build *compose.BuildConfig) []buildStep {
+	t.Helper()
+	const dest = "us-central1-docker.pkg.dev/my-project/my-repo/app:latest"
+
+	var steps []buildStep
+	var unmarshalErr error
+	var wg sync.WaitGroup
+	wg.Add(1)
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		out := generateBuildSteps(build, pulumi.String(dest).ToStringOutput())
+		out.ApplyT(func(stepsYAML string) string {
+			defer wg.Done()
+			unmarshalErr = yaml.Unmarshal([]byte(stepsYAML), &steps)
+			return stepsYAML
+		})
+		return nil
+	}, pulumi.WithMocks("proj", "stack", testMocks{}))
+	require.NoError(t, err)
+	wg.Wait()
+	require.NoError(t, unmarshalErr)
+	require.Len(t, steps, 2)
+	return steps
+}
+
+// argValue returns the token following flag in args.
+func argValue(t *testing.T, args []string, flag string) string {
+	t.Helper()
+	for i, a := range args {
+		if a == flag && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	t.Fatalf("flag %q not found in %v", flag, args)
+	return ""
+}
+
+// A compose service is free to name its Dockerfile something other than
+// "Dockerfile" (`dockerfile: api.Dockerfile`). Without -f, buildx looks for
+// <context>/Dockerfile and the build dies with
+// "failed to read dockerfile: open Dockerfile: no such file or directory".
+func TestGenerateBuildStepsPassesDockerfile(t *testing.T) {
+	dockerfile := "api.Dockerfile"
+	steps := renderBuildSteps(t, &compose.BuildConfig{
+		Context:    pulumi.String("."),
+		Dockerfile: &dockerfile,
+	})
+
+	assert.Equal(t, dockerfile, argValue(t, steps[1].Args, "-f"))
+}
+
+// Unset dockerfile still has to be passed explicitly; GetDockerfile defaults it.
+func TestGenerateBuildStepsDefaultsDockerfile(t *testing.T) {
+	steps := renderBuildSteps(t, &compose.BuildConfig{Context: pulumi.String("./app")})
+
+	assert.Equal(t, "Dockerfile", argValue(t, steps[1].Args, "-f"))
+}
+
+// Build args reach the build as --build-arg KEY with the value in the step's
+// env, so values stay out of the Pulumi state that stores these steps.
+// Ordering is sorted so an unchanged build does not look changed.
+func TestGenerateBuildStepsPassesBuildArgsInEnv(t *testing.T) {
+	steps := renderBuildSteps(t, &compose.BuildConfig{
+		Context: pulumi.String("./app"),
+		Args:    map[string]string{"MODE": "production", "API_URL": "https://example.invalid"},
+	})
+
+	assert.Equal(t, []string{"API_URL=https://example.invalid", "MODE=production"}, steps[1].Env)
+	assert.Subset(t, steps[1].Args, []string{"--build-arg", "MODE", "API_URL"})
+	assert.NotContains(t, strings.Join(steps[1].Args, " "), "production",
+		"build arg values must not appear on the command line")
+}
+
+func TestGenerateBuildStepsPassesTarget(t *testing.T) {
+	target := "runtime"
+	steps := renderBuildSteps(t, &compose.BuildConfig{
+		Context: pulumi.String("./app"),
+		Target:  &target,
+	})
+
+	assert.Equal(t, target, argValue(t, steps[1].Args, "--target"))
+}
+
+func TestGenerateBuildStepsOmitsTargetWhenUnset(t *testing.T) {
+	steps := renderBuildSteps(t, &compose.BuildConfig{Context: pulumi.String("./app")})
+
+	assert.NotContains(t, steps[1].Args, "--target")
+	assert.Empty(t, steps[1].Env)
+}


### PR DESCRIPTION
## Problem

`generateBuildSteps` (`provider/defanggcp/gcp/image.go`) emitted only `--platform` and the cache flags. Three compose `build:` fields never reached `buildx`:

| field | effect on GCP today |
|---|---|
| `dockerfile:` | **ignored** — anything not named `Dockerfile` fails the build |
| `args:` | **silently dropped** — image builds without them |
| `target:` | **silently dropped** — wrong stage published |

The hard failure looks like this:

```
ERROR: failed to solve: failed to read dockerfile: open Dockerfile: no such file or directory
```

The two silent ones are worse: the build *succeeds* and ships an image assembled with the wrong inputs.

Tellingly, the same file already hashes `Dockerfile`, `Target` and `Args` into the rebuild cache key — the code treated all three as build-affecting while never passing them on.

**GCP was the only provider with this gap.** AWS (`aws/codebuild.go:304,316,322`) and Azure (`azure/acr.go:56`, `azure/image.go:167`) both handle them.

## Fix

Add `-f <dockerfile>` (always, since `GetDockerfile()` defaults to `Dockerfile`), `--target` when set, and `--build-arg` per entry, sorted via `common.Sorted` so an unchanged build does not look changed — a map walk would reshuffle the args on every run.

Build arg **values travel in the step's `env`**, names on the command line. To be precise about what that does and does not buy (an earlier revision of this description overstated it): it keeps values out of the docker invocation recorded in the **Cloud Build log**. It does **not** hide them from Pulumi state — `env` is part of the same steps YAML that becomes the Build resource's `steps` input.

That is acceptable because compose `build.args` are not a secret channel: Docker documents them as visible in image history, and they are already plaintext in the user's committed `compose.yaml`. Anything genuinely secret belongs in a BuildKit secret mount, which no provider here exposes today. For symmetry, AWS's name-only form carries values in the CodeBuild project's environment-variable input, which is likewise persisted — so no provider currently keeps build arg values out of state, and this does not make GCP worse than the other two.

## Verification

Found while deploying a real project to GCP in a scratch project: `api` builds from `api.Dockerfile` and `ui` from a `Dockerfile` with `MODE=production`. Before this change the `api` build failed outright and the `ui` image built without its build arg — silently.

- 5 new tests: custom dockerfile, the default, build args landing in `env` (asserting values never appear on the command line), target set, target omitted
- `go build ./...`, `go test ./provider/...`, `go test ./cd/...` — green
- `golangci-lint run --config=.golangci.yaml ./provider/...` at CI's pinned v2.11.4 — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197fecoxGCAfRuqfPQfXhaC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Cloud Build Docker steps now support build arguments supplied through environment variables.
  - Build-argument values are kept out of Docker command-line arguments while remaining in the build configuration.
  - Docker builds consistently use the configured Dockerfile and pass through build targets when provided.
  - Build arguments are applied in a deterministic order.
  - Dollar signs in build-argument values are escaped to prevent unintended substitutions.

- **Bug Fixes**
  - Unset build targets are now omitted instead of being passed to the build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->