### PR TITLE
refactor(aws): drop the single-use autonamingPattern constant

### DIFF
--- a/cd/config.go
+++ b/cd/config.go
@@ -76,9 +76,6 @@ func unmarshalRecipe(recipePulumiConfig string, config configMap) error {
 // lowercased) is prepended where one is still wanted.
 const defaultAutonamingSuffix = "${project}-${stack}-${name}-${hex(7)}"
 
-// autonamingPattern is the key of a per-resource autonaming rule.
-const autonamingPattern = "pattern"
-
 func setDefaultStackConfig(prefix string, config configMap) {
 	// defang:prefix holds the bare prefix (e.g. "Defang"); its consumers
 	// (common.Prefix, e.g. ProjectResourceGroupName) append their own "-"
@@ -90,7 +87,7 @@ func setDefaultStackConfig(prefix string, config configMap) {
 	}
 	lowerPrefix := strings.ToLower(prefix)
 	// Types that reject an uppercase physical name all share this pattern.
-	lowercased := map[string]string{autonamingPattern: lowerPrefix + defaultAutonamingSuffix}
+	lowercased := map[string]string{"pattern": lowerPrefix + defaultAutonamingSuffix}
 	config["pulumi:autonaming"] = configValue{Value: map[string]any{
 		"pattern": prefix + defaultAutonamingSuffix,
 		"providers": map[string]any{


### PR DESCRIPTION
## Summary
- Follow-up to #534. Lionello's [post-merge review comment](https://github.com/DefangLabs/pulumi-defang/pull/534#discussion_r0) flagged the `autonamingPattern` constant as over-engineered: it wraps the string `"pattern"` for a single use, while every other entry in the same map literal (the `aws:lb/...`, `aws:ecs/...` overrides right above it) spells the key out directly.
- Drops the constant and uses the literal `"pattern"` instead, matching the surrounding code.

## Test plan
- [x] `go build ./...` in `cd/`
- [x] `go test ./...` in `cd/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal configuration handling for lowercase automatic naming without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->