### PR TITLE
fix(gcp): adopt the resources the legacy defang-mvp CD created

### DIFF
--- a/provider/compose/aliases.go
+++ b/provider/compose/aliases.go
@@ -7,12 +7,9 @@ import "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 // service.
 const (
 	AliasCluster        = "cluster"
-	AliasDatabase       = "database"
-	AliasInstance       = "instance"
 	AliasParameterGroup = "parameter-group"
 	AliasSecurityGroup  = "security-group"
 	AliasSubnetGroup    = "subnet-group"
-	AliasUser           = "user"
 )
 
 // AliasOptions returns pulumi.Aliases resource options for the given child

--- a/provider/compose/aliases.go
+++ b/provider/compose/aliases.go
@@ -7,9 +7,12 @@ import "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 // service.
 const (
 	AliasCluster        = "cluster"
+	AliasDatabase       = "database"
+	AliasInstance       = "instance"
 	AliasParameterGroup = "parameter-group"
 	AliasSecurityGroup  = "security-group"
 	AliasSubnetGroup    = "subnet-group"
+	AliasUser           = "user"
 )
 
 // AliasOptions returns pulumi.Aliases resource options for the given child

--- a/provider/defanggcp/gcp/artifact_registry.go
+++ b/provider/defanggcp/gcp/artifact_registry.go
@@ -170,7 +170,9 @@ func createBuildInfra(
 		Location:     pulumi.String(region),
 		Description:  pulumi.String("Docker images for " + projectName),
 		Format:       pulumi.String("DOCKER"),
-	}, opts...)
+	}, common.MergeOptions(opts,
+		// resourceName(project, config) with no extra parts in the legacy CD.
+		legacyAlias(legacyResourceName(ctx, projectName)))...)
 	if err != nil {
 		return nil, fmt.Errorf("creating artifact registry repository: %w", err)
 	}

--- a/provider/defanggcp/gcp/cloudsql.go
+++ b/provider/defanggcp/gcp/cloudsql.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/DefangLabs/pulumi-defang/provider/common"
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/sql"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -96,6 +95,7 @@ func sqlBackupConfig(ctx *pulumi.Context) *sql.DatabaseInstanceSettingsBackupCon
 func CreateCloudSQL(
 	ctx *pulumi.Context,
 	configProvider compose.ConfigProvider,
+	projectName string,
 	serviceName string,
 	svc compose.ServiceConfig,
 	infra *SharedInfra,
@@ -123,8 +123,10 @@ func CreateCloudSQL(
 		return gcpPostgresVersion(v)
 	}).(pulumi.StringOutput)
 
-	instanceOpts := common.MergeOptions(
-		[]pulumi.ResourceOption{opt}, svc.AliasOptions(compose.AliasInstance)...)
+	// resourceName(project, config, service, "postgres") in the legacy CD.
+	instanceOpts := []pulumi.ResourceOption{
+		opt, legacyAlias(legacyResourceName(ctx, projectName, serviceName, "postgres")),
+	}
 	if infra != nil && infra.ServiceConnection != nil {
 		instanceOpts = append(instanceOpts,
 			pulumi.DependsOn([]pulumi.Resource{infra.ServiceConnection}))
@@ -176,8 +178,7 @@ func CreateCloudSQL(
 			// delete and nothing to leak; the RetainOnDelete that used to sit on top was
 			// redundant with the deletion policy, which already suppresses the API call.
 			DeletionPolicy: pulumi.String("ABANDON"),
-		}, common.MergeOptions([]pulumi.ResourceOption{opt},
-			svc.AliasOptions(compose.AliasUser)...)...)
+		}, opt, legacyAlias(legacyPlainName(projectName, serviceName, "postgres", "user")))
 		if err != nil {
 			return nil, fmt.Errorf("creating Cloud SQL user: %w", err)
 		}
@@ -193,8 +194,7 @@ func CreateCloudSQL(
 			Instance: instance.Name,
 			// ABANDON alone, same reasoning as the user above.
 			DeletionPolicy: pulumi.String("ABANDON"),
-		}, common.MergeOptions([]pulumi.ResourceOption{opt},
-			svc.AliasOptions(compose.AliasDatabase)...)...)
+		}, opt, legacyAlias(legacyPlainName(projectName, serviceName, "postgres", "db")))
 		if err != nil {
 			return nil, fmt.Errorf("creating Cloud SQL database: %w", err)
 		}

--- a/provider/defanggcp/gcp/cloudsql.go
+++ b/provider/defanggcp/gcp/cloudsql.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/DefangLabs/pulumi-defang/provider/common"
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/sql"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -122,9 +123,10 @@ func CreateCloudSQL(
 		return gcpPostgresVersion(v)
 	}).(pulumi.StringOutput)
 
-	var instanceOpt pulumi.ResourceOption = opt
+	instanceOpts := common.MergeOptions(
+		[]pulumi.ResourceOption{opt}, svc.AliasOptions(compose.AliasInstance)...)
 	if infra != nil && infra.ServiceConnection != nil {
-		instanceOpt = pulumi.Composite(opt,
+		instanceOpts = append(instanceOpts,
 			pulumi.DependsOn([]pulumi.Resource{infra.ServiceConnection}))
 	}
 
@@ -154,7 +156,7 @@ func CreateCloudSQL(
 			},
 		},
 		DeletionProtection: pulumi.Bool(DeletionProtection.Get(ctx)),
-	}, instanceOpt)
+	}, instanceOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("creating Cloud SQL instance: %w", err)
 	}
@@ -174,7 +176,8 @@ func CreateCloudSQL(
 			// delete and nothing to leak; the RetainOnDelete that used to sit on top was
 			// redundant with the deletion policy, which already suppresses the API call.
 			DeletionPolicy: pulumi.String("ABANDON"),
-		}, opt)
+		}, common.MergeOptions([]pulumi.ResourceOption{opt},
+			svc.AliasOptions(compose.AliasUser)...)...)
 		if err != nil {
 			return nil, fmt.Errorf("creating Cloud SQL user: %w", err)
 		}
@@ -190,7 +193,8 @@ func CreateCloudSQL(
 			Instance: instance.Name,
 			// ABANDON alone, same reasoning as the user above.
 			DeletionPolicy: pulumi.String("ABANDON"),
-		}, opt)
+		}, common.MergeOptions([]pulumi.ResourceOption{opt},
+			svc.AliasOptions(compose.AliasDatabase)...)...)
 		if err != nil {
 			return nil, fmt.Errorf("creating Cloud SQL database: %w", err)
 		}

--- a/provider/defanggcp/gcp/cloudsql_test.go
+++ b/provider/defanggcp/gcp/cloudsql_test.go
@@ -82,3 +82,72 @@ func TestCloudSQLResolvesConfigPasswordWithExplicitProvider(t *testing.T) {
 		assert.NotEmpty(t, p, "Secret Manager invoke was made without an explicit provider")
 	}
 }
+
+// aliasSpy records the aliases each registered resource carried.
+type aliasSpy struct {
+	noopMocks
+	aliases map[string][]string
+}
+
+func (m *aliasSpy) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+	if m.aliases == nil {
+		m.aliases = map[string][]string{}
+	}
+	for _, alias := range args.RegisterRPC.GetAliases() {
+		if urn := alias.GetUrn(); urn != "" {
+			m.aliases[args.Name] = append(m.aliases[args.Name], urn)
+		}
+	}
+	return args.Name + "_id", args.Inputs, nil
+}
+
+// A legacy defang-mvp stack registered its Cloud SQL resources under different
+// URNs than this CD does. Without aliases an `up` creates a new instance and
+// deletes the old one — and the legacy DatabaseInstance is not retained, so
+// that destroys the data. x-defang-aliases carries the old URNs across.
+func TestCloudSQLAppliesMigrationAliases(t *testing.T) {
+	const (
+		instanceURN = "urn:pulumi:mig::proj::gcp:sql/databaseInstance:DatabaseInstance::legacy-postgres"
+		userURN     = "urn:pulumi:mig::proj::gcp:sql/user:User::legacy-postgres-user"
+		databaseURN = "urn:pulumi:mig::proj::gcp:sql/database:Database::legacy-postgres-db"
+	)
+	spy := &aliasSpy{}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		_, err := CreateCloudSQL(ctx, &compose.DryRunConfigProvider{}, "database", compose.ServiceConfig{
+			Image:    pulumi.String("postgres:16"),
+			Postgres: &compose.PostgresConfig{},
+			Environment: compose.Environment{
+				"POSTGRES_PASSWORD": pulumi.String("literal-password"),
+				"POSTGRES_USER":     pulumi.String("martekio"),
+				"POSTGRES_DB":       pulumi.String("martekioDB"),
+			},
+			Aliases: map[string]string{
+				compose.AliasInstance: instanceURN,
+				compose.AliasUser:     userURN,
+				compose.AliasDatabase: databaseURN,
+			},
+		}, nil, pulumi.Parent(nil))
+		return err
+	}, pulumi.WithMocks("proj", "mig", spy))
+	require.NoError(t, err)
+
+	assert.Contains(t, spy.aliases["database"], instanceURN, "Cloud SQL instance lost its migration alias")
+	assert.Contains(t, spy.aliases["database-user"], userURN, "Cloud SQL user lost its migration alias")
+	assert.Contains(t, spy.aliases["database-db"], databaseURN, "Cloud SQL database lost its migration alias")
+}
+
+// No x-defang-aliases means no aliases: a greenfield stack must not carry them.
+func TestCloudSQLWithoutAliasesRegistersNone(t *testing.T) {
+	spy := &aliasSpy{}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		_, err := CreateCloudSQL(ctx, &compose.DryRunConfigProvider{}, "database", compose.ServiceConfig{
+			Image:       pulumi.String("postgres:16"),
+			Postgres:    &compose.PostgresConfig{},
+			Environment: compose.Environment{"POSTGRES_PASSWORD": pulumi.String("literal-password")},
+		}, nil, pulumi.Parent(nil))
+		return err
+	}, pulumi.WithMocks("proj", "mig", spy))
+	require.NoError(t, err)
+
+	assert.Empty(t, spy.aliases["database"])
+}

--- a/provider/defanggcp/gcp/cloudsql_test.go
+++ b/provider/defanggcp/gcp/cloudsql_test.go
@@ -64,7 +64,7 @@ func TestCloudSQLResolvesConfigPasswordWithExplicitProvider(t *testing.T) {
 		prov, err := gcp.NewProvider(ctx, "explicit-gcp", &gcp.ProviderArgs{})
 		require.NoError(t, err)
 
-		_, err = CreateCloudSQL(ctx, NewConfigProvider("myproject"), "database", compose.ServiceConfig{
+		_, err = CreateCloudSQL(ctx, NewConfigProvider("myproject"), "myproject", "database", compose.ServiceConfig{
 			Image:    pulumi.String("postgres:16"),
 			Postgres: &compose.PostgresConfig{},
 			Environment: compose.Environment{
@@ -83,7 +83,7 @@ func TestCloudSQLResolvesConfigPasswordWithExplicitProvider(t *testing.T) {
 	}
 }
 
-// aliasSpy records the aliases each registered resource carried.
+// aliasSpy records the legacy names each registered resource declared.
 type aliasSpy struct {
 	noopMocks
 	aliases map[string][]string
@@ -94,60 +94,35 @@ func (m *aliasSpy) NewResource(args pulumi.MockResourceArgs) (string, resource.P
 		m.aliases = map[string][]string{}
 	}
 	for _, alias := range args.RegisterRPC.GetAliases() {
-		if urn := alias.GetUrn(); urn != "" {
-			m.aliases[args.Name] = append(m.aliases[args.Name], urn)
+		if spec := alias.GetSpec(); spec != nil {
+			m.aliases[args.Name] = append(m.aliases[args.Name], spec.GetName())
 		}
 	}
 	return args.Name + "_id", args.Inputs, nil
 }
 
-// A legacy defang-mvp stack registered its Cloud SQL resources under different
-// URNs than this CD does. Without aliases an `up` creates a new instance and
-// deletes the old one — and the legacy DatabaseInstance is not retained, so
-// that destroys the data. x-defang-aliases carries the old URNs across.
-func TestCloudSQLAppliesMigrationAliases(t *testing.T) {
-	const (
-		instanceURN = "urn:pulumi:mig::proj::gcp:sql/databaseInstance:DatabaseInstance::legacy-postgres"
-		userURN     = "urn:pulumi:mig::proj::gcp:sql/user:User::legacy-postgres-user"
-		databaseURN = "urn:pulumi:mig::proj::gcp:sql/database:Database::legacy-postgres-db"
-	)
+// Without these aliases an `up` over a legacy defang-mvp stack plans a create
+// plus a delete for the database rather than an update, and the legacy
+// DatabaseInstance carries no retainOnDelete — the delete takes the data too.
+func TestCloudSQLAdoptsLegacyMvpNames(t *testing.T) {
 	spy := &aliasSpy{}
 	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
-		_, err := CreateCloudSQL(ctx, &compose.DryRunConfigProvider{}, "database", compose.ServiceConfig{
-			Image:    pulumi.String("postgres:16"),
-			Postgres: &compose.PostgresConfig{},
-			Environment: compose.Environment{
-				"POSTGRES_PASSWORD": pulumi.String("literal-password"),
-				"POSTGRES_USER":     pulumi.String("martekio"),
-				"POSTGRES_DB":       pulumi.String("martekioDB"),
-			},
-			Aliases: map[string]string{
-				compose.AliasInstance: instanceURN,
-				compose.AliasUser:     userURN,
-				compose.AliasDatabase: databaseURN,
-			},
-		}, nil, pulumi.Parent(nil))
+		_, err := CreateCloudSQL(ctx, &compose.DryRunConfigProvider{}, "martekio-mig", "database",
+			compose.ServiceConfig{
+				Image:    pulumi.String("postgres:16"),
+				Postgres: &compose.PostgresConfig{},
+				Environment: compose.Environment{
+					"POSTGRES_PASSWORD": pulumi.String("literal-password"),
+					"POSTGRES_USER":     pulumi.String("martekio"),
+					"POSTGRES_DB":       pulumi.String("martekioDB"),
+				},
+			}, nil, pulumi.Parent(nil))
 		return err
-	}, pulumi.WithMocks("proj", "mig", spy))
+	}, pulumi.WithMocks("martekio-mig", "cyc", spy))
 	require.NoError(t, err)
 
-	assert.Contains(t, spy.aliases["database"], instanceURN, "Cloud SQL instance lost its migration alias")
-	assert.Contains(t, spy.aliases["database-user"], userURN, "Cloud SQL user lost its migration alias")
-	assert.Contains(t, spy.aliases["database-db"], databaseURN, "Cloud SQL database lost its migration alias")
-}
-
-// No x-defang-aliases means no aliases: a greenfield stack must not carry them.
-func TestCloudSQLWithoutAliasesRegistersNone(t *testing.T) {
-	spy := &aliasSpy{}
-	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
-		_, err := CreateCloudSQL(ctx, &compose.DryRunConfigProvider{}, "database", compose.ServiceConfig{
-			Image:       pulumi.String("postgres:16"),
-			Postgres:    &compose.PostgresConfig{},
-			Environment: compose.Environment{"POSTGRES_PASSWORD": pulumi.String("literal-password")},
-		}, nil, pulumi.Parent(nil))
-		return err
-	}, pulumi.WithMocks("proj", "mig", spy))
-	require.NoError(t, err)
-
-	assert.Empty(t, spy.aliases["database"])
+	assert.Contains(t, spy.aliases["database"], "defang-martekio-mig-cyc-database-postgres",
+		"Cloud SQL instance would be replaced instead of adopted")
+	assert.Contains(t, spy.aliases["database-user"], "martekio-mig-database-postgres-user")
+	assert.Contains(t, spy.aliases["database-db"], "martekio-mig-database-postgres-db")
 }

--- a/provider/defanggcp/gcp/gcp.go
+++ b/provider/defanggcp/gcp/gcp.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/DefangLabs/pulumi-defang/provider/common"
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/artifactregistry"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/certificatemanager"
@@ -116,9 +117,10 @@ func BuildGlobalConfig(
 	// Pulumi state, which left the VPC orphaned with nothing left to delete it: the project then
 	// ran into its NETWORKS quota (issue #183). Letting the destroy fail is what puts the CLI's
 	// cleanup tool (DefangLabs/defang#2157) in front of the user.
+	// networkName(project + "-vpc") in the legacy CD; it skipped the prefix and stack.
 	vpc, err := compute.NewNetwork(ctx, "vpc", &compute.NetworkArgs{
 		AutoCreateSubnetworks: pulumi.Bool(false),
-	}, opts...)
+	}, common.MergeOptions(opts, legacyAlias(legacyNetworkName(projectName+"-vpc")))...)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +129,8 @@ func BuildGlobalConfig(
 		IpCidrRange: pulumi.String("10.0.0.0/16"),
 		Region:      pulumi.String(region),
 		Network:     vpc.ID(),
-	}, opts...)
+	}, common.MergeOptions(opts,
+		legacyAlias(legacyResourceName(ctx, projectName, "shared-subnet")))...)
 	if err != nil {
 		return nil, err
 	}
@@ -178,18 +181,7 @@ func BuildGlobalConfig(
 	// public-dns below: Pulumi's default resource ID already prefixes it with
 	// <pulumi-project>-<stack>, which includes projectName, so repeating it here
 	// risked exceeding GCP's 63-char resource ID limit.
-	privateZone, err := dns.NewManagedZone(ctx, "private-dns", &dns.ManagedZoneArgs{
-		Description: pulumi.String(fmt.Sprintf("Private DNS zone for %v", projectName)),
-		DnsName:     pulumi.String("google.internal."),
-		Visibility:  pulumi.String("private"),
-		PrivateVisibilityConfig: &dns.ManagedZonePrivateVisibilityConfigArgs{
-			Networks: dns.ManagedZonePrivateVisibilityConfigNetworkArray{
-				&dns.ManagedZonePrivateVisibilityConfigNetworkArgs{
-					NetworkUrl: vpc.ID(),
-				},
-			},
-		},
-	}, append(opts, pulumi.ReplaceOnChanges([]string{"forwardingConfig"}), pulumi.DeleteBeforeReplace(true))...)
+	privateZone, err := createPrivateZone(ctx, projectName, vpc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -244,7 +236,7 @@ func buildOptionalInfra(
 	}
 
 	if needsVpcPeering(services) {
-		serviceConn, err := createVPCPeeringInfra(ctx, cfg.VpcId, opts...)
+		serviceConn, err := createVPCPeeringInfra(ctx, projectName, cfg.VpcId, opts...)
 		if err != nil {
 			return err
 		}
@@ -370,4 +362,32 @@ func GcpRegion(ctx *pulumi.Context) string {
 		return r
 	}
 	return defaultGCPRegion
+}
+
+// createPrivateZone creates the project's private google.internal. zone.
+// Extracted so BuildGlobalConfig stays within the length limit.
+func createPrivateZone(
+	ctx *pulumi.Context,
+	projectName string,
+	vpc *compute.Network,
+	opts ...pulumi.ResourceOption,
+) (*dns.ManagedZone, error) {
+	privateZone, err := dns.NewManagedZone(ctx, "private-dns", &dns.ManagedZoneArgs{
+		Description: pulumi.String(fmt.Sprintf("Private DNS zone for %v", projectName)),
+		DnsName:     pulumi.String("google.internal."),
+		Visibility:  pulumi.String("private"),
+		PrivateVisibilityConfig: &dns.ManagedZonePrivateVisibilityConfigArgs{
+			Networks: dns.ManagedZonePrivateVisibilityConfigNetworkArray{
+				&dns.ManagedZonePrivateVisibilityConfigNetworkArgs{
+					NetworkUrl: vpc.ID(),
+				},
+			},
+		},
+	}, append(common.MergeOptions(opts,
+		legacyAlias(legacyResourceName(ctx, projectName, "private-dns"))),
+		pulumi.ReplaceOnChanges([]string{"forwardingConfig"}), pulumi.DeleteBeforeReplace(true))...)
+	if err != nil {
+		return nil, err
+	}
+	return privateZone, nil
 }

--- a/provider/defanggcp/gcp/legacy_aliases.go
+++ b/provider/defanggcp/gcp/legacy_aliases.go
@@ -1,0 +1,97 @@
+package gcp
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// Adoption of resources created by the legacy defang-mvp CD.
+//
+// The two CDs register the same cloud resources under different logical names,
+// and the legacy ones hang off the stack rather than off a component. Pulumi
+// therefore sees no continuity: an `up` plans a create plus a delete instead of
+// an update. For a Cloud SQL instance that delete is real — it carries no
+// retainOnDelete — so it takes the data with it. For the VPC it is quieter but
+// just as fatal: the adopted database keeps the private network it was created
+// on, so a fresh VPC leaves every service without a route to it.
+//
+// The legacy names are deterministic, so they are reconstructed here rather
+// than asked of the operator. Everything below mirrors defang-mvp's
+// pulumi/cd/gcp/gcpcd/safe_namings.go; keep the two in step.
+
+// legacyPrefix is DEFANG_PREFIX's default in the legacy CD. Sanitization
+// lowercases it.
+const legacyPrefix = "Defang"
+
+// legacyPulumiSuffixLength is the room the legacy CD left for Pulumi's own
+// random suffix when trimming a name.
+const legacyPulumiSuffixLength = 8
+
+var legacyNonNameChars = regexp.MustCompile(`[^a-z0-9-]`)
+
+// legacyAlias declares the name a resource had under the legacy CD. NoParent is
+// required: legacy resources were registered at stack level, whereas this CD
+// nests them under the Project component, and an alias without it would inherit
+// the current parent and so name a URN that never existed.
+func legacyAlias(name string) pulumi.ResourceOption {
+	return pulumi.Aliases([]pulumi.Alias{{
+		Name:     pulumi.String(name),
+		NoParent: pulumi.Bool(true),
+	}})
+}
+
+// legacyResourceName mirrors resourceName(): "<prefix>-<project>-<stack>-<parts...>".
+func legacyResourceName(ctx *pulumi.Context, projectName string, parts ...string) string {
+	all := append([]string{legacyPrefix, projectName, ctx.Stack()}, parts...)
+	return legacyHashTrim(legacySanitize(strings.Join(all, "-")), 63-legacyPulumiSuffixLength)
+}
+
+// legacyPlainName mirrors the places the legacy CD joined names by hand,
+// without the prefix, the stack, or any trimming — the Cloud SQL user and
+// database, for instance.
+func legacyPlainName(parts ...string) string {
+	return strings.Join(parts, "-")
+}
+
+// legacyNetworkName mirrors networkName(), which skips the prefix and stack and
+// trims at the full 63 characters.
+func legacyNetworkName(name string) string {
+	name = legacySanitize(name)
+	if name == "" || name[0] == '-' {
+		name = "net" + name
+	}
+	if name[0] < 'a' || name[0] > 'z' {
+		name = "net-" + name
+	}
+	return legacyHashTrim(name, 63)
+}
+
+func legacySanitize(name string) string {
+	name = strings.ToLower(name)
+	name = legacyNonNameChars.ReplaceAllLiteralString(name, "-")
+	return strings.TrimRight(name, "-")
+}
+
+func legacyHashTrim(name string, maxLength int) string {
+	if len(name) <= maxLength {
+		return name
+	}
+	const hashLength = 6
+	return name[:maxLength-hashLength] + legacyHashN(name[maxLength-hashLength:], hashLength)
+}
+
+func legacyHashN(str string, length int) string {
+	hash := sha256.New()
+	hash.Write([]byte(str))
+	hashBase36 := strconv.FormatUint(binary.LittleEndian.Uint64(hash.Sum(nil)[:8]), 36)
+	if len(hashBase36) > length {
+		return hashBase36[:length]
+	}
+	return fmt.Sprintf("%0*s", length, hashBase36)
+}

--- a/provider/defanggcp/gcp/legacy_aliases_test.go
+++ b/provider/defanggcp/gcp/legacy_aliases_test.go
@@ -1,0 +1,65 @@
+package gcp
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The names below were read out of a real stack that the legacy defang-mvp CD
+// deployed (project "martekio-mig", stack "cyc"). If the reconstruction drifts
+// from defang-mvp's pulumi/cd/gcp/gcpcd/safe_namings.go, migrations stop
+// adopting and start replacing — so pin the exact strings.
+func TestLegacyNamesMatchTheMvpCD(t *testing.T) {
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		const project = "martekio-mig"
+
+		assert.Equal(t, "martekio-mig-vpc", legacyNetworkName(project+"-vpc"))
+		assert.Equal(t, "defang-martekio-mig-cyc-shared-subnet",
+			legacyResourceName(ctx, project, "shared-subnet"))
+		assert.Equal(t, "defang-martekio-mig-cyc-private-dns",
+			legacyResourceName(ctx, project, "private-dns"))
+		assert.Equal(t, "defang-martekio-mig-cyc-vpc-peering-ip",
+			legacyResourceName(ctx, project, "vpc-peering-ip"))
+		assert.Equal(t, "defang-martekio-mig-cyc-service-connection",
+			legacyResourceName(ctx, project, "service-connection"))
+		assert.Equal(t, "defang-martekio-mig-cyc", legacyResourceName(ctx, project))
+		assert.Equal(t, "defang-martekio-mig-cyc-database-postgres",
+			legacyResourceName(ctx, project, "database", "postgres"))
+		assert.Equal(t, "martekio-mig-database-postgres-user",
+			legacyPlainName(project, "database", "postgres", "user"))
+		assert.Equal(t, "martekio-mig-database-postgres-db",
+			legacyPlainName(project, "database", "postgres", "db"))
+		return nil
+	}, pulumi.WithMocks("martekio-mig", "cyc", testMocks{}))
+	require.NoError(t, err)
+}
+
+// resourceName left 8 characters for Pulumi's suffix, so it trimmed at 55 with a
+// 6-character base36 hash. A project name long enough to trip that must trim the
+// same way or the alias names a URN that never existed.
+func TestLegacyResourceNameTrimsLikeTheMvpCD(t *testing.T) {
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		got := legacyResourceName(ctx, "a-very-long-project-name-that-will-certainly-overflow", "shared-subnet")
+
+		assert.Len(t, got, 55)
+		// 49 characters of name, then a 6-character base36 hash of the remainder.
+		assert.Equal(t, "defang-a-very-long-project-name-that-will-certain", got[:49])
+		assert.Regexp(t, `^[a-z0-9]{6}$`, got[49:])
+		return nil
+	}, pulumi.WithMocks("proj", "somestack", testMocks{}))
+	require.NoError(t, err)
+}
+
+// Uppercase and other stray characters are folded, matching replaceNonAlphaNumericOrDash.
+func TestLegacyNameSanitization(t *testing.T) {
+	assert.Equal(t, "my-proj-vpc", legacyNetworkName("My_Proj-vpc"))
+	assert.Equal(t, "lead", legacySanitize("lead---"))
+}
+
+// A network name may not start with a non-letter; the legacy CD prefixed those.
+func TestLegacyNetworkNamePrefixesNonLetters(t *testing.T) {
+	assert.Equal(t, "net-9lives-vpc", legacyNetworkName("9lives-vpc"))
+}

--- a/provider/defanggcp/gcp/vpc_peering.go
+++ b/provider/defanggcp/gcp/vpc_peering.go
@@ -1,6 +1,7 @@
 package gcp
 
 import (
+	"github.com/DefangLabs/pulumi-defang/provider/common"
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/compute"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/servicenetworking"
@@ -21,6 +22,7 @@ func needsVpcPeering(services map[string]compose.ServiceConfig) bool {
 // connection for Cloud SQL private IP access.
 func createVPCPeeringInfra(
 	ctx *pulumi.Context,
+	projectName string,
 	vpcId pulumi.StringOutput,
 	opts ...pulumi.ResourceOption,
 ) (*servicenetworking.Connection, error) {
@@ -33,7 +35,8 @@ func createVPCPeeringInfra(
 		AddressType:  pulumi.String("INTERNAL"),
 		PrefixLength: pulumi.Int(16),
 		Network:      vpcId,
-	}, opts...)
+	}, common.MergeOptions(opts,
+		legacyAlias(legacyResourceName(ctx, projectName, "vpc-peering-ip")))...)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +60,8 @@ func createVPCPeeringInfra(
 			ReservedPeeringRanges: pulumi.StringArray{privateIpAlloc.Name},
 			DeletionPolicy:        pulumi.String("ABANDON"),
 		},
-		opts...,
+		common.MergeOptions(opts,
+			legacyAlias(legacyResourceName(ctx, projectName, "service-connection")))...,
 	)
 	if err != nil {
 		return nil, err

--- a/provider/defanggcp/postgres.go
+++ b/provider/defanggcp/postgres.go
@@ -60,7 +60,7 @@ func (*Postgres) Construct(
 	}
 	// Standalone Construct runs without a shared GlobalConfig; the project-level
 	// dispatcher calls createPostgres with a non-nil infra.
-	return comp, createPostgres(ctx, comp, configProvider, name, svc, nil)
+	return comp, createPostgres(ctx, comp, configProvider, inputs.ProjectName, name, svc, nil)
 }
 
 // createPostgres creates the Cloud SQL instance under an already-registered Postgres
@@ -70,13 +70,14 @@ func createPostgres(
 	ctx *pulumi.Context,
 	comp *PostgresOutputs,
 	configProvider compose.ConfigProvider,
+	projectName string,
 	serviceName string,
 	svc compose.ServiceConfig,
 	infra *providergcp.SharedInfra,
 ) error {
 	childOpt := pulumi.Parent(comp)
 
-	sqlResult, err := providergcp.CreateCloudSQL(ctx, configProvider, serviceName, svc, infra, childOpt)
+	sqlResult, err := providergcp.CreateCloudSQL(ctx, configProvider, projectName, serviceName, svc, infra, childOpt)
 	if err != nil {
 		return fmt.Errorf("creating Cloud SQL for %s: %w", serviceName, err)
 	}

--- a/provider/defanggcp/project.go
+++ b/provider/defanggcp/project.go
@@ -216,7 +216,7 @@ func buildService(
 		if err := ctx.RegisterComponentResource(PostgresComponentType, svcName, pgComp, svcChildOpts...); err != nil {
 			return pulumi.StringOutput{}, nil, nil, nil, fmt.Errorf("registering Cloud SQL component %s: %w", svcName, err)
 		}
-		if err := createPostgres(ctx, pgComp, configProvider, svcName, svc, infra); err != nil {
+		if err := createPostgres(ctx, pgComp, configProvider, projectName, svcName, svc, infra); err != nil {
 			return pulumi.StringOutput{}, nil, nil, nil, err
 		}
 		endpoint = pgComp.Endpoint


### PR DESCRIPTION
## Problem

A GCP project deployed by the legacy defang-mvp CD cannot move onto this one. The two CDs register the same cloud resources under different logical names, and the legacy ones hang off the stack rather than off a component:

```
legacy   urn:...::Stack$gcp:sql/databaseInstance:DatabaseInstance::defang-<proj>-<stack>-database-postgres
current  urn:...::Project$Postgres$gcp:sql/databaseInstance:DatabaseInstance::database
```

Pulumi sees no continuity, so an `up` plans a **create plus a delete** rather than an update. For the Cloud SQL instance that delete is real — it carries no `retainOnDelete` — so it takes the data with it.

The VPC matters just as much, and less obviously: an adopted Cloud SQL instance keeps the private network it was created on. Adopt the database but not the network and the migrated services land on a fresh VPC with no route to it, dying with `dial tcp 10.x.x.x:5432: connect: connection timed out`. Same for the private DNS zone, which is refused outright (`dnsNameInUse`) because the legacy zone already claims `google.internal.` on that network.

## Approach

The legacy names are deterministic, so the provider reconstructs them rather than asking an operator to paste URNs into compose. `legacy_aliases.go` mirrors defang-mvp's `pulumi/cd/gcp/gcpcd/safe_namings.go`, including its 55-character `hashTrim`.

`NoParent` is required on every alias: legacy resources were registered at stack level while this CD nests them under the `Project` component, and an alias without it inherits the *current* parent and so names a URN that never existed.

Adopted: **VPC, subnet, private DNS zone, peering range, service-networking connection, artifact registry, and the Cloud SQL instance, user and database.**

`createPrivateZone` is split out of `BuildGlobalConfig` purely to keep it under the `funlen` limit.

## Verified end to end, twice, on live infrastructure

A real project (managed Postgres, two build-from-source services) deployed to a scratch GCP project with the **legacy defang-mvp CD**, then the *same project and stack* redeployed with a CD built from `main` + #528 + this PR. Nothing hand-written in compose:

```
~  gcp:sql:DatabaseInstance database updated   [diff: +deletionPolicy~settings]
~  gcp:compute:Network vpc updated
~  gcp:dns:ManagedZone private-dns updated

Resources:  + 103 created   ~ 6 updated   - 105 deleted
```

The database, VPC and private DNS zone were **updated in place, not replaced**. The instance kept its identity and its data — same name, same creation timestamp, database and user intact — and all three Cloud SQL resources now sit under this CD's URNs with unchanged physical IDs. Both services came up healthy and the application connected to the adopted database.

Without this change the same run plans a create-and-delete of the database.

## Known gap: the artifact registry is still replaced

`repositoryId` is ForceNew and this CD computes `defang-<proj>-<stack>-repo` where the legacy CD used `defang-<proj>-<stack>`. The alias adopts the URN, but an alias cannot stop a replacement driven by an immutable input:

```
++ gcp:artifactregistry:Repository repo created replacement [~repositoryId]
```

It is a registry rather than data and the replacement succeeds cleanly, so the migration is green regardless. Keeping the legacy `repositoryId` when the alias applies would fix it and is worth doing separately; no open naming PR covers it (#460 touches only ALB/LB and Azure DNS naming).

## One caveat for legacy state

A legacy GCP stack also contains `cloudbuild:index:CloudBuild` resources from defang-mvp's private `pulumi-resource-cloudbuild` plugin, which this CD's image does not ship — Pulumi needs a plugin to delete a resource. Those entries have to come out of the state first. They record completed builds, so dropping them loses nothing.

## Verification

- New tests pin every reconstructed name against strings read out of a real MVP-deployed stack, plus the trim, sanitization and non-letter-prefix rules
- A test asserts all three Cloud SQL aliases reach the registered resources; reverted against the instance alias it fails with `Cloud SQL instance would be replaced instead of adopted`
- `go build ./...`, `go test ./provider/...`, `go test ./cd/...` — green
- `golangci-lint run --config=.golangci.yaml ./provider/...` at CI's pinned v2.11.4 — 0 issues

## Related

- #528 — GCP dropped `build.dockerfile`/`args`/`target`; needed for the migration to build at all
- #496 — its preflight's `aliasTargetEnabled` checks the raw compose before `ResolvedEnvironment` runs, so it wrongly concludes a config-sourced `POSTGRES_USER`/`POSTGRES_DB` target will not be registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197fecoxGCAfRuqfPQfXhaC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for adopting existing GCP resources created by earlier Defang deployments.
  - Preserved compatibility with legacy names for Cloud SQL instances, databases, users, VPCs, subnets, private DNS zones, Artifact Registry repositories, and VPC peering resources.
  - Improved project-aware naming across PostgreSQL and networking infrastructure.
  - Added handling for legacy resource names with consistent sanitization, trimming, and hashing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->