### PR TITLE
fix(aws): name the managed databases in lowercase, as AWS requires

### DIFF
--- a/cd/config.go
+++ b/cd/config.go
@@ -76,6 +76,9 @@ func unmarshalRecipe(recipePulumiConfig string, config configMap) error {
 // lowercased) is prepended where one is still wanted.
 const defaultAutonamingSuffix = "${project}-${stack}-${name}-${hex(7)}"
 
+// autonamingPattern is the key of a per-resource autonaming rule.
+const autonamingPattern = "pattern"
+
 func setDefaultStackConfig(prefix string, config configMap) {
 	// defang:prefix holds the bare prefix (e.g. "Defang"); its consumers
 	// (common.Prefix, e.g. ProjectResourceGroupName) append their own "-"
@@ -86,6 +89,8 @@ func setDefaultStackConfig(prefix string, config configMap) {
 		prefix += "-"
 	}
 	lowerPrefix := strings.ToLower(prefix)
+	// Types that reject an uppercase physical name all share this pattern.
+	lowercased := map[string]string{autonamingPattern: lowerPrefix + defaultAutonamingSuffix}
 	config["pulumi:autonaming"] = configValue{Value: map[string]any{
 		"pattern": prefix + defaultAutonamingSuffix,
 		"providers": map[string]any{
@@ -95,10 +100,21 @@ func setDefaultStackConfig(prefix string, config configMap) {
 					"aws:lb/targetGroup:TargetGroup":   map[string]string{"pattern": "${name}-${hex(4)}"},
 					// ecs.Service is always scoped to an ecs.Cluster, so the cluster's
 					// full prefix already disambiguates it; no need to repeat it here.
-					"aws:ecs/service:Service":                 map[string]string{"pattern": "${name}-${hex(7)}"},
-					"aws:elasticache/subnetGroup:SubnetGroup": map[string]string{"pattern": lowerPrefix + defaultAutonamingSuffix}, // lowercase
-					"aws:ecr/repository:Repository":           map[string]string{"pattern": lowerPrefix + defaultAutonamingSuffix}, // lowercase
-					"aws:rds/subnetGroup:SubnetGroup":         map[string]string{"pattern": lowerPrefix + defaultAutonamingSuffix}, // lowercase
+					"aws:ecs/service:Service": map[string]string{"pattern": "${name}-${hex(7)}"},
+					// Every type below rejects an uppercase physical name, so the
+					// prefix is lowercased for them. The databases matter as much
+					// as the groups they sit in: a managed Postgres deploy failed
+					// with `only lowercase alphanumeric characters and hyphens
+					// allowed in "identifier"` because rds/instance was missing
+					// here and fell back to the capitalised default pattern.
+					"aws:ecr/repository:Repository":                     lowercased,
+					"aws:elasticache/replicationGroup:ReplicationGroup": lowercased,
+					"aws:elasticache/subnetGroup:SubnetGroup":           lowercased,
+					"aws:memorydb/cluster:Cluster":                      lowercased,
+					"aws:memorydb/parameterGroup:ParameterGroup":        lowercased,
+					"aws:memorydb/subnetGroup:SubnetGroup":              lowercased,
+					"aws:rds/instance:Instance":                         lowercased,
+					"aws:rds/subnetGroup:SubnetGroup":                   lowercased,
 				},
 			},
 			"azure-native": map[string]any{
@@ -182,7 +198,7 @@ func addStackConfigFromEnv(config configMap) error {
 	// that pass the generic REGION var for their own region fallback below —
 	// this is exactly what "conflicting cloud providers configured" fired on.
 	awsRegion := os.Getenv("AWS_REGION")
-	azureLocation := getenv("AZURE_LOCATION", region) // Azure only
+	azureLocation := getenv("AZURE_LOCATION", region)         // Azure only
 	azureSubscriptionId := os.Getenv("AZURE_SUBSCRIPTION_ID") // Azure only; the project RG and Key Vault names are derived from (project, stack, location) and (subscription, RG) respectively — see provider/defangazure/azure/azure.go
 	cdImage := os.Getenv("DEFANG_CD_IMAGE")                   // GCP only; for cleanup
 	delegationSetId := os.Getenv("DELEGATION_SET_ID")         // AWS only

--- a/cd/config_test.go
+++ b/cd/config_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
+	"strings"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optdestroy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -531,5 +533,35 @@ func unsetenv(t *testing.T, keys ...string) {
 			t.Setenv(key, "") // sets up restoration and checks for parallel test interference
 			os.Unsetenv(key)
 		}
+	}
+}
+
+// AWS rejects an uppercase physical name for these types. rds/instance was
+// missing from the recipe, so it fell back to the capitalised default pattern
+// and a real managed-Postgres deploy died with `only lowercase alphanumeric
+// characters and hyphens allowed in "identifier"` before any database existed.
+func Test_setDefaultStackConfigLowercasesAwsDatabaseNames(t *testing.T) {
+	config := configMap{}
+	setDefaultStackConfig("Defang", config)
+
+	autonamingMap := config["pulumi:autonaming"].Value.(map[string]any)
+	providers := autonamingMap["providers"].(map[string]any)
+	resources := providers["aws"].(map[string]any)["resources"].(map[string]any)
+
+	for _, typeToken := range []string{
+		"aws:ecr/repository:Repository",
+		"aws:elasticache/replicationGroup:ReplicationGroup",
+		"aws:elasticache/subnetGroup:SubnetGroup",
+		"aws:memorydb/cluster:Cluster",
+		"aws:memorydb/parameterGroup:ParameterGroup",
+		"aws:memorydb/subnetGroup:SubnetGroup",
+		"aws:rds/instance:Instance",
+		"aws:rds/subnetGroup:SubnetGroup",
+	} {
+		entry, ok := resources[typeToken]
+		require.True(t, ok, "%s has no autonaming pattern, so it inherits the capitalised default", typeToken)
+		pattern := entry.(map[string]string)["pattern"]
+		require.Equal(t, strings.ToLower(pattern), pattern,
+			"%s must be named in lowercase; AWS rejects the name otherwise", typeToken)
 	}
 }


### PR DESCRIPTION
Second bug found by the three-cloud `mastra-extended` end-to-end run. With #533's ECR fix worked around, the AWS deploy got as far as the database and died:

```
aws:rds/instance:Instance resource 'postgres' has a problem:
  only lowercase alphanumeric characters and hyphens allowed in "identifier"
aws:rds/instance:Instance resource 'postgres' has a problem:
  first character of "identifier" must be a letter
```

## Cause

`cd/config.go` lowercases the prefix for `ecr/repository` and for the RDS and ElastiCache **subnet groups** — but not for the databases those subnet groups exist to serve. Missing from that list, `aws:rds/instance:Instance` inherited the global pattern and asked AWS for:

```
Defang-mastra-extended-<stack>-postgres-<hex(7)>
```

Nothing in the provider sets these identifiers (`rds.go` passes no `Identifier`, `elasticache.go` no `ReplicationGroupId`), so the recipe is the only thing that decides them.

Both messages come from that one capital `D`: the AWS provider's identifier validation requires the first character to be a **lowercase** letter, so an uppercase initial trips the charset rule and the first-character rule together.

## Fix

The five remaining types that reject an uppercase physical name now share one `lowercased` rule:

| type | why |
|---|---|
| `aws:rds/instance:Instance` | the failure above |
| `aws:elasticache/replicationGroup:ReplicationGroup` | same constraint; would fail the same way |
| `aws:memorydb/cluster:Cluster` | ditto |
| `aws:memorydb/parameterGroup:ParameterGroup` | ditto |
| `aws:memorydb/subnetGroup:SubnetGroup` | ditto |

Only `rds/instance` is proven by a live failure; the other four are the same constraint reached by reading, and they cost nothing to fix now rather than one deploy at a time. ElastiCache would have been the very next error in this same run, since the sample has a `redis` service.

## Tests

`Test_setDefaultStackConfigLowercasesAwsDatabaseNames` asserts each of these types has a pattern and that the pattern is already lowercase — it fails on a missing entry, which is the shape of this bug, rather than on a wrong string.

`go test ./...` in the cd module green; `golangci-lint --new-from-rev=origin/main` 0 issues.

## Note for whoever merges

This lives in the CD program, so it only reaches a deployment through a rebuilt CD image. The AWS third of the end-to-end run stays blocked until this merges and an image carrying it exists — GCP and Azure are unaffected and were exercised on `2.6.0-alpha-4d1f722f`.

## Related

- #533 — the ECR pull-through-cache prefix, the first blocker in the same run
- #460 — the naming work this run was meant to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3WmpdY3zc555sNdkY9dzQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded automatic naming support for AWS container registries, caching services, databases, and database subnet groups.
  - Added consistent naming patterns for AWS resources, including ECS services and RDS instances.

- **Bug Fixes**
  - Corrected database-related AWS resource names to use lowercase formatting consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->