### PR TITLE
fix(gcp): adopt the Memorystore instance the legacy defang-mvp CD created

### DIFF
--- a/provider/defanggcp/gcp/legacy_aliases.go
+++ b/provider/defanggcp/gcp/legacy_aliases.go
@@ -48,8 +48,19 @@ func legacyAlias(name string) pulumi.ResourceOption {
 
 // legacyResourceName mirrors resourceName(): "<prefix>-<project>-<stack>-<parts...>".
 func legacyResourceName(ctx *pulumi.Context, projectName string, parts ...string) string {
+	return legacyTrimmedName(ctx, 63-legacyPulumiSuffixLength, projectName, parts...)
+}
+
+// legacyRedisInstanceName mirrors redisInstanceName(), which built the same
+// name but trimmed it at 40 characters rather than 63, for Memorystore's own
+// limit.
+func legacyRedisInstanceName(ctx *pulumi.Context, projectName, serviceName string) string {
+	return legacyTrimmedName(ctx, 40-legacyPulumiSuffixLength, projectName, serviceName, "redis")
+}
+
+func legacyTrimmedName(ctx *pulumi.Context, maxLength int, projectName string, parts ...string) string {
 	all := append([]string{legacyPrefix, projectName, ctx.Stack()}, parts...)
-	return legacyHashTrim(legacySanitize(strings.Join(all, "-")), 63-legacyPulumiSuffixLength)
+	return legacyHashTrim(legacySanitize(strings.Join(all, "-")), maxLength)
 }
 
 // legacyPlainName mirrors the places the legacy CD joined names by hand,

--- a/provider/defanggcp/gcp/legacy_aliases_test.go
+++ b/provider/defanggcp/gcp/legacy_aliases_test.go
@@ -3,6 +3,7 @@ package gcp
 import (
 	"testing"
 
+	"github.com/DefangLabs/pulumi-defang/provider/compose"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -62,4 +63,58 @@ func TestLegacyNameSanitization(t *testing.T) {
 // A network name may not start with a non-letter; the legacy CD prefixed those.
 func TestLegacyNetworkNamePrefixesNonLetters(t *testing.T) {
 	assert.Equal(t, "net-9lives-vpc", legacyNetworkName("9lives-vpc"))
+}
+
+// The Memorystore instance is the other data resource a legacy defang-mvp
+// project owns; redisInstanceName() trimmed at 40 characters rather than 63.
+func TestLegacyRedisInstanceName(t *testing.T) {
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		// 26 characters, so it survives whole.
+		assert.Equal(t, "defang-mig-cyc-cache-redis", legacyRedisInstanceName(ctx, "mig", "cache"))
+
+		// 40-8 characters is a tight budget: even a short project overflows it,
+		// and then the tail becomes a 6-character base36 hash.
+		trimmed := legacyRedisInstanceName(ctx, "martekio-mig", "cache")
+		assert.Len(t, trimmed, 32)
+		assert.Equal(t, "defang-martekio-mig-cyc-ca", trimmed[:26])
+		assert.Regexp(t, `^[a-z0-9]{6}$`, trimmed[26:])
+		return nil
+	}, pulumi.WithMocks("martekio-mig", "cyc", testMocks{}))
+	require.NoError(t, err)
+}
+
+// Without this alias an `up` over a legacy defang-mvp stack plans a create plus
+// a delete for the Memorystore instance rather than an update.
+func TestMemorystoreAdoptsLegacyMvpName(t *testing.T) {
+	spy := &aliasSpy{}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		_, err := CreateMemoryStore(ctx, "cache", compose.ServiceConfig{
+			Image: pulumi.String("redis:7"),
+			Redis: &compose.RedisConfig{},
+		}, &SharedInfra{
+			ProjectName: "martekio-mig",
+			VpcId:       pulumi.String("projects/p/global/networks/vpc").ToStringOutput(),
+		}, pulumi.Parent(nil))
+		return err
+	}, pulumi.WithMocks("martekio-mig", "cyc", spy))
+	require.NoError(t, err)
+
+	assert.Contains(t, spy.aliases["cache"], "defang-martekio-mig-cyc-ca2jud8n",
+		"Memorystore instance would be replaced instead of adopted")
+}
+
+// A standalone Redis component has no infra and no legacy history, so it must
+// not claim a legacy name.
+func TestMemorystoreWithoutInfraDeclaresNoLegacyAlias(t *testing.T) {
+	spy := &aliasSpy{}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		_, err := CreateMemoryStore(ctx, "cache", compose.ServiceConfig{
+			Image: pulumi.String("redis:7"),
+			Redis: &compose.RedisConfig{},
+		}, nil, pulumi.Parent(nil))
+		return err
+	}, pulumi.WithMocks("martekio-mig", "cyc", spy))
+	require.NoError(t, err)
+
+	assert.Empty(t, spy.aliases["cache"])
 }

--- a/provider/defanggcp/gcp/memorystore.go
+++ b/provider/defanggcp/gcp/memorystore.go
@@ -67,6 +67,15 @@ func CreateMemoryStore(
 			pulumi.DependsOn([]pulumi.Resource{infra.ServiceConnection}),
 		}, opts...)
 	}
+	// Adopt the instance the legacy defang-mvp CD created (redis.go:38 there:
+	// redisInstanceName(project, service, config)). The compose project name
+	// comes from SharedInfra rather than a parameter because only a CD-driven
+	// project can have legacy state to adopt; a standalone Redis component has
+	// no infra and no history.
+	if infra != nil && infra.ProjectName != "" {
+		instanceOpts = append(instanceOpts,
+			legacyAlias(legacyRedisInstanceName(ctx, infra.ProjectName, serviceName)))
+	}
 
 	var authorizedNetwork pulumi.StringPtrInput
 	if infra != nil {


### PR DESCRIPTION
The last piece of #496 that is worth keeping, in the shape #529 established.

## Problem

#529 adopted the Cloud SQL instance plus the VPC, subnet, private DNS zone, peering range, service-networking connection and Artifact Registry. It left the other data resource a legacy project owns: the Memorystore instance. Without an alias, an `up` over a legacy defang-mvp stack plans a create plus a delete for it.

## Fix

`legacyRedisInstanceName` mirrors defang-mvp's `redisInstanceName()` (`gcpcd/redis.go:38`, `safe_namings.go:54`), which built the same string as `resourceName()` but trimmed it at 40 characters rather than 63 — Memorystore's own limit. `legacyResourceName` therefore grew a length-taking core that both share.

That budget is tight enough to matter: `defang-martekio-mig-cyc-cache-redis` is 35 characters, so a real project's instance name is already hash-trimmed to `defang-martekio-mig-cyc-ca2jud8n`. Getting the limit wrong would produce a name that never existed, and the test pins both the surviving and the trimmed form.

The compose project name comes from `SharedInfra` rather than a new parameter: only a CD-driven project can have legacy state to adopt, and a standalone `Redis` component has neither infra nor history. A test asserts that path declares no legacy alias at all.

## Why an alias is enough here

Unlike the Artifact Registry repository in #530, nothing in this code sets the instance's physical `name`: it is auto-named, so the name stored in state survives the adoption and the ForceNew property never diffs. That is the same reason #529's Cloud SQL instance came back as an in-place update on live infrastructure.

## Verification

- `TestLegacyRedisInstanceName` pins the exact name for a short project and the 32-character hash-trimmed form for a real one.
- `TestMemorystoreAdoptsLegacyMvpName` asserts the alias reaches the registered instance; `TestMemorystoreWithoutInfraDeclaresNoLegacyAlias` asserts the standalone path stays clean.
- `CGO_ENABLED=0 go test ./provider/...` — green. `golangci-lint --new-from-rev=origin/main ./provider/...` — 0 issues.
- Not verified on live infrastructure: #529's migration test used managed Postgres. A legacy project with managed Redis is the missing proof, and the `tier` input is where I would look first — the legacy CD only set `STANDARD_HA` in production, this one always does.

## Related

- #529, #530 — the rest of the GCP migration
- #531 — the AWS half
- #496 — replaced by these

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3WmpdY3zc555sNdkY9dzQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Memorystore resource naming compatibility with legacy deployments.
  - Redis instances associated with shared infrastructure can now adopt their previous resource name.
  - Standalone Redis deployments continue without legacy aliases.
  - Long Redis names are trimmed according to the platform’s naming limits while preserving uniqueness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->