### PR TITLE
fix(aws): adopt the managed databases the legacy defang-mvp CD created

### DIFF
--- a/provider/defangaws/aws/elasticache.go
+++ b/provider/defangaws/aws/elasticache.go
@@ -247,7 +247,10 @@ func CreateElasticache(
 			Description: pulumi.String(common.DefangComment),
 			SubnetIds:   privateSubnetIDs,
 			Tags:        tags,
-		}, common.MergeOptions(opts, svc.AliasOptions(compose.AliasSubnetGroup)...)...)
+			// stack(service_name) in the legacy CD (redis.ts).
+		}, common.MergeOptions(opts,
+			append(svc.AliasOptions(compose.AliasSubnetGroup),
+				legacyAlias(legacyStackName(ctx, serviceName)))...)...)
 		if err != nil {
 			return nil, fmt.Errorf("creating ElastiCache subnet group: %w", err)
 		}
@@ -284,6 +287,8 @@ func CreateElasticache(
 		Tags: tags,
 	}, common.MergeOptions(common.MergeOptions(opts, svc.AliasOptions(compose.AliasSecurityGroup)...),
 		pulumi.Timeouts(&pulumi.CustomTimeouts{Delete: "2m"}),
+		// createSecurityGroup() registered every SG under stack(name).
+		legacyAlias(legacyStackName(ctx, serviceName)),
 	)...)
 	if err != nil {
 		return nil, fmt.Errorf("creating ElastiCache security group: %w", err)
@@ -335,7 +340,9 @@ func CreateElasticache(
 		rgArgs.SnapshotWindow = pulumi.String("09:30-10:30")
 	}
 
-	clusterOpts := common.MergeOptions(opts, svc.AliasOptions(compose.AliasCluster)...)
+	clusterOpts := common.MergeOptions(opts,
+		// The legacy CD named the replication group after the bare service.
+		append(svc.AliasOptions(compose.AliasCluster), legacyAlias(serviceName))...)
 	clusterOpts = append(clusterOpts, pulumi.IgnoreChanges([]string{
 		"atRestEncryptionEnabled",
 		"authToken", // TODO: allow user to set authToken via config

--- a/provider/defangaws/aws/legacy_aliases.go
+++ b/provider/defangaws/aws/legacy_aliases.go
@@ -1,0 +1,93 @@
+package aws
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"regexp"
+	"strings"
+
+	"github.com/DefangLabs/pulumi-defang/provider/common"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// Adoption of the managed databases the legacy defang-mvp CD created.
+//
+// The two CDs register the same cloud resources under different logical names,
+// and the legacy ones hang off the stack rather than off a component. Pulumi
+// therefore sees no continuity: an `up` plans a create plus a delete instead of
+// an update, and for an RDS instance or an ElastiCache replication group that
+// delete takes the data with it.
+//
+// The legacy names are deterministic, so they are reconstructed here rather
+// than asked of the operator. Everything below mirrors defang-mvp's
+// pulumi/shared/config.ts (stack()) and pulumi/shared/aws/safe_namings.ts
+// (awsIdentifierSafe(), truncate()); keep the two in step.
+//
+// Two things differ from the GCP side (see defanggcp/gcp/legacy_aliases.go):
+//
+//   - The legacy program was the Pulumi project "cd" -- the name in
+//     pulumi/cd/Pulumi.yaml -- while this CD's project is the compose project
+//     name. Every legacy URN therefore carries "cd" as its project, and the
+//     alias has to say so; an alias without it names a URN that never existed.
+//     The legacy GCP CD passed the compose project to the automation API, so
+//     its aliases need no such override.
+//   - The legacy names embed that same "cd" rather than the compose project,
+//     because shared/config.ts built its prefix from pulumi.getProject().
+
+// legacyProject is the Pulumi project of the legacy CD program, both in the
+// URNs it wrote and in the names it generated.
+const legacyProject = "cd"
+
+// legacyRdsInstanceNameMaxLength is MAX_DB_INSTANCE_IDENTITIER_LENGTH minus the
+// 8 characters the legacy CD reserved for Pulumi's own random suffix.
+const legacyRdsInstanceNameMaxLength = 63 - 8
+
+// legacyIdentifierInvalidChars mirrors the character class awsIdentifierSafe
+// folds. The + matters: a run of invalid characters collapses to one hyphen.
+var legacyIdentifierInvalidChars = regexp.MustCompile(`[^a-z0-9-]+`)
+
+// legacyAlias declares the name a resource had under the legacy CD. NoParent is
+// required: legacy resources were registered at stack level, whereas this CD
+// nests them under a component, and an alias without it would inherit the
+// current parent and so name a URN that never existed.
+func legacyAlias(name string) pulumi.ResourceOption {
+	return pulumi.Aliases([]pulumi.Alias{{
+		Name:     pulumi.String(name),
+		Project:  pulumi.String(legacyProject),
+		NoParent: pulumi.Bool(true),
+	}})
+}
+
+// legacyStackName mirrors stack(): "<prefix>-cd-<stack>-<parts...>", with the
+// prefix omitted on the playground stacks that never set one.
+func legacyStackName(ctx *pulumi.Context, parts ...string) string {
+	all := make([]string, 0, len(parts)+3)
+	if prefix := common.Prefix.Get(ctx); prefix != "" {
+		all = append(all, prefix)
+	}
+	all = append(all, legacyProject, ctx.Stack())
+	return strings.Join(append(all, parts...), "-")
+}
+
+// legacyRdsInstanceName mirrors the one legacy name that was not used verbatim:
+// awsIdentifierSafe(stack(service), MAX_DB_INSTANCE_IDENTITIER_LENGTH-8).
+func legacyRdsInstanceName(ctx *pulumi.Context, serviceName string) string {
+	return legacyTruncate(legacySanitize(legacyStackName(ctx, serviceName)), legacyRdsInstanceNameMaxLength)
+}
+
+// legacySanitize mirrors awsIdentifierSafe()'s folding: lowercase, then every
+// run of characters outside [a-z0-9-] replaced by a single hyphen.
+func legacySanitize(name string) string {
+	return legacyIdentifierInvalidChars.ReplaceAllLiteralString(strings.ToLower(name), "-")
+}
+
+// legacyTruncate mirrors truncate(): the head of the name plus a hex hash of
+// the whole of it, with no separator between them.
+func legacyTruncate(name string, maxLength int) string {
+	if len(name) <= maxLength {
+		return name
+	}
+	const hashLength = 6
+	digest := sha256.Sum256([]byte(name))
+	return name[:maxLength-hashLength] + hex.EncodeToString(digest[:])[:hashLength]
+}

--- a/provider/defangaws/aws/legacy_aliases_test.go
+++ b/provider/defangaws/aws/legacy_aliases_test.go
@@ -70,10 +70,18 @@ func (noopAWSMocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error)
 	return args.Args, nil
 }
 
-// legacyAliasSpy records the legacy identity each registered resource declared.
+// legacyAliasSpy records the legacy identity each registered resource declared,
+// keyed by resource type as well as name: several of the resources below share
+// a Pulumi name (e.g. the RDS instance, its security group and its subnet group
+// are all registered as "postgres"), so name alone can't tell them apart.
 type legacyAliasSpy struct {
 	noopAWSMocks
-	aliases map[string][]legacyAliasSpec
+	aliases map[legacyResourceKey][]legacyAliasSpec
+}
+
+type legacyResourceKey struct {
+	typeToken string
+	name      string
 }
 
 type legacyAliasSpec struct {
@@ -84,11 +92,12 @@ type legacyAliasSpec struct {
 
 func (m *legacyAliasSpy) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
 	if m.aliases == nil {
-		m.aliases = map[string][]legacyAliasSpec{}
+		m.aliases = map[legacyResourceKey][]legacyAliasSpec{}
 	}
+	key := legacyResourceKey{typeToken: args.TypeToken, name: args.Name}
 	for _, alias := range args.RegisterRPC.GetAliases() {
 		if spec := alias.GetSpec(); spec != nil {
-			m.aliases[args.Name] = append(m.aliases[args.Name], legacyAliasSpec{
+			m.aliases[key] = append(m.aliases[key], legacyAliasSpec{
 				name:     spec.GetName(),
 				project:  spec.GetProject(),
 				noParent: spec.GetNoParent(),
@@ -118,13 +127,13 @@ func TestRDSAdoptsLegacyMvpNames(t *testing.T) {
 	}, pulumi.WithMocks("myproject", "prod1", spy))
 	require.NoError(t, err)
 
-	assert.Contains(t, spy.aliases["postgres"], legacyAliasSpec{
+	assert.Contains(t, spy.aliases[legacyResourceKey{"aws:rds/instance:Instance", "postgres"}], legacyAliasSpec{
 		name: "defang-cd-prod1-postgres", project: legacyProject, noParent: true,
 	}, "RDS instance would be replaced instead of adopted")
-	assert.Contains(t, spy.aliases["postgres"], legacyAliasSpec{
+	assert.Contains(t, spy.aliases[legacyResourceKey{"aws:ec2/securityGroup:SecurityGroup", "postgres"}], legacyAliasSpec{
 		name: "Defang-cd-prod1-postgres", project: legacyProject, noParent: true,
 	}, "RDS security group would be replaced instead of adopted")
-	assert.Contains(t, spy.aliases["postgres"], legacyAliasSpec{
+	assert.Contains(t, spy.aliases[legacyResourceKey{"aws:rds/subnetGroup:SubnetGroup", "postgres"}], legacyAliasSpec{
 		name: "postgres", project: legacyProject, noParent: true,
 	}, "RDS subnet group would be replaced instead of adopted")
 }
@@ -144,10 +153,13 @@ func TestElasticacheAdoptsLegacyMvpNames(t *testing.T) {
 	}, pulumi.WithMocks("myproject", "prod1", spy))
 	require.NoError(t, err)
 
-	assert.Contains(t, spy.aliases[service], legacyAliasSpec{
+	assert.Contains(t, spy.aliases[legacyResourceKey{"aws:elasticache/replicationGroup:ReplicationGroup", service}], legacyAliasSpec{
 		name: service, project: legacyProject, noParent: true,
 	}, "replication group would be replaced instead of adopted")
-	assert.Contains(t, spy.aliases[service], legacyAliasSpec{
+	assert.Contains(t, spy.aliases[legacyResourceKey{"aws:elasticache/subnetGroup:SubnetGroup", service}], legacyAliasSpec{
 		name: "Defang-cd-prod1-" + service, project: legacyProject, noParent: true,
-	}, "ElastiCache subnet group and security group would be replaced instead of adopted")
+	}, "ElastiCache subnet group would be replaced instead of adopted")
+	assert.Contains(t, spy.aliases[legacyResourceKey{"aws:ec2/securityGroup:SecurityGroup", service}], legacyAliasSpec{
+		name: "Defang-cd-prod1-" + service, project: legacyProject, noParent: true,
+	}, "ElastiCache security group would be replaced instead of adopted")
 }

--- a/provider/defangaws/aws/legacy_aliases_test.go
+++ b/provider/defangaws/aws/legacy_aliases_test.go
@@ -1,0 +1,153 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/DefangLabs/pulumi-defang/provider/compose"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The shapes below were read out of a stack the legacy defang-mvp CD deployed:
+// its Pulumi project is "cd", its resources hang off the stack, and its names
+// carry that same "cd" where this CD would carry the compose project. If the
+// reconstruction drifts from defang-mvp's pulumi/shared/config.ts and
+// pulumi/shared/aws/safe_namings.ts, migrations stop adopting and start
+// replacing -- so pin the exact strings.
+func TestLegacyNamesMatchTheMvpCD(t *testing.T) {
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		// stack(service): the SG and the ElastiCache subnet group keep the
+		// prefix's capital D, because stack() sanitizes nothing.
+		assert.Equal(t, "Defang-cd-prod1-postgres", legacyStackName(ctx, "postgres"))
+		assert.Equal(t, "Defang-cd-prod1-redis", legacyStackName(ctx, engineRedis))
+
+		// awsIdentifierSafe(stack(service), 55) for the RDS instance.
+		assert.Equal(t, "defang-cd-prod1-postgres", legacyRdsInstanceName(ctx, "postgres"))
+		return nil
+	}, pulumi.WithMocks("myproject", "prod1", noopAWSMocks{}))
+	require.NoError(t, err)
+}
+
+// Playground stacks set no prefix, so stack() began at the project.
+func TestLegacyNamesWithoutPrefix(t *testing.T) {
+	t.Setenv("PULUMI_CONFIG", `{"defang:prefix": ""}`)
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		assert.Equal(t, "cd-prod1-redis", legacyStackName(ctx, engineRedis))
+		return nil
+	}, pulumi.WithMocks("myproject", "prod1", noopAWSMocks{}))
+	require.NoError(t, err)
+}
+
+// truncate() kept the head of the name and appended six hex characters of its
+// hash, with no separator. A service name long enough to trip that must trim
+// the same way or the alias names a URN that never existed.
+func TestLegacyIdentifierTrimsLikeTheMvpCD(t *testing.T) {
+	long := "a-very-long-service-name-that-will-certainly-overflow-the-limit"
+	got := legacyTruncate("defang-cd-prod1-"+long, legacyRdsInstanceNameMaxLength)
+
+	assert.Len(t, got, legacyRdsInstanceNameMaxLength)
+	assert.Equal(t, "defang-cd-prod1-a-very-long-service-name-that-wil", got[:49])
+	assert.Regexp(t, `^[0-9a-f]{6}$`, got[49:])
+}
+
+// awsIdentifierSafe() lowercased and folded each RUN of invalid characters to a
+// single hyphen.
+func TestLegacyIdentifierSanitization(t *testing.T) {
+	assert.Equal(t, "defang-cd-prod1-my-svc", legacySanitize("Defang-cd-prod1-My_Svc"))
+	assert.Equal(t, "a-b", legacySanitize("A__..B"))
+}
+
+// noopAWSMocks answers resource registrations without recording them.
+type noopAWSMocks struct{}
+
+func (noopAWSMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+	return args.Name + "_id", args.Inputs, nil
+}
+
+func (noopAWSMocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
+	return args.Args, nil
+}
+
+// legacyAliasSpy records the legacy identity each registered resource declared.
+type legacyAliasSpy struct {
+	noopAWSMocks
+	aliases map[string][]legacyAliasSpec
+}
+
+type legacyAliasSpec struct {
+	name     string
+	project  string
+	noParent bool
+}
+
+func (m *legacyAliasSpy) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+	if m.aliases == nil {
+		m.aliases = map[string][]legacyAliasSpec{}
+	}
+	for _, alias := range args.RegisterRPC.GetAliases() {
+		if spec := alias.GetSpec(); spec != nil {
+			m.aliases[args.Name] = append(m.aliases[args.Name], legacyAliasSpec{
+				name:     spec.GetName(),
+				project:  spec.GetProject(),
+				noParent: spec.GetNoParent(),
+			})
+		}
+	}
+	return args.Name + "_id", args.Inputs, nil
+}
+
+// Without these aliases an `up` over a legacy defang-mvp stack plans a create
+// plus a delete for the database rather than an update, and the delete takes
+// the data with it.
+func TestRDSAdoptsLegacyMvpNames(t *testing.T) {
+	spy := &legacyAliasSpy{}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		_, err := CreateRDS(ctx, &compose.DryRunConfigProvider{}, "postgres", compose.ServiceConfig{
+			Image:    pulumi.String("postgres:16"),
+			Postgres: &compose.PostgresConfig{},
+			Environment: compose.Environment{
+				"POSTGRES_PASSWORD": pulumi.String("literal-password"),
+			},
+		},
+			pulumi.String("vpc-123"),
+			pulumi.StringArray{pulumi.String("subnet-1"), pulumi.String("subnet-2")},
+			nil, nil, nil, pulumi.Parent(nil))
+		return err
+	}, pulumi.WithMocks("myproject", "prod1", spy))
+	require.NoError(t, err)
+
+	assert.Contains(t, spy.aliases["postgres"], legacyAliasSpec{
+		name: "defang-cd-prod1-postgres", project: legacyProject, noParent: true,
+	}, "RDS instance would be replaced instead of adopted")
+	assert.Contains(t, spy.aliases["postgres"], legacyAliasSpec{
+		name: "Defang-cd-prod1-postgres", project: legacyProject, noParent: true,
+	}, "RDS security group would be replaced instead of adopted")
+	assert.Contains(t, spy.aliases["postgres"], legacyAliasSpec{
+		name: "postgres", project: legacyProject, noParent: true,
+	}, "RDS subnet group would be replaced instead of adopted")
+}
+
+func TestElasticacheAdoptsLegacyMvpNames(t *testing.T) {
+	const service = engineRedis // the compose service is named after its engine here
+	spy := &legacyAliasSpy{}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		_, err := CreateElasticache(ctx, service, compose.ServiceConfig{
+			Image: pulumi.String("redis:7"),
+			Redis: &compose.RedisConfig{},
+		},
+			pulumi.String("vpc-123"),
+			pulumi.StringArray{pulumi.String("subnet-1"), pulumi.String("subnet-2")},
+			nil, nil, nil, pulumi.Parent(nil))
+		return err
+	}, pulumi.WithMocks("myproject", "prod1", spy))
+	require.NoError(t, err)
+
+	assert.Contains(t, spy.aliases[service], legacyAliasSpec{
+		name: service, project: legacyProject, noParent: true,
+	}, "replication group would be replaced instead of adopted")
+	assert.Contains(t, spy.aliases[service], legacyAliasSpec{
+		name: "Defang-cd-prod1-" + service, project: legacyProject, noParent: true,
+	}, "ElastiCache subnet group and security group would be replaced instead of adopted")
+}

--- a/provider/defangaws/aws/legacy_aliases_test.go
+++ b/provider/defangaws/aws/legacy_aliases_test.go
@@ -107,6 +107,11 @@ func (m *legacyAliasSpy) NewResource(args pulumi.MockResourceArgs) (string, reso
 	return args.Name + "_id", args.Inputs, nil
 }
 
+// specs returns the legacy identities one registered resource declared.
+func (m *legacyAliasSpy) specs(typeToken, name string) []legacyAliasSpec {
+	return m.aliases[legacyResourceKey{typeToken: typeToken, name: name}]
+}
+
 // Without these aliases an `up` over a legacy defang-mvp stack plans a create
 // plus a delete for the database rather than an update, and the delete takes
 // the data with it.
@@ -127,13 +132,13 @@ func TestRDSAdoptsLegacyMvpNames(t *testing.T) {
 	}, pulumi.WithMocks("myproject", "prod1", spy))
 	require.NoError(t, err)
 
-	assert.Contains(t, spy.aliases[legacyResourceKey{"aws:rds/instance:Instance", "postgres"}], legacyAliasSpec{
+	assert.Contains(t, spy.specs("aws:rds/instance:Instance", "postgres"), legacyAliasSpec{
 		name: "defang-cd-prod1-postgres", project: legacyProject, noParent: true,
 	}, "RDS instance would be replaced instead of adopted")
-	assert.Contains(t, spy.aliases[legacyResourceKey{"aws:ec2/securityGroup:SecurityGroup", "postgres"}], legacyAliasSpec{
+	assert.Contains(t, spy.specs("aws:ec2/securityGroup:SecurityGroup", "postgres"), legacyAliasSpec{
 		name: "Defang-cd-prod1-postgres", project: legacyProject, noParent: true,
 	}, "RDS security group would be replaced instead of adopted")
-	assert.Contains(t, spy.aliases[legacyResourceKey{"aws:rds/subnetGroup:SubnetGroup", "postgres"}], legacyAliasSpec{
+	assert.Contains(t, spy.specs("aws:rds/subnetGroup:SubnetGroup", "postgres"), legacyAliasSpec{
 		name: "postgres", project: legacyProject, noParent: true,
 	}, "RDS subnet group would be replaced instead of adopted")
 }
@@ -153,13 +158,13 @@ func TestElasticacheAdoptsLegacyMvpNames(t *testing.T) {
 	}, pulumi.WithMocks("myproject", "prod1", spy))
 	require.NoError(t, err)
 
-	assert.Contains(t, spy.aliases[legacyResourceKey{"aws:elasticache/replicationGroup:ReplicationGroup", service}], legacyAliasSpec{
+	assert.Contains(t, spy.specs("aws:elasticache/replicationGroup:ReplicationGroup", service), legacyAliasSpec{
 		name: service, project: legacyProject, noParent: true,
 	}, "replication group would be replaced instead of adopted")
-	assert.Contains(t, spy.aliases[legacyResourceKey{"aws:elasticache/subnetGroup:SubnetGroup", service}], legacyAliasSpec{
+	assert.Contains(t, spy.specs("aws:elasticache/subnetGroup:SubnetGroup", service), legacyAliasSpec{
 		name: "Defang-cd-prod1-" + service, project: legacyProject, noParent: true,
 	}, "ElastiCache subnet group would be replaced instead of adopted")
-	assert.Contains(t, spy.aliases[legacyResourceKey{"aws:ec2/securityGroup:SecurityGroup", service}], legacyAliasSpec{
+	assert.Contains(t, spy.specs("aws:ec2/securityGroup:SecurityGroup", service), legacyAliasSpec{
 		name: "Defang-cd-prod1-" + service, project: legacyProject, noParent: true,
 	}, "ElastiCache security group would be replaced instead of adopted")
 }

--- a/provider/defangaws/aws/rds.go
+++ b/provider/defangaws/aws/rds.go
@@ -198,7 +198,9 @@ func CreateRDS(
 			Description: pulumi.String(common.DefangComment),
 			SubnetIds:   privateSubnetIDs,
 			Tags:        tags,
-		}, opt)
+			// The legacy CD named this one after the bare service, with no stack
+			// prefix (postgres.ts: new aws.rds.SubnetGroup(service_name)).
+		}, pulumi.Composite(opt, legacyAlias(serviceName)))
 		if err != nil {
 			return nil, fmt.Errorf("creating DB subnet group: %w", err)
 		}
@@ -234,6 +236,8 @@ func CreateRDS(
 		Tags: tags,
 	}, pulumi.Composite(opt,
 		pulumi.Timeouts(&pulumi.CustomTimeouts{Delete: "2m"}),
+		// createSecurityGroup() registered every SG under stack(name).
+		legacyAlias(legacyStackName(ctx, serviceName)),
 	))
 	if err != nil {
 		return nil, fmt.Errorf("creating RDS security group: %w", err)
@@ -284,7 +288,8 @@ func CreateRDS(
 	// (now-removed) `storage-encrypted` recipe defaulted to false would otherwise
 	// force-replace on next up. RDS can't toggle encryption in-place, so we
 	// preserve the existing instance and leave migration to the operator.
-	rdsOpts := []pulumi.ResourceOption{opt, pulumi.IgnoreChanges([]string{"storageEncrypted"})}
+	rdsOpts := []pulumi.ResourceOption{opt, pulumi.IgnoreChanges([]string{"storageEncrypted"}),
+		legacyAlias(legacyRdsInstanceName(ctx, serviceName))}
 	if len(deps) > 0 {
 		rdsOpts = append(rdsOpts, pulumi.DependsOn(deps))
 	}


### PR DESCRIPTION
Replaces #496, cut down to the shape your review asked for: aliases on the stateful resources, no CD-side state preflight and no safety preview. ~5.5k lines of that machinery are gone; what is left is one 85-line file and six alias options.

## Problem

An AWS project deployed by the legacy defang-mvp CD cannot move onto this one. The two CDs register the same cloud resources under different logical names, and the legacy ones hang off the stack rather than off a component:

```
legacy   urn:pulumi:<stack>::cd::aws:rds/instance:Instance::defang-cd-<stack>-postgres
current  urn:pulumi:<stack>::<project>::…$Postgres$aws:rds/instance:Instance::postgres
```

Pulumi sees no continuity, so an `up` plans a create plus a delete. For the RDS instance and the ElastiCache replication group that delete is real, and it takes the data with it.

## Approach

Same as #529 did for GCP: the legacy names are deterministic, so `legacy_aliases.go` reconstructs them rather than asking an operator to paste URNs into compose. It mirrors defang-mvp's `pulumi/shared/config.ts` (`stack()`) and `pulumi/shared/aws/safe_namings.ts` (`awsIdentifierSafe()`, `truncate()`).

Two things differ from the GCP side, and both are easy to get wrong:

- **The legacy program was the Pulumi project `cd`** — the name in `pulumi/cd/Pulumi.yaml` — while this CD's project is the compose project name. Every legacy URN therefore carries `cd`, and the alias has to say so with `Project`. The legacy GCP CD passed the compose project to the automation API (`gcpcd.go:442`), which is why #529 needed no such override.
- **The legacy names embed that same `cd`**, not the compose project, because `shared/config.ts` built its prefix from `pulumi.getProject()`. So the RDS security group is `Defang-cd-<stack>-postgres`, not `Defang-<project>-<stack>-postgres`.

`NoParent` is required on every alias, for the same reason as on GCP.

Adopted, with the legacy name each one had:

| resource | legacy logical name |
|---|---|
| `aws:rds/instance:Instance` | `awsIdentifierSafe(stack(svc), 55)` → `defang-cd-<stack>-<svc>` |
| `aws:rds/subnetGroup:SubnetGroup` | `<svc>` |
| `aws:ec2/securityGroup:SecurityGroup` (RDS) | `stack(svc)` → `Defang-cd-<stack>-<svc>` |
| `aws:elasticache/replicationGroup:ReplicationGroup` | `<svc>` |
| `aws:elasticache/subnetGroup:SubnetGroup` | `stack(svc)` |
| `aws:ec2/securityGroup:SecurityGroup` (ElastiCache) | `stack(svc)` |

The capital `D` in the security-group and subnet-group names is not a typo: `stack()` sanitized nothing, while the RDS instance went through `awsIdentifierSafe()` and came out lowercased. A real legacy state shows exactly that pair, `E-cd-…-postgres` beside `e-cd-…-postgres`.

These aliases append to the `x-defang-aliases` ones (#313) rather than replacing them, so an explicit URN override still works.

## Tests

- `TestLegacyNamesMatchTheMvpCD` pins every reconstructed string, including the mixed case, plus the no-prefix (playground) form, the 55-character trim with its 6-hex hash, and the run-folding sanitizer.
- `TestRDSAdoptsLegacyMvpNames` / `TestElasticacheAdoptsLegacyMvpNames` assert the alias specs actually reach the registered resources — name, `Project: "cd"` and `NoParent` together. Reverted against the instance alias, the first fails with `RDS instance would be replaced instead of adopted`.
- `CGO_ENABLED=0 go build ./... && go test ./provider/...` — green.
- `golangci-lint run --config=.golangci.yaml --new-from-rev=origin/main ./provider/...` — 0 issues.

## Why an alias is enough for the data resources

Nothing in this code sets the RDS instance's `Identifier` or the replication group's `ReplicationGroupId`: both are auto-named, so the name stored in state survives the adoption and the ForceNew property never diffs. That is the same reason #529's Cloud SQL instance came back as an in-place update on live infrastructure, and the opposite of the Artifact Registry repository in #530, whose physical ID this code computes itself.

## What this does NOT do — please read before merging

- **No live migration test.** #529 was verified twice on live GCP; I have no AWS account with write access from this box, so this is name-level and alias-level evidence only. A real legacy-CD project migrated on AWS is the missing proof.
- **Only the databases.** #529 taught us the network matters just as much: an adopted Cloud SQL instance keeps the private network it was created on, so adopting the database and not the VPC left services with no route to it, and the legacy private DNS zone was refused outright. The AWS equivalents (VPC, subnets, the private Route 53 zone, the ALB, the ECS cluster, ECR) are **not** adopted here. Expect the same class of failure on a real AWS migration until they are — I would rather land the data-safety half and size that work separately than block on it.
- **MemoryDB has nothing to adopt.** The legacy CD never created it (`redis.ts`: `TODO: support MemoryDB`), so an ElastiCache→MemoryDB engine switch is still a replacement, and #496's MemoryDB aliases described a migration that cannot exist.
- **No DocumentDB.** The legacy CD had `mongodb.ts`; this provider has no AWS Mongo to alias to.

## Related

- #529 — the GCP half of the same migration
- #530 — its known gap (Artifact Registry `repositoryId`)
- #496 — replaced by this
- #459 — logical-name hardening

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3WmpdY3zc555sNdkY9dzQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved adoption of existing RDS and ElastiCache resources created by the legacy deployment system.
  * Preserved resource identities for subnet groups, security groups, replication groups, and RDS instances during updates or migrations.
  * Reduced unnecessary resource replacement when transitioning from legacy deployments.

* **Tests**
  * Added coverage for legacy resource naming, including stack prefixes, sanitization, truncation, and resource adoption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->