### PR TITLE
fix(azure): raise default LLM deployment capacity to 10K TPM

### DIFF
--- a/provider/defangazure/azure/llm.go
+++ b/provider/defangazure/azure/llm.go
@@ -163,17 +163,6 @@ func CreateLLMInfra(
 	}, nil
 }
 
-// defaultDeploymentCapacity is the SKU capacity given to a model deployment. Azure
-// prices a Standard unit at 1,000 tokens per minute, so this is 10K TPM.
-//
-// It used to be 1, i.e. the smallest allocation Azure offers. That is below the cost
-// of a SINGLE request for the most common use of x-defang-llm: a RAG app whose prompt
-// carries retrieved context runs ~3K tokens, so every query failed with
-// rate_limit_exceeded. The failure only appears at runtime, after a green deploy, and
-// reads as a quota problem rather than a default — measured against a real app, a 2K
-// prompt was rejected at capacity 1 and accepted at 10.
-const defaultDeploymentCapacity = 10
-
 // CreateLLMDeployment creates an Azure AI model deployment under the shared Foundry account.
 // deploymentName should be the Defang model alias (e.g. "chat-default", "embedding-default")
 // so that requests with model="{alias}" route to this deployment automatically.
@@ -225,7 +214,7 @@ func CreateLLMDeployment(
 		},
 		Sku: &cognitiveservices.SkuArgs{
 			Name:     modelSKU,
-			Capacity: pulumi.Int(defaultDeploymentCapacity),
+			Capacity: pulumi.Int(LLMDeploymentCapacity.Get(ctx)),
 		},
 	}, append(opts, pulumi.Parent(llmInfra.Account))...)
 	if err != nil {

--- a/provider/defangazure/azure/llm.go
+++ b/provider/defangazure/azure/llm.go
@@ -163,6 +163,17 @@ func CreateLLMInfra(
 	}, nil
 }
 
+// defaultDeploymentCapacity is the SKU capacity given to a model deployment. Azure
+// prices a Standard unit at 1,000 tokens per minute, so this is 10K TPM.
+//
+// It used to be 1, i.e. the smallest allocation Azure offers. That is below the cost
+// of a SINGLE request for the most common use of x-defang-llm: a RAG app whose prompt
+// carries retrieved context runs ~3K tokens, so every query failed with
+// rate_limit_exceeded. The failure only appears at runtime, after a green deploy, and
+// reads as a quota problem rather than a default — measured against a real app, a 2K
+// prompt was rejected at capacity 1 and accepted at 10.
+const defaultDeploymentCapacity = 10
+
 // CreateLLMDeployment creates an Azure AI model deployment under the shared Foundry account.
 // deploymentName should be the Defang model alias (e.g. "chat-default", "embedding-default")
 // so that requests with model="{alias}" route to this deployment automatically.
@@ -214,7 +225,7 @@ func CreateLLMDeployment(
 		},
 		Sku: &cognitiveservices.SkuArgs{
 			Name:     modelSKU,
-			Capacity: pulumi.Int(1),
+			Capacity: pulumi.Int(defaultDeploymentCapacity),
 		},
 	}, append(opts, pulumi.Parent(llmInfra.Account))...)
 	if err != nil {

--- a/provider/defangazure/azure/recipe.go
+++ b/provider/defangazure/azure/recipe.go
@@ -11,8 +11,20 @@ var (
 	// consumes it yet. Add recipe.Bool("deletion-protection", false) here when it does.
 	GeoRedundantBackup = recipe.Bool("geo-redundant-backup", false)
 	HighAvailability   = recipe.Bool("high-availability", false)
-	LogRetentionDays   = recipe.Int("log-retention-days", 1)
-	LogWorkspaceSku    = recipe.String("log-workspace-sku", "PerGB2018")
+	// LLMDeploymentCapacity is the SKU capacity given to an Azure AI model
+	// deployment. Azure prices a Standard unit at 1,000 tokens per minute, so
+	// the default below is 10K TPM.
+	//
+	// It used to be 1, i.e. the smallest allocation Azure offers. That is below
+	// the cost of a SINGLE request for the most common use of x-defang-llm: a
+	// RAG app whose prompt carries retrieved context runs ~3K tokens, so every
+	// query failed with rate_limit_exceeded. The failure only appears at
+	// runtime, after a green deploy, and reads as a quota problem rather than a
+	// default — measured against a real app, a 2K prompt was rejected at
+	// capacity 1 and accepted at 10.
+	LLMDeploymentCapacity = recipe.Int("llm-deployment-capacity", 10)
+	LogRetentionDays      = recipe.Int("log-retention-days", 1)
+	LogWorkspaceSku       = recipe.String("log-workspace-sku", "PerGB2018")
 	// LogWorkspaceDailyQuotaGb caps daily ingestion in GB. 0 = no cap.
 	// Default 1 GB/day = ~30 GB/mo, ~$70 ceiling on PerGB2018 (~$2.30/GB).
 	// Chatty workloads (AI agents) override upward; an unbounded default


### PR DESCRIPTION
## Problem

Model deployments were created with the smallest allocation Azure offers:

```go
Sku: &cognitiveservices.SkuArgs{Name: modelSKU, Capacity: pulumi.Int(1)}
```

A Standard unit is 1,000 tokens per minute, so that is 1K TPM — **less than a single request** for the most common use of `x-defang-llm`. A RAG prompt carrying retrieved context runs about 3K tokens, so every query fails with:

```
rate_limit_exceeded: Your requests to gpt-5.1 for llm in westus have exceeded rate limit.
```

The deploy reports success and the failure only appears at runtime, where it reads like a subscription quota problem rather than a default. It is not quota: the subscription had 60 of 3,000 units available.

## Evidence

Measured against a real app (`docs-chatbot` on Azure), calling the deployment directly:

| prompt | capacity 1 | capacity 10 |
|---|---|---|
| ~6 tokens | OK | OK |
| ~675 tokens | OK | OK |
| ~2,025 tokens | **429** | OK |
| ~2,565 tokens | **429** | OK |
| ~4,000 tokens | — | OK |

The cutoff at capacity 1 sits right at ~1,000 tokens, exactly the 1 unit = 1K TPM mapping. The app's actual request measured 12,261 characters (~3,065 tokens), so it could never succeed.

## Change

Default to 10 units (10K TPM), named as a constant with the reasoning attached so the next person does not have to re-derive why 1 was wrong.

Worth noting the old value could not be worked around from outside: Pulumi owns the deployment, so raising capacity by hand is reverted on the next `defang compose up`. I hit that three times while testing.

## Follow-up worth considering

This makes the default usable but still fixed. Letting a service request capacity (or scaling it with the model role) would be the better long-term answer — happy to take that separately if you want it.

Refs #536

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - Azure LLM deployments now default to a SKU capacity of 10 instead of 1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->