### PR TITLE
fix(gcp): keep the legacy repositoryId so an adopted registry is not replaced

### DIFF
--- a/provider/defanggcp/gcp/artifact_registry.go
+++ b/provider/defanggcp/gcp/artifact_registry.go
@@ -91,6 +91,9 @@ func collectExternalRegistries(services map[string]compose.ServiceConfig) []stri
 // checks for one and returns logicalName unchanged when none is set, so that
 // no-op return is what tells us to fall back to the legacy prefix/project/
 // stack scoping ourselves instead of re-parsing the pulumi:autonaming config.
+//
+// An empty logicalName asks for the project-scoped ID with no role segment at
+// all; see projectRepositoryID.
 func artifactRegistryRepositoryID(ctx *pulumi.Context, projectName, logicalName string) string {
 	name := common.AutonamingPrefix(ctx, logicalName)
 	if name == logicalName {
@@ -98,10 +101,35 @@ func artifactRegistryRepositoryID(ctx *pulumi.Context, projectName, logicalName 
 		if prefix := common.Prefix.Get(ctx); prefix != "" {
 			parts = append(parts, prefix)
 		}
-		parts = append(parts, projectName, ctx.Stack(), logicalName)
+		parts = append(parts, projectName, ctx.Stack())
+		if logicalName != "" {
+			parts = append(parts, logicalName)
+		}
 		name = strings.Join(parts, "-")
 	}
 	return sanitizeRepoName(name)
+}
+
+// projectRepositoryID returns the physical ID of the project's own image
+// repository: "<prefix>-<project>-<stack>", with no role segment.
+//
+// The segment is deliberately absent. "repo" on an Artifact Registry
+// repository says nothing the resource type does not already say, and dropping
+// it makes this ID identical to the one the legacy defang-mvp CD chose
+// (resourceName(project, config) with no extra parts -- see
+// legacy_aliases.go). repositoryId is ForceNew, so an alias alone cannot stop
+// a replacement when it differs: matching the legacy ID is what turns the
+// adoption of a legacy repository into an update instead of a
+// create-replacement.
+//
+// The two CDs still part company on names long enough to need trimming: the
+// legacy CD hash-trimmed at 55 characters with a base36 hash, this one trims
+// at 63 with a hex hash. Such a project adopts the URN and then replaces the
+// repository anyway. It holds images rather than data and the replacement
+// succeeds cleanly, so that residue is left alone rather than pinning today's
+// naming to the legacy trim forever.
+func projectRepositoryID(ctx *pulumi.Context, projectName string) string {
+	return artifactRegistryRepositoryID(ctx, projectName, "")
 }
 
 // createRemoteRepos creates Artifact Registry REMOTE repositories that act as
@@ -166,12 +194,14 @@ func createBuildInfra(
 
 	ar, err := artifactregistry.NewRepository(ctx, "repo", &artifactregistry.RepositoryArgs{
 		// RepositoryId is required by the GCP API; unlike AWS, GCP does not auto-generate resource IDs.
-		RepositoryId: pulumi.String(artifactRegistryRepositoryID(ctx, projectName, "repo")),
+		RepositoryId: pulumi.String(projectRepositoryID(ctx, projectName)),
 		Location:     pulumi.String(region),
 		Description:  pulumi.String("Docker images for " + projectName),
 		Format:       pulumi.String("DOCKER"),
 	}, common.MergeOptions(opts,
-		// resourceName(project, config) with no extra parts in the legacy CD.
+		// resourceName(project, config) with no extra parts in the legacy CD --
+		// which is also the repositoryId above, so the adoption is an update
+		// rather than a create-replacement.
 		legacyAlias(legacyResourceName(ctx, projectName)))...)
 	if err != nil {
 		return nil, fmt.Errorf("creating artifact registry repository: %w", err)

--- a/provider/defanggcp/gcp/artifact_registry_test.go
+++ b/provider/defanggcp/gcp/artifact_registry_test.go
@@ -87,6 +87,60 @@ func repositoryIDForTest(
 	return repositoryID
 }
 
+// gcpAutonamingPattern is the pattern the CD writes for the gcp provider; the
+// project repository ID has to come out right under the real recipe, not only
+// under the no-recipe fallback.
+const gcpAutonamingPattern = `{"pattern":"defang-${project}-${stack}-${name}-${hex(7)}"}`
+
+func projectRepositoryIDForTest(t *testing.T, stack, composeProject string, config map[string]string) string {
+	t.Helper()
+
+	var repositoryID string
+	opts := []pulumi.RunOption{pulumi.WithMocks(composeProject, stack, testMocks{})}
+	if config != nil {
+		opts = append(opts, withPulumiConfig(config))
+	}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		repositoryID = projectRepositoryID(ctx, composeProject)
+		return nil
+	}, opts...)
+	require.NoError(t, err)
+	return repositoryID
+}
+
+// The project repository carries no role segment, with or without the recipe.
+func TestProjectRepositoryIDHasNoRoleSegment(t *testing.T) {
+	assert.Equal(t, "defang-compose-project-dev",
+		projectRepositoryIDForTest(t, "dev", "compose-project", nil))
+	assert.Equal(t, "defang-compose-project-dev",
+		projectRepositoryIDForTest(t, "dev", "compose-project",
+			map[string]string{pulumiAutonamingConfigKey: gcpAutonamingPattern}))
+}
+
+// The adoption invariant: the ID this CD asks for must be the one the legacy
+// defang-mvp CD already gave the repository, or the alias adopts a URN whose
+// ForceNew repositoryId then replaces it anyway.
+func TestProjectRepositoryIDMatchesLegacyID(t *testing.T) {
+	for _, tc := range []struct{ stack, project string }{
+		{"dev", "compose-project"},
+		{"prod", "app"},
+		{"newprovidergcp", "html-css-js"},
+	} {
+		t.Run(tc.project+"-"+tc.stack, func(t *testing.T) {
+			var legacyID string
+			err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+				legacyID = legacyResourceName(ctx, tc.project)
+				return nil
+			}, pulumi.WithMocks(tc.project, tc.stack, testMocks{}))
+			require.NoError(t, err)
+
+			assert.Equal(t, legacyID,
+				projectRepositoryIDForTest(t, tc.stack, tc.project,
+					map[string]string{pulumiAutonamingConfigKey: gcpAutonamingPattern}))
+		})
+	}
+}
+
 func TestArtifactRegistryRepositoryIDFallsBackToLegacyScope(t *testing.T) {
 	devID := repositoryIDForTest(t, "dev", "compose-project", "repo", nil)
 	prodID := repositoryIDForTest(t, "prod", "compose-project", "repo", nil)
@@ -162,11 +216,11 @@ func TestCreateBuildInfraUsesScopedRepositoryIDInImageURL(t *testing.T) {
 	require.Len(t, mocks.repositories, 1)
 	assert.Equal(t, artifactRepositoryRegistration{
 		logicalName:    "repo",
-		repositoryID:   "defang-compose-project-dev-repo",
+		repositoryID:   "defang-compose-project-dev",
 		retainOnDelete: false,
 	}, mocks.repositories[0])
 	assert.Equal(t,
-		"us-central1-docker.pkg.dev/gcp-project/defang-compose-project-dev-repo",
+		"us-central1-docker.pkg.dev/gcp-project/defang-compose-project-dev",
 		<-url,
 	)
 }


### PR DESCRIPTION
## Problem

#529 left one gap: an adopted Artifact Registry repository is still replaced.

```
++ gcp:artifactregistry:Repository repo created replacement [~repositoryId]
```

`repositoryId` is ForceNew, so the alias adopts the URN and the provider then replaces the resource anyway, because this CD asks for `defang-<project>-<stack>-repo` where the legacy defang-mvp CD created `defang-<project>-<stack>` (`tenant_stack.go:59`, `RepositoryId: resourceName(proj.Name, config)`).

## Fix

Drop the `repo` role segment from the physical ID. `repo` on an `artifactregistry:Repository` says nothing the resource type does not already say, and dropping it makes the ID identical to the legacy one — so the alias that #529 already attaches now adopts the repository in place.

- The **logical** name stays `repo`; only the physical `repositoryId` changes.
- Remote pull-through repositories are untouched: their ID keeps the registry hostname as its segment (`defang-<project>-<stack>-docker-io`), so nothing collides with the bare project ID.
- `artifactRegistryRepositoryID` grew an empty-`logicalName` case; `projectRepositoryID` is the named caller.

## Cost

Existing pulumi-defang GCP stacks replace their registry once on the next `up` (ID `…-repo` → `…`). That is acceptable while the aws/gcp packages are prerelease, and it buys the migration path from the legacy CD.

## Known residue

A project whose `<prefix>-<project>-<stack>` exceeds the trim limit still replaces: the legacy CD hash-trimmed at 55 characters with a base36 hash, this one trims at 63 with a hex hash. Documented in the code rather than fixed — the repository holds images, not data, the replacement succeeds cleanly, and pinning today's naming to the legacy trim forever costs more than the residue does.

## Tests

- `TestProjectRepositoryIDMatchesLegacyID` asserts the ID equals `legacyResourceName(ctx, project)` — the actual adoption invariant — under the real CD recipe, for three project/stack shapes.
- `TestProjectRepositoryIDHasNoRoleSegment` pins it with and without the recipe.
- `CGO_ENABLED=0 go build ./... && go test ./provider/...` — green.
- `golangci-lint run --config=.golangci.yaml --new-from-rev=origin/main ./provider/...` — 0 issues.

## Related

- #529 — GCP legacy adoption (this closes its "known gap")
- #459 — logical-name hardening

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3WmpdY3zc555sNdkY9dzQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated primary build Artifact Registry repository IDs to use a project-scoped format without the previous `-repo` suffix.
  - Improved compatibility when adopting existing repositories that use legacy resource IDs.
  - Repository naming now supports projects with an empty logical repository name while preserving custom naming behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->