### PR TITLE
fix(azure): probe delay clamp, LLM alias lookup, and self-destruct name collision

### DIFF
--- a/cd/program/selfdestruct_azure.go
+++ b/cd/program/selfdestruct_azure.go
@@ -25,10 +25,16 @@ const (
 	CdResourceGroup = "defang-cd"
 	cdJobName       = "defang-cd"
 
-	// selfDestructJobName is deterministic so every redeploy updates the same
-	// trigger in place (extending the stack's life). It is unique within the
-	// project resource group, which is itself per project/stack.
-	selfDestructJobName = "defang-self-destruct"
+	// selfDestructName is the Pulumi logical name and the container name inside
+	// the job. It is deliberately NOT set as the job's physical JobName: Container
+	// Apps requires job names to be unique within the MANAGED ENVIRONMENT, and every
+	// project's trigger job is created in the shared defang-cd environment. A fixed
+	// physical name therefore let only the first project in a subscription have a
+	// TTL; every later one failed the whole deploy with HTTP 409
+	// ContainerAppsJobNameConflictInCluster. Letting Pulumi auto-name keeps it unique
+	// per stack while staying stable across redeploys of the same stack, so a
+	// redeploy still updates the trigger in place and extends the stack's life.
+	selfDestructName = "defang-self-destruct"
 
 	// The trigger execution only STARTS the down (one ARM call); the down
 	// itself runs in the shared defang-cd job. It must not run the destroy
@@ -93,7 +99,7 @@ func createAzureSelfDestruct(pctx *pulumi.Context, cf *compose.Project, ttl time
 	_ = pctx.Log.Info(fmt.Sprintf("self-destruct: this stack will run `defang cd down` on itself at %s (ttl %s); redeploying extends it",
 		fireAt.UTC().Format(time.RFC3339), ttl), nil)
 
-	job, err := app.NewJob(pctx, selfDestructJobName, args,
+	job, err := app.NewJob(pctx, selfDestructName, args,
 		append(opts, pulumi.DependsOn([]pulumi.Resource{dep}))...)
 	if err != nil {
 		return err
@@ -146,7 +152,8 @@ func azureSelfDestructJobArgs(cdJob armappcontainers.Job, environ []string, fire
 	}
 
 	args := &app.JobArgs{
-		JobName:           pulumi.String(selfDestructJobName),
+		// No JobName: Pulumi auto-names it, keeping it unique within the shared
+		// defang-cd managed environment. See selfDestructName above.
 		ResourceGroupName: pulumi.String(resourceGroup),
 		Location:          pulumi.String(*cdJob.Location), // must match the CD environment's region
 		EnvironmentId:     pulumi.String(*cdJob.Properties.EnvironmentID),
@@ -170,7 +177,7 @@ func azureSelfDestructJobArgs(cdJob armappcontainers.Job, environ []string, fire
 		Template: app.JobTemplateArgs{
 			Containers: app.ContainerArray{
 				app.ContainerArgs{
-					Name:    pulumi.String(selfDestructJobName),
+					Name:    pulumi.String(selfDestructName),
 					Image:   pulumi.String(image),
 					Command: pulumi.ToStringArray([]string{"/app/cd"}),
 					Args:    pulumi.ToStringArray([]string{"trigger-down"}),

--- a/cd/program/selfdestruct_azure_test.go
+++ b/cd/program/selfdestruct_azure_test.go
@@ -41,8 +41,8 @@ func TestAzureSelfDestructJobArgs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if args.JobName != pulumi.String(selfDestructJobName) {
-		t.Errorf("JobName = %v", args.JobName)
+	if args.JobName != nil {
+		t.Errorf("JobName must stay unset so Pulumi auto-names the job (a fixed name collides in the shared defang-cd environment), got %v", args.JobName)
 	}
 	if args.ResourceGroupName != pulumi.String("Defang-myproj-preview-rg") {
 		t.Errorf("ResourceGroupName = %v", args.ResourceGroupName)

--- a/provider/defangazure/azure/containerapp.go
+++ b/provider/defangazure/azure/containerapp.go
@@ -18,6 +18,11 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
+// maxProbeInitialDelaySeconds is Azure Container Apps' hard ceiling for a probe's
+// InitialDelaySeconds; exceeding it fails the deploy with HTTP 400
+// ContainerAppProbeInitialDelaySecondsOutOfRange.
+const maxProbeInitialDelaySeconds = 60
+
 // postgresURLEndpoint checks whether v is a postgres(ql):// URL whose host matches a managed
 // service in serviceEndpoints. If so it returns a new URL with:
 //   - the hostname replaced by the managed service FQDN
@@ -272,7 +277,7 @@ func CreateContainerApp(
 		// readLiveCustomDomains.
 		ingress.CustomDomains = readLiveCustomDomains(ctx, infra, serviceName)
 	}
-	probes := buildProbes(svc)
+	probes := buildProbes(ctx, serviceName, svc)
 
 	var registries app.RegistryCredentialsArray
 	// Collect user-assigned identities the app needs: one for ACR pull (when
@@ -526,7 +531,7 @@ func buildIngress(svc compose.ServiceConfig, networks compose.Networks) *app.Ing
 // `/`, which 404s for many services (Hasura is the canonical case) and puts
 // the container into a crash-loop. A TCP probe just checks the listener is
 // up, which is correct default behavior regardless of HTTP semantics.
-func buildProbes(svc compose.ServiceConfig) app.ContainerAppProbeArray {
+func buildProbes(ctx *pulumi.Context, serviceName string, svc compose.ServiceConfig) app.ContainerAppProbeArray {
 	if len(svc.Ports) == 0 {
 		return nil
 	}
@@ -568,7 +573,21 @@ func buildProbes(svc compose.ServiceConfig) app.ContainerAppProbeArray {
 		probe.FailureThreshold = pulumi.Int(svc.HealthCheck.Retries)
 	}
 	if svc.HealthCheck.StartPeriodSeconds != 0 {
-		probe.InitialDelaySeconds = pulumi.Int(svc.HealthCheck.StartPeriodSeconds)
+		// Azure rejects anything above maxProbeInitialDelaySeconds with a 400
+		// (ContainerAppProbeInitialDelaySecondsOutOfRange), which fails the whole
+		// deploy. ECS allows far longer start periods, so a compose that is
+		// perfectly valid on AWS would otherwise be undeployable here. Clamp and
+		// warn instead: FailureThreshold * PeriodSeconds still governs how long a
+		// slow-starting container gets before it is declared unhealthy.
+		delay := svc.HealthCheck.StartPeriodSeconds
+		if delay > maxProbeInitialDelaySeconds {
+			ctx.Log.Warn(fmt.Sprintf(
+				"service %q: start_period %ds exceeds the Azure maximum of %ds; clamping. "+
+					"Increase healthcheck retries if the container needs longer to start.",
+				serviceName, delay, maxProbeInitialDelaySeconds), nil)
+			delay = maxProbeInitialDelaySeconds
+		}
+		probe.InitialDelaySeconds = pulumi.Int(delay)
 	}
 	return app.ContainerAppProbeArray{probe}
 }

--- a/provider/defangazure/azure/containerapp.go
+++ b/provider/defangazure/azure/containerapp.go
@@ -21,7 +21,15 @@ import (
 // maxProbeInitialDelaySeconds is Azure Container Apps' hard ceiling for a probe's
 // InitialDelaySeconds; exceeding it fails the deploy with HTTP 400
 // ContainerAppProbeInitialDelaySecondsOutOfRange.
-const maxProbeInitialDelaySeconds = 60
+const (
+	maxProbeInitialDelaySeconds = 60
+	// maxProbeFailureThreshold is Azure's ceiling for FailureThreshold, which bounds
+	// how much of a clamped start_period can be recovered into the retry window.
+	maxProbeFailureThreshold = 10
+	// Azure's own defaults, used when the compose file leaves them unset.
+	defaultProbePeriodSeconds    = 10
+	defaultProbeFailureThreshold = 3
+)
 
 // postgresURLEndpoint checks whether v is a postgres(ql):// URL whose host matches a managed
 // service in serviceEndpoints. If so it returns a new URL with:
@@ -576,15 +584,44 @@ func buildProbes(ctx *pulumi.Context, serviceName string, svc compose.ServiceCon
 		// Azure rejects anything above maxProbeInitialDelaySeconds with a 400
 		// (ContainerAppProbeInitialDelaySecondsOutOfRange), which fails the whole
 		// deploy. ECS allows far longer start periods, so a compose that is
-		// perfectly valid on AWS would otherwise be undeployable here. Clamp and
-		// warn instead: FailureThreshold * PeriodSeconds still governs how long a
-		// slow-starting container gets before it is declared unhealthy.
+		// perfectly valid on AWS would otherwise be undeployable here.
+		//
+		// Clamping alone would silently shorten the grace a slow-starting container
+		// gets, turning a deploy-time error into a restart loop. What the author
+		// actually asked for is a total startup budget: start_period grace plus
+		// retries * interval before the container is declared unhealthy. So move the
+		// clamped-off seconds into the retry window and keep that budget intact.
 		delay := svc.HealthCheck.StartPeriodSeconds
 		if delay > maxProbeInitialDelaySeconds {
-			ctx.Log.Warn(fmt.Sprintf(
-				"service %q: start_period %ds exceeds the Azure maximum of %ds; clamping. "+
-					"Increase healthcheck retries if the container needs longer to start.",
-				serviceName, delay, maxProbeInitialDelaySeconds), nil)
+			period := svc.HealthCheck.IntervalSeconds
+			if period <= 0 {
+				period = defaultProbePeriodSeconds
+			}
+			threshold := svc.HealthCheck.Retries
+			if threshold <= 0 {
+				threshold = defaultProbeFailureThreshold
+			}
+			// Round up: the budget may only grow, never shrink.
+			lost := delay - maxProbeInitialDelaySeconds
+			want := threshold + (lost+period-1)/period
+			if want > maxProbeFailureThreshold {
+				want = maxProbeFailureThreshold
+			}
+			budget := maxProbeInitialDelaySeconds + want*period
+			if budget < delay+threshold*period {
+				_ = ctx.Log.Warn(fmt.Sprintf(
+					"service %q: start_period %ds exceeds the Azure maximum of %ds. Clamped and raised "+
+						"healthcheck retries to %d, but that only reaches %ds of startup budget instead of "+
+						"the %ds requested; raise the healthcheck interval if the container needs longer.",
+					serviceName, delay, maxProbeInitialDelaySeconds, want, budget,
+					delay+threshold*period), nil)
+			} else {
+				_ = ctx.Log.Info(fmt.Sprintf(
+					"service %q: start_period %ds exceeds the Azure maximum of %ds; clamped and raised "+
+						"healthcheck retries from %d to %d, preserving %ds of startup budget.",
+					serviceName, delay, maxProbeInitialDelaySeconds, threshold, want, budget), nil)
+			}
+			probe.FailureThreshold = pulumi.Int(want)
 			delay = maxProbeInitialDelaySeconds
 		}
 		probe.InitialDelaySeconds = pulumi.Int(delay)

--- a/provider/defangazure/azure/containerapp_test.go
+++ b/provider/defangazure/azure/containerapp_test.go
@@ -122,16 +122,39 @@ func TestBuildEnvVarsInjectsDefangServiceEnv(t *testing.T) {
 // TestBuildProbesClampsInitialDelay covers the Azure ceiling on a probe's
 // InitialDelaySeconds. A compose file that is valid on ECS (start_period well over a
 // minute) used to fail the whole deploy with HTTP 400
-// ContainerAppProbeInitialDelaySecondsOutOfRange; it is now clamped instead.
+// ContainerAppProbeInitialDelaySecondsOutOfRange. It is now clamped, and the seconds
+// removed from the delay are moved into the retry window so the container keeps the
+// startup budget its author asked for.
 func TestBuildProbesClampsInitialDelay(t *testing.T) {
 	for _, tt := range []struct {
-		name        string
-		startPeriod int32
-		want        int
+		name                           string
+		startPeriod, interval, retries int32
+		wantDelay, wantThreshold       int
+		wantThresholdSet               bool
 	}{
-		{"over the ceiling is clamped", 240, maxProbeInitialDelaySeconds},
-		{"exactly at the ceiling is kept", 60, 60},
-		{"under the ceiling is kept", 15, 15},
+		{
+			name:        "under the ceiling is left alone",
+			startPeriod: 15, interval: 30, retries: 5,
+			wantDelay: 15, wantThreshold: 5, wantThresholdSet: true,
+		},
+		{
+			name:        "exactly at the ceiling is left alone",
+			startPeriod: 60, interval: 30, retries: 5,
+			wantDelay: 60, wantThreshold: 5, wantThresholdSet: true,
+		},
+		{
+			// 240 + 5*30 = 390s requested; 60 + 11*30 would be needed, so the
+			// threshold rises by ceil(180/30) = 6, from 5 to 11 -> capped at 10.
+			name:        "over the ceiling moves the lost grace into retries",
+			startPeriod: 240, interval: 30, retries: 5,
+			wantDelay: 60, wantThreshold: 10, wantThresholdSet: true,
+		},
+		{
+			// 120 + 2*60 = 240s requested; losing 60s needs ceil(60/60) = 1 more retry.
+			name:        "raises the threshold just enough",
+			startPeriod: 120, interval: 60, retries: 2,
+			wantDelay: 60, wantThreshold: 3, wantThresholdSet: true,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			err := pulumi.RunErr(func(ctx *pulumi.Context) error {
@@ -140,13 +163,19 @@ func TestBuildProbesClampsInitialDelay(t *testing.T) {
 					HealthCheck: &compose.HealthCheckConfig{
 						Test:               []string{"CMD", "curl", "-f", "http://localhost:5050/"},
 						StartPeriodSeconds: tt.startPeriod,
+						IntervalSeconds:    tt.interval,
+						Retries:            tt.retries,
 					},
 				}
 				probes := buildProbes(ctx, "app", svc)
 				require.Len(t, probes, 1)
 				args, ok := probes[0].(app.ContainerAppProbeArgs)
 				require.True(t, ok)
-				assert.Equal(t, pulumi.Int(tt.want), args.InitialDelaySeconds)
+				assert.Equal(t, pulumi.Int(tt.wantDelay), args.InitialDelaySeconds)
+				assert.LessOrEqual(t, tt.wantDelay, maxProbeInitialDelaySeconds)
+				if tt.wantThresholdSet {
+					assert.Equal(t, pulumi.Int(tt.wantThreshold), args.FailureThreshold)
+				}
 				return nil
 			}, pulumi.WithMocks("project", "stack", azureNoopMocks{}))
 			require.NoError(t, err)

--- a/provider/defangazure/azure/containerapp_test.go
+++ b/provider/defangazure/azure/containerapp_test.go
@@ -118,3 +118,38 @@ func TestBuildEnvVarsInjectsDefangServiceEnv(t *testing.T) {
 	}, pulumi.WithMocks("proj", "stack", azureNoopMocks{}))
 	require.NoError(t, err)
 }
+
+// TestBuildProbesClampsInitialDelay covers the Azure ceiling on a probe's
+// InitialDelaySeconds. A compose file that is valid on ECS (start_period well over a
+// minute) used to fail the whole deploy with HTTP 400
+// ContainerAppProbeInitialDelaySecondsOutOfRange; it is now clamped instead.
+func TestBuildProbesClampsInitialDelay(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		startPeriod int32
+		want        int
+	}{
+		{"over the ceiling is clamped", 240, maxProbeInitialDelaySeconds},
+		{"exactly at the ceiling is kept", 60, 60},
+		{"under the ceiling is kept", 15, 15},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+				svc := compose.ServiceConfig{
+					Ports: []compose.ServicePortConfig{{Target: 5050}},
+					HealthCheck: &compose.HealthCheckConfig{
+						Test:               []string{"CMD", "curl", "-f", "http://localhost:5050/"},
+						StartPeriodSeconds: tt.startPeriod,
+					},
+				}
+				probes := buildProbes(ctx, "app", svc)
+				require.Len(t, probes, 1)
+				args, ok := probes[0].(app.ContainerAppProbeArgs)
+				require.True(t, ok)
+				assert.Equal(t, pulumi.Int(tt.want), args.InitialDelaySeconds)
+				return nil
+			}, pulumi.WithMocks("project", "stack", azureNoopMocks{}))
+			require.NoError(t, err)
+		})
+	}
+}

--- a/provider/defangazure/project.go
+++ b/provider/defangazure/project.go
@@ -592,10 +592,23 @@ func (*Project) Construct(
 	return comp, nil
 }
 
-// llmModelAlias finds the model alias for an LLM service by scanning dependent services'
-// environments. The CLI injects {UPPER(svcName)}_MODEL into every service that depends on
-// the LLM service. Returns the alias (e.g. "chat-default") or svcName as a fallback.
+// llmModelAlias finds the model alias for an LLM service, which becomes the name of
+// the Azure AI Foundry deployment. Dependent services send that name as the "model"
+// field, so getting it wrong yields DeploymentNotFound at runtime after a green deploy.
+//
+// The CLI writes the alias into the LLM service's own command ("--alias <alias>"), which
+// is authoritative: it is present whatever the dependents look like. Only if that is
+// missing do we fall back to scanning dependents for {UPPER(svcName)}_MODEL — the env
+// var the CLI injects by default. That scan alone is not enough, because compose lets a
+// dependent rename the variable (`models: {<svc>: {model_var: MODEL}}`), in which case
+// the lookup silently missed and we deployed under svcName while the CLI told the app to
+// ask for the alias.
 func llmModelAlias(svcName string, services compose.Services) string {
+	if svc, ok := services[svcName]; ok {
+		if alias := aliasFromCommand(svc.Command); alias != "" {
+			return alias
+		}
+	}
 	envKey := strings.ToUpper(svcName) + "_MODEL"
 	for _, svc := range services {
 		if sv, _ := compose.StaticEnvValue(svc.Environment[envKey]); sv != nil && *sv != "" {
@@ -603,6 +616,17 @@ func llmModelAlias(svcName string, services compose.Services) string {
 		}
 	}
 	return svcName // fallback: use service name as deployment name
+}
+
+// aliasFromCommand returns the value following "--alias" in the LiteLLM command the CLI
+// generates, or "" when absent.
+func aliasFromCommand(command []string) string {
+	for i, arg := range command {
+		if arg == "--alias" && i+1 < len(command) {
+			return command[i+1]
+		}
+	}
+	return ""
 }
 
 // fqdnToHTTPS converts a Container App FQDN to an https:// URL, or returns "" for empty FQDNs.

--- a/provider/defangazure/project_test.go
+++ b/provider/defangazure/project_test.go
@@ -31,10 +31,13 @@ func TestLlmModelAlias(t *testing.T) {
 			want: "chat-default",
 		},
 		{
-			name: "alias comes from the command with the default env var too",
+			// Precedence: the command must win over the env var. The two carry
+			// different values here on purpose — identical ones would pass whichever
+			// source were consulted and prove nothing.
+			name: "the command wins over a conflicting env var",
 			services: compose.Services{
 				"llm": {Command: litellmCmd, LLM: &compose.LlmConfig{}},
-				"app": {Environment: compose.Environment{"LLM_MODEL": pulumi.String("chat-default")}},
+				"app": {Environment: compose.Environment{"LLM_MODEL": pulumi.String("stale-env-alias")}},
 			},
 			want: "chat-default",
 		},

--- a/provider/defangazure/project_test.go
+++ b/provider/defangazure/project_test.go
@@ -1,0 +1,65 @@
+package defangazure
+
+import (
+	"testing"
+
+	"github.com/DefangLabs/pulumi-defang/provider/compose"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// TestLlmModelAlias covers how the Azure AI Foundry deployment gets its name.
+// Dependent services send that name as the "model" field, so a wrong answer here
+// surfaces as DeploymentNotFound at runtime, after a deploy that looked green.
+func TestLlmModelAlias(t *testing.T) {
+	litellmCmd := []string{"--drop_params", "--model", "chat-default", "--alias", "chat-default"}
+
+	for _, tt := range []struct {
+		name     string
+		services compose.Services
+		want     string
+	}{
+		{
+			// The regression: compose lets a dependent rename the injected variable
+			// (models: {llm: {model_var: MODEL}}). The old env-var scan looked only for
+			// LLM_MODEL, missed it, and silently deployed under the service name while
+			// the CLI told the app to ask for "chat-default".
+			name: "alias comes from the command even when model_var is renamed",
+			services: compose.Services{
+				"llm": {Command: litellmCmd, LLM: &compose.LlmConfig{}},
+				"app": {Environment: compose.Environment{"MODEL": pulumi.String("chat-default")}},
+			},
+			want: "chat-default",
+		},
+		{
+			name: "alias comes from the command with the default env var too",
+			services: compose.Services{
+				"llm": {Command: litellmCmd, LLM: &compose.LlmConfig{}},
+				"app": {Environment: compose.Environment{"LLM_MODEL": pulumi.String("chat-default")}},
+			},
+			want: "chat-default",
+		},
+		{
+			// Older CLIs emit no --alias; the env-var scan is still the fallback.
+			name: "falls back to the injected env var when the command has no alias",
+			services: compose.Services{
+				"llm": {LLM: &compose.LlmConfig{}},
+				"app": {Environment: compose.Environment{"LLM_MODEL": pulumi.String("chat-default")}},
+			},
+			want: "chat-default",
+		},
+		{
+			name: "falls back to the service name when nothing else is available",
+			services: compose.Services{
+				"llm": {LLM: &compose.LlmConfig{}},
+				"app": {},
+			},
+			want: "llm",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := llmModelAlias("llm", tt.services); got != tt.want {
+				t.Errorf("llmModelAlias() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Three independent Azure bugs, all found by deploying a real application (`DefangLabs/docs-chatbot`) to a preview stack rather than by reading code. Each one fails *after* a green-looking deploy, and none is currently covered by a test.

## 1. `start_period` over 60s fails the whole deploy

```
Status=400 Code="ContainerAppProbeInitialDelaySecondsOutOfRange"
Message="Container 'app' 'Type' probe's InitialDelaySeconds must be in the range of ['0', '60']."
```

`buildProbes` assigned `StartPeriodSeconds` straight to `InitialDelaySeconds` with no bound. ECS allows far longer start periods, so a compose file that is valid on AWS is simply undeployable on Azure — and the error names an ARM field the user never wrote.

Now clamped to 60 with a warning that points at `retries`, since `FailureThreshold * PeriodSeconds` is what actually governs how long a slow-starting container gets.

## 2. A renamed `model_var` breaks model routing

`llmModelAlias` recovered the alias by scanning dependents for `{UPPER(svc)}_MODEL`. But compose lets a dependent rename that variable:

```yaml
models:
  llm:
    endpoint_var: OPENAI_BASE_URL
    model_var: MODEL          # <- no LLM_MODEL anywhere
```

The scan then finds nothing and falls back to the service name, so the deployment is created as `llm` while the CLI tells the app to ask for `chat-default`. Confirmed against the live endpoint:

| `model` sent | result |
|---|---|
| `chat-default` | `DeploymentNotFound` |
| `llm` | answers |

The alias is already carried unambiguously in the LLM service's own command (`--alias <alias>`, written by the CLI), which is present regardless of what dependents look like. That is now the primary source; the env-var scan stays as a fallback for older CLIs, then the service name.

## 3. The self-destruct job's fixed name collides across projects

```
Status=409 Code="ContainerAppsJobNameConflictInCluster"
Message="Cannot create container apps job 'defang-self-destruct' because the
environment 'defang-cd' already has a resource with this name"
```

`JobArgs.JobName` pinned the physical name to `defang-self-destruct`. The comment justified it as "unique within the project resource group" — but Container Apps requires job names to be unique within the **managed environment**, and every project's trigger job is created in the *shared* `defang-cd` environment. Subscription-wide there was exactly one:

```
defang-self-destruct    Defang-portal-dev
```

So the first project to use a TTL claimed the name and every later one failed its entire deploy. That makes `--ttl` unusable for preview environments, which is the case it exists to serve.

Dropping the explicit `JobName` lets Pulumi auto-name it: unique per stack, still stable across redeploys of the same stack, so a redeploy keeps updating the trigger in place and extending the stack's life. No aliases needed — the resource is a scheduled trigger, and an existing deployment simply keeps what it has.

## Tests

- `TestBuildProbesClampsInitialDelay` — over / exactly at / under the ceiling
- `TestLlmModelAlias` — renamed `model_var`, default env var, no-`--alias` fallback, and the service-name fallback
- the existing self-destruct test now asserts `JobName` stays **unset**, which is the property that prevents the collision from coming back

`go test ./provider/...` and `./cd/...` both pass.

## Not fixed here

Deployments are created with `Capacity: pulumi.Int(1)` (1K TPM / 10 RPM), hardcoded in `llm.go`. A single RAG request with retrieved context exceeds that, so the app 429s on every real query; I raised it by hand to 50 to finish verifying. Worth its own change — it needs a decision about the default and whether it should be configurable, so I left it out rather than guess.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Azure Container Apps now cap probe startup delays at 60 seconds and adjust retry thresholds to preserve startup grace periods where possible.
  * LLM deployments resolve model aliases from command-line settings, dependent-service environment variables, or the service name.
  * Self-destruct jobs receive unique Azure names while preserving stable logical and container names across redeployments.

* **Tests**
  * Added coverage for probe configuration, LLM alias resolution, and Azure self-destruct job naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->