### PR TITLE
fix(aws): stop truncating the ECR cache prefix onto a separator

### DIFF
--- a/provider/defangaws/aws/ecr.go
+++ b/provider/defangaws/aws/ecr.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"strings"
 
@@ -42,6 +44,45 @@ type PullThroughCache struct {
 	CachePrefix pulumi.StringOutput
 }
 
+// maxCacheRepoLength is the longest ecrRepositoryPrefix AWS accepts.
+// It was 20 before https://github.com/hashicorp/terraform-provider-aws/pull/34716.
+const maxCacheRepoLength = 30
+
+// cachePrefixHashLength is how much of an over-long prefix is given over to a
+// hash of the whole of it.
+const cachePrefixHashLength = 6
+
+// cachePrefixSeparators are the characters AWS allows inside an
+// ecrRepositoryPrefix but not at its end.
+const cachePrefixSeparators = "._-/"
+
+// cachePrefixName fits a seed into ecrRepositoryPrefix's 30 characters.
+//
+// Plain truncation was not enough on two counts. AWS rejects a prefix that
+// ends in a separator, and cutting "defang-mastra-extended-e2eaws-mastra-
+// extended-ecr-public" at 30 characters produces exactly that -- the deploy
+// failed with "invalid value for ecr_repository_prefix", whose message lists
+// the allowed characters and so points away from the real cause. And the
+// prefix is an ACCOUNT-GLOBAL namespace, so two projects whose names agree for
+// the first 30 characters would otherwise claim one rule.
+//
+// Trading the tail for a hash of the full seed answers both. Seeds that fit
+// are returned unchanged, and existing rules keep their current prefix through
+// IgnoreChanges below, so nothing already deployed moves.
+func cachePrefixName(prefix string) string {
+	if len(prefix) <= maxCacheRepoLength {
+		return strings.TrimRight(prefix, cachePrefixSeparators)
+	}
+
+	digest := sha256.Sum256([]byte(prefix))
+	hash := hex.EncodeToString(digest[:])[:cachePrefixHashLength]
+	head := strings.TrimRight(prefix[:maxCacheRepoLength-cachePrefixHashLength-1], cachePrefixSeparators)
+	if head == "" {
+		return hash
+	}
+	return head + "-" + hash
+}
+
 // createEcrPullThroughCache creates an ECR pull-through cache rule for the given upstream registry.
 // Matches TS createEcrPullThroughCache in shared/aws/repos.ts. prefixSeed
 // seeds the repository prefix — an ACCOUNT-global namespace, so it must be
@@ -54,13 +95,8 @@ func createEcrPullThroughCache(
 	upstreamRegistryURL pulumi.StringInput,
 	opts ...pulumi.ResourceOption,
 ) (*PullThroughCache, error) {
-	const maxCacheRepoLength = 30 // was 20 https://github.com/hashicorp/terraform-provider-aws/pull/34716
 	// PullThroughCacheRule does not support autonaming, so we need to generate a unique and compliant prefix ourselves.
-	prefix := strings.ToLower(common.AutonamingPrefix(ctx, prefixSeed))
-	if len(prefix) > maxCacheRepoLength {
-		// 	TODO: hashTrim/truncate prefix smartly
-		prefix = prefix[:maxCacheRepoLength]
-	}
+	prefix := cachePrefixName(strings.ToLower(common.AutonamingPrefix(ctx, prefixSeed)))
 	rule, err := ecr.NewPullThroughCacheRule(ctx, name, &ecr.PullThroughCacheRuleArgs{
 		EcrRepositoryPrefix: pulumi.String(prefix),
 		UpstreamRegistryUrl: upstreamRegistryURL,

--- a/provider/defangaws/aws/ecr_test.go
+++ b/provider/defangaws/aws/ecr_test.go
@@ -1,0 +1,46 @@
+package aws
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The exact string that failed a live deploy of the mastra-extended sample to
+// project "mastra-extended", stack "e2eaws": the 30-character cut landed on a
+// hyphen, and AWS rejected the prefix.
+func TestCachePrefixNameDoesNotEndInASeparator(t *testing.T) {
+	const seed = "defang-mastra-extended-e2eaws-mastra-extended-ecr-public"
+
+	got := cachePrefixName(seed)
+
+	require.LessOrEqual(t, len(got), maxCacheRepoLength)
+	assert.NotEqual(t, "defang-mastra-extended-e2eaws-", got, "the truncation that AWS rejected")
+	assert.NotEmpty(t, strings.TrimRight(got, cachePrefixSeparators),
+		"a prefix of only separators is not a name")
+	assert.Equal(t, strings.TrimRight(got, cachePrefixSeparators), got,
+		"ecrRepositoryPrefix may not end in a separator")
+}
+
+// The prefix is an account-global namespace, so two projects that agree for
+// the first 30 characters must not claim one rule.
+func TestCachePrefixNameLongSeedsDoNotCollide(t *testing.T) {
+	shared := "defang-" + strings.Repeat("verylongproject", 3)
+
+	first := cachePrefixName(shared + "-alpha-ecr-public")
+	second := cachePrefixName(shared + "-bravo-ecr-public")
+
+	require.LessOrEqual(t, len(first), maxCacheRepoLength)
+	require.LessOrEqual(t, len(second), maxCacheRepoLength)
+	assert.NotEqual(t, first, second)
+	assert.Equal(t, first, cachePrefixName(shared+"-alpha-ecr-public"), "must be deterministic")
+}
+
+// A seed that already fits is left exactly as it is: existing rules keep their
+// prefix, and this is the common case.
+func TestCachePrefixNameShortSeedsAreUnchanged(t *testing.T) {
+	assert.Equal(t, "defang-app-prod-ecr-public", cachePrefixName("defang-app-prod-ecr-public"))
+	assert.Len(t, cachePrefixName(strings.Repeat("a", maxCacheRepoLength)), maxCacheRepoLength)
+}


### PR DESCRIPTION
Found by the three-cloud `mastra-extended` end-to-end run on merged main (the one #460 asked for). The AWS leg never reached a single service:

```
aws:ecr/pullThroughCacheRule:PullThroughCacheRule resource 'ecr-public' has a problem:
invalid value for ecr_repository_prefix (must be 'ROOT' or only include alphanumeric,
underscore, period, hyphen, or slash characters)
```

## Cause

`createEcrPullThroughCache` seeds the prefix with `<project>-ecr-public`, runs it through the autonaming recipe, lowercases it and truncates at 30 characters (`ecr.go`, under a `TODO: hashTrim/truncate prefix smartly`). For project `mastra-extended`, stack `e2eaws`:

```
full   defang-mastra-extended-e2eaws-mastra-extended-ecr-public   (56)
cut    defang-mastra-extended-e2eaws-                             (30, trailing hyphen)
```

AWS allows a hyphen *inside* a prefix but not at its end. The error text lists the allowed character set, which sends you looking for a stray character — I first suspected a colon from an `image:tag` — when the character set was never the problem.

It is entirely name-length dependent, which is why CI never saw it: a stack name one character shorter or longer moves the cut off the hyphen and the same project deploys fine.

## Fix

`cachePrefixName` trades the tail for a 6-character hash of the full seed, after trimming separators off the head. That also closes the second hole the TODO left open: `ecrRepositoryPrefix` is an **account-global** namespace, so two projects whose names agree for 30 characters would otherwise claim one rule — the same collision class #460 fixed for target groups.

```
before  defang-mastra-extended-e2eaws-
after   defang-mastra-extended-d144a1
```

Seeds that already fit are returned unchanged, and the pre-existing `IgnoreChanges(ecrRepositoryPrefix)` means deployed rules keep the prefix they have. So nothing already running moves.

## Tests

- `TestCachePrefixNameDoesNotEndInASeparator` pins the exact string that failed the live deploy.
- `TestCachePrefixNameLongSeedsDoNotCollide` — two projects sharing 30 characters stay distinct and deterministic.
- `TestCachePrefixNameShortSeedsAreUnchanged` — the common case is untouched.
- `CGO_ENABLED=0 go test ./provider/...` green; `golangci-lint --new-from-rev=origin/main ./provider/...` 0 issues.

## Not verified end to end yet

The AWS leg is being re-run with a stack name that sidesteps the length, to get the naming evidence #460 was after. This PR is the fix for the bug that run exposed; a full AWS deploy on an image containing it is still owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3WmpdY3zc555sNdkY9dzQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Amazon ECR pull-through cache naming for long prefixes.
  - Prevented generated cache names from ending with separators.
  - Reduced the risk of naming collisions while preserving short and valid-length prefixes.
- **Tests**
  - Added coverage for deterministic naming, separator handling, long-prefix collision avoidance, and preservation of valid prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->