### PR TITLE
fix(azure): truncate Postgres image version to major version

### DIFF
--- a/provider/defangazure/azure/postgres.go
+++ b/provider/defangazure/azure/postgres.go
@@ -3,6 +3,7 @@ package azure
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
@@ -33,6 +34,23 @@ func sanitizePostgresName(name string) string {
 		s = strings.Trim(s[:50], "-")
 	}
 	return s
+}
+
+// azurePostgresMajorVersion reduces pg.Version to the bare major-version token
+// Azure's Flexible Server API expects (e.g. "18"). pg.Version carries whatever
+// the compose layer parsed out of the image tag, which keeps the minor version
+// when present (e.g. "18.6" from postgres:18.6-alpine); sent as-is, Azure
+// rejects it with a "should be in: []" error. Falls back to the input
+// unchanged if it doesn't parse as a version, matching prior behavior.
+func azurePostgresMajorVersion(v *string) *string {
+	if v == nil {
+		return nil
+	}
+	major := compose.GetPostgresVersion(*v)
+	if major == 0 {
+		return v
+	}
+	return pulumi.StringRef(strconv.Itoa(major))
 }
 
 type postgresResult struct {
@@ -93,10 +111,12 @@ func buildPostgresServerArgs(
 		return prefix + "-" + s
 	}).(pulumi.StringOutput)
 
+	version := pg.Version.ToStringPtrOutput().ApplyT(azurePostgresMajorVersion).(pulumi.StringPtrOutput)
+
 	serverArgs := &dbforpostgresql.ServerArgs{
 		ResourceGroupName: infra.ResourceGroup.Name,
 		ServerName:        serverName.ToStringPtrOutput(),
-		Version:           pg.Version,
+		Version:           version,
 		Tags:              ServiceTags(serviceName),
 		Sku: &dbforpostgresql.SkuArgs{
 			Name: pulumi.String(skuName),

--- a/provider/defangazure/azure/postgres.go
+++ b/provider/defangazure/azure/postgres.go
@@ -111,7 +111,13 @@ func buildPostgresServerArgs(
 		return prefix + "-" + s
 	}).(pulumi.StringOutput)
 
-	version := pg.Version.ToStringPtrOutput().ApplyT(azurePostgresMajorVersion).(pulumi.StringPtrOutput)
+	// pg.Version is nil when the service has no static image (e.g. built from
+	// a Dockerfile, or a dynamic image expression), so guard before calling
+	// ToStringPtrOutput on it.
+	var version pulumi.StringPtrInput
+	if pg.Version != nil {
+		version = pg.Version.ToStringPtrOutput().ApplyT(azurePostgresMajorVersion).(pulumi.StringPtrOutput)
+	}
 
 	serverArgs := &dbforpostgresql.ServerArgs{
 		ResourceGroupName: infra.ResourceGroup.Name,

--- a/provider/defangazure/azure/postgres_version_test.go
+++ b/provider/defangazure/azure/postgres_version_test.go
@@ -1,0 +1,35 @@
+package azure
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAzurePostgresMajorVersion(t *testing.T) {
+	tests := []struct {
+		name  string
+		input *string
+		want  *string
+	}{
+		{"nil", nil, nil},
+		{"minor version from image tag", pulumi.StringRef("18.6"), pulumi.StringRef("18")},
+		{"bookworm-style suffix", pulumi.StringRef("16.3-bookworm"), pulumi.StringRef("16")},
+		{"bare major version", pulumi.StringRef("17"), pulumi.StringRef("17")},
+		{"unparseable falls back unchanged", pulumi.StringRef("latest"), pulumi.StringRef("latest")},
+		{"empty falls back unchanged", pulumi.StringRef(""), pulumi.StringRef("")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := azurePostgresMajorVersion(tt.input)
+			if tt.want == nil {
+				assert.Nil(t, got)
+				return
+			}
+			if assert.NotNil(t, got) {
+				assert.Equal(t, *tt.want, *got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Every Azure `defang up` for a service using a Postgres image with a minor-version tag (e.g. `postgres:18.6-alpine`) fails with:

```
Status=400 Code="ParameterOutOfRange" Message="The value of the 'Version' should be in: []. Verify that the specified parameter value is correct."
```

Reproduced on `DefangLabs/station`'s `Defang up production` workflow (compose.yaml pins `postgres:18.6-alpine`): https://github.com/DefangLabs/station/actions/runs/34235983586

## Root cause

`getPostgresVersion()` in `provider/compose/types.go` returns the full `major.minor` string parsed from the image tag (e.g. `"18.6"`), and `provider/defangazure/azure/postgres.go` passes that straight through as the Azure Flexible Server `Version` field. Azure's ARM API only accepts a bare major-version token (`"16"`, `"17"`, `"18"`, ...) — a dotted value isn't a recognized enum member, so the API rejects it and (apparently) doesn't bother enumerating valid options for an unparseable input, hence the empty `[]` in the error.

GCP already has this exact problem solved: `provider/defanggcp/gcp/cloudsql.go` runs `pg.Version` through `compose.GetPostgresVersion()` (extracts the major version as an int) before mapping it to GCP's version enum. AWS doesn't need this because RDS's `EngineVersion` accepts dotted versions. Azure was the one provider forwarding the raw, unnormalized string.

Confirmed via Azure docs that Postgres major version 18 (GA, current minor 18.6) is itself fully supported by Flexible Server — this is purely a string-formatting bug, not a missing-version-support issue.

## Fix

Reuse the existing `compose.GetPostgresVersion()` helper (same one GCP already uses) to reduce `pg.Version` to a bare major-version string before setting it on `dbforpostgresql.ServerArgs.Version`. Falls back to the original value unchanged if it doesn't parse, preserving prior behavior for that edge case.

## Test plan

- [x] `go build ./provider/defangazure/...`
- [x] `go test ./provider/...` (all packages pass)
- [x] `cd tests && go test -short ./azure/...` (integration tests pass)
- [x] New unit test `TestAzurePostgresMajorVersion` covers: nil, `"18.6"` → `"18"`, `"16.3-bookworm"` → `"16"`, bare `"17"` → `"17"`, and unparseable/empty fallback
- [x] `golangci-lint run ./provider/defangazure/...` — no new findings (pre-existing `goconst`/`govet` findings in unrelated code untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Azure PostgreSQL Flexible Server deployments now use the major PostgreSQL version when processing version tags, including tags with minor versions or distribution suffixes.
  * Unrecognized or empty version values continue to be preserved unchanged.

* **Tests**
  * Added coverage for supported version formats, empty values, and unparseable version tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->