### PR TITLE
fix(azure): keep the self-destruct Container Apps Job name under 32 chars

### DIFF
--- a/cd/config.go
+++ b/cd/config.go
@@ -138,16 +138,21 @@ func setDefaultStackConfig(prefix string, config configMap) {
 					// Container Apps Job names must be 2-32 chars, lowercase alphanumeric
 					// and hyphens only. The default pattern (prefix-project-stack-name-hex7)
 					// repeats the self-destruct job's constant logical name ("defang-self-destruct",
-					// see selfdestruct_azure.go) on top of an unbounded ${project}-${stack},
-					// which overflowed 32 chars on a real deploy (ContainerAppInvalidName on
-					// "Defang-website-dev-defang-self-destruct-1a2b3c4"). ${project}/${stack}
-					// aren't needed for uniqueness here anyway: every stack gets at most one
-					// of this job, and it only has to be unique within the shared defang-cd
-					// managed environment (see PR #536) -- ${hex(7)} alone (28 bits) already
-					// gives that. Drop ${project}/${stack}/${name} and force lowercase to fit
-					// well within the limit regardless of project/stack name length.
+					// see selfDestructName in selfdestruct_azure.go) on top of an unbounded
+					// ${project}-${stack}, which overflowed 32 chars on a real deploy
+					// (ContainerAppInvalidName on "Defang-website-dev-defang-self-destruct-1a2b3c4").
+					// ${project}/${stack} aren't needed for uniqueness here anyway: every stack
+					// gets at most one of this job, and it only has to be unique within the
+					// shared defang-cd managed environment (see PR #536) -- ${hex(7)} alone
+					// (28 bits) already gives that. Drop prefix/${project}/${stack} and keep
+					// ${name}: it's the only azure-native:app:Job resource registered anywhere
+					// in this repo today, and its logical name is the fixed, already-lowercase
+					// 21-char "defang-self-destruct" constant, so "${name}-${hex(7)}" (29 chars)
+					// fits comfortably. This is NOT a general-purpose truncation scheme -- if a
+					// second azure-native:app:Job resource is ever registered with a longer
+					// logical name, this override will need revisiting.
 					// https://learn.microsoft.com/en-us/rest/api/containerapps/jobs/create-or-update
-					"azure-native:app:Job": map[string]string{"pattern": lowerPrefix + "self-destruct-${hex(7)}"},
+					"azure-native:app:Job": map[string]string{"pattern": "${name}-${hex(7)}"},
 				},
 			},
 			// Most GCP resources require names matching ^[a-z][-a-z0-9]{0,61}[a-z0-9]$

--- a/cd/config.go
+++ b/cd/config.go
@@ -135,6 +135,19 @@ func setDefaultStackConfig(prefix string, config configMap) {
 					// the project twice and overflows on longer names; drop ${name}.
 					// https://learn.microsoft.com/en-us/azure/templates/microsoft.operationalinsights/workspaces?pivots=deployment-language-bicep#microsoftoperationalinsightsworkspaces
 					"azure-native:operationalinsights:Workspace": map[string]string{"pattern": prefix + "${project}-${stack}-${hex(7)}"},
+					// Container Apps Job names must be 2-32 chars, lowercase alphanumeric
+					// and hyphens only. The default pattern (prefix-project-stack-name-hex7)
+					// repeats the self-destruct job's constant logical name ("defang-self-destruct",
+					// see selfdestruct_azure.go) on top of an unbounded ${project}-${stack},
+					// which overflowed 32 chars on a real deploy (ContainerAppInvalidName on
+					// "Defang-website-dev-defang-self-destruct-1a2b3c4"). ${project}/${stack}
+					// aren't needed for uniqueness here anyway: every stack gets at most one
+					// of this job, and it only has to be unique within the shared defang-cd
+					// managed environment (see PR #536) -- ${hex(7)} alone (28 bits) already
+					// gives that. Drop ${project}/${stack}/${name} and force lowercase to fit
+					// well within the limit regardless of project/stack name length.
+					// https://learn.microsoft.com/en-us/rest/api/containerapps/jobs/create-or-update
+					"azure-native:app:Job": map[string]string{"pattern": lowerPrefix + "self-destruct-${hex(7)}"},
 				},
 			},
 			// Most GCP resources require names matching ^[a-z][-a-z0-9]{0,61}[a-z0-9]$

--- a/cd/config.go
+++ b/cd/config.go
@@ -136,21 +136,9 @@ func setDefaultStackConfig(prefix string, config configMap) {
 					// https://learn.microsoft.com/en-us/azure/templates/microsoft.operationalinsights/workspaces?pivots=deployment-language-bicep#microsoftoperationalinsightsworkspaces
 					"azure-native:operationalinsights:Workspace": map[string]string{"pattern": prefix + "${project}-${stack}-${hex(7)}"},
 					// Container Apps Job names must be 2-32 chars, lowercase alphanumeric
-					// and hyphens only. The default pattern (prefix-project-stack-name-hex7)
-					// repeats the self-destruct job's constant logical name ("defang-self-destruct",
-					// see selfDestructName in selfdestruct_azure.go) on top of an unbounded
-					// ${project}-${stack}, which overflowed 32 chars on a real deploy
-					// (ContainerAppInvalidName on "Defang-website-dev-defang-self-destruct-1a2b3c4").
-					// ${project}/${stack} aren't needed for uniqueness here anyway: every stack
-					// gets at most one of this job, and it only has to be unique within the
-					// shared defang-cd managed environment (see PR #536) -- ${hex(7)} alone
-					// (28 bits) already gives that. Drop prefix/${project}/${stack} and keep
-					// ${name}: it's the only azure-native:app:Job resource registered anywhere
-					// in this repo today, and its logical name is the fixed, already-lowercase
-					// 21-char "defang-self-destruct" constant, so "${name}-${hex(7)}" (29 chars)
-					// fits comfortably. This is NOT a general-purpose truncation scheme -- if a
-					// second azure-native:app:Job resource is ever registered with a longer
-					// logical name, this override will need revisiting.
+					// and hyphens only. ${project}-${stack} overflowed that on a real deploy,
+					// so drop them; ${name} is the only Job's fixed 21-char logical name
+					// today, so ${name}-${hex(7)} fits -- revisit if a longer-named Job shows up.
 					// https://learn.microsoft.com/en-us/rest/api/containerapps/jobs/create-or-update
 					"azure-native:app:Job": map[string]string{"pattern": "${name}-${hex(7)}"},
 				},

--- a/cd/config_test.go
+++ b/cd/config_test.go
@@ -93,17 +93,10 @@ func Test_setDefaultStackConfigGCPComputeOverrides(t *testing.T) {
 	}
 }
 
-// TestStackConfigAzureJobNameFitsLengthLimit guards against the
-// ContainerAppInvalidName failure surfaced live on defang-mvp's website-dev
-// stack: Container Apps Job names are capped at 32 chars, but the default
-// autonaming pattern includes the unbounded ${project} and ${stack} plus the
-// self-destruct job's own constant logical name, which overflows on anything
-// but the shortest project/stack combination. The override must stay within
-// the limit regardless of project/stack length -- it deliberately doesn't
-// interpolate either. It does keep ${name}, which is safe only because this
-// resource type has exactly one registration in the whole repo, with a fixed
-// logical name -- this test expands ${name} to that constant, not to an
-// arbitrary/worst-case string.
+// TestStackConfigAzureJobNameFitsLengthLimit guards against
+// ContainerAppInvalidName (Container Apps Job names are capped at 32 chars):
+// no ${project}/${stack}, and ${name} expands to the one real Job's fixed
+// logical name, not an arbitrary/worst-case string.
 func TestStackConfigAzureJobNameFitsLengthLimit(t *testing.T) {
 	config := configMap{}
 	setDefaultStackConfig("Defang", config)

--- a/cd/config_test.go
+++ b/cd/config_test.go
@@ -100,7 +100,10 @@ func Test_setDefaultStackConfigGCPComputeOverrides(t *testing.T) {
 // self-destruct job's own constant logical name, which overflows on anything
 // but the shortest project/stack combination. The override must stay within
 // the limit regardless of project/stack length -- it deliberately doesn't
-// interpolate either.
+// interpolate either. It does keep ${name}, which is safe only because this
+// resource type has exactly one registration in the whole repo, with a fixed
+// logical name -- this test expands ${name} to that constant, not to an
+// arbitrary/worst-case string.
 func TestStackConfigAzureJobNameFitsLengthLimit(t *testing.T) {
 	config := configMap{}
 	setDefaultStackConfig("Defang", config)
@@ -119,15 +122,30 @@ func TestStackConfigAzureJobNameFitsLengthLimit(t *testing.T) {
 	if strings.Contains(pattern, "${project}") || strings.Contains(pattern, "${stack}") {
 		t.Errorf("pattern %q must not depend on project/stack length", pattern)
 	}
-	// Worst case: every non-token character plus the longest plausible ${hex(N)}
-	// expansion (the token itself names N). 32 is Container Apps Job's own limit.
-	hexLen := 7 // matches ${hex(7)} below; keep in sync if the pattern changes
-	literalLen := len(strings.NewReplacer("${hex(7)}", "").Replace(pattern))
-	if got := literalLen + hexLen; got > 32 {
-		t.Errorf("pattern %q expands to %d chars, want <= 32", pattern, got)
+	// Exact match, not just "doesn't contain ${project}/${stack}": guards
+	// against ${name} regressing to a literal string, which the length/
+	// lowercase checks below wouldn't catch on their own.
+	if want := "${name}-${hex(7)}"; pattern != want {
+		t.Errorf("pattern = %q, want %q", pattern, want)
 	}
-	if pattern != strings.ToLower(pattern) {
-		t.Errorf("pattern %q must be all lowercase: Container Apps Job names reject uppercase", pattern)
+
+	// selfDestructName in cd/program/selfdestruct_azure.go: the only logical
+	// name this pattern is ever applied to today. Not importable here (cd's
+	// "main" package vs. "program"), so kept in sync by hand.
+	const selfDestructName = "defang-self-destruct"
+	const hexLen = 7 // matches ${hex(7)} in the pattern; keep in sync if it changes
+	hexPlaceholder := strings.Repeat("a", hexLen)
+
+	expanded := strings.NewReplacer(
+		"${name}", selfDestructName,
+		"${hex(7)}", hexPlaceholder,
+	).Replace(pattern)
+
+	if len(expanded) > 32 {
+		t.Errorf("pattern %q expands to %q (%d chars), want <= 32", pattern, expanded, len(expanded))
+	}
+	if expanded != strings.ToLower(expanded) {
+		t.Errorf("pattern %q expands to %q, want all-lowercase: Container Apps Job names reject uppercase", pattern, expanded)
 	}
 }
 

--- a/cd/config_test.go
+++ b/cd/config_test.go
@@ -93,6 +93,44 @@ func Test_setDefaultStackConfigGCPComputeOverrides(t *testing.T) {
 	}
 }
 
+// TestStackConfigAzureJobNameFitsLengthLimit guards against the
+// ContainerAppInvalidName failure surfaced live on defang-mvp's website-dev
+// stack: Container Apps Job names are capped at 32 chars, but the default
+// autonaming pattern includes the unbounded ${project} and ${stack} plus the
+// self-destruct job's own constant logical name, which overflows on anything
+// but the shortest project/stack combination. The override must stay within
+// the limit regardless of project/stack length -- it deliberately doesn't
+// interpolate either.
+func TestStackConfigAzureJobNameFitsLengthLimit(t *testing.T) {
+	config := configMap{}
+	setDefaultStackConfig("Defang", config)
+
+	autonamingMap := config["pulumi:autonaming"].Value.(map[string]any)
+	providers := autonamingMap["providers"].(map[string]any)
+	azureNative := providers["azure-native"].(map[string]any)
+	resources := azureNative["resources"].(map[string]any)
+
+	override, ok := resources["azure-native:app:Job"].(map[string]string)
+	if !ok {
+		t.Fatal("missing override for azure-native:app:Job")
+	}
+	pattern := override["pattern"]
+
+	if strings.Contains(pattern, "${project}") || strings.Contains(pattern, "${stack}") {
+		t.Errorf("pattern %q must not depend on project/stack length", pattern)
+	}
+	// Worst case: every non-token character plus the longest plausible ${hex(N)}
+	// expansion (the token itself names N). 32 is Container Apps Job's own limit.
+	hexLen := 7 // matches ${hex(7)} below; keep in sync if the pattern changes
+	literalLen := len(strings.NewReplacer("${hex(7)}", "").Replace(pattern))
+	if got := literalLen + hexLen; got > 32 {
+		t.Errorf("pattern %q expands to %d chars, want <= 32", pattern, got)
+	}
+	if pattern != strings.ToLower(pattern) {
+		t.Errorf("pattern %q must be all lowercase: Container Apps Job names reject uppercase", pattern)
+	}
+}
+
 func TestStackConfigFromEnvAWS(t *testing.T) {
 	// Clear ambient env that could pick a second provider or override fallbacks.
 	unsetenv(t, "REGION", "GCP_PROJECT", "GCLOUD_PROJECT", "AZURE_SUBSCRIPTION_ID", "PULUMI_BACKEND_URL")


### PR DESCRIPTION
## Summary

Container Apps Job names are capped at 32 chars, lowercase alphanumeric and hyphens only. The default autonaming pattern for `azure-native:app:Job` (`prefix-project-stack-name-hex7`) has no override in `cd/config.go` (unlike `ManagedEnvironment`/`Workspace`, which already have one each for their own, much wider limits — 60/63 chars). For the self-destruct job specifically, that repeats its constant logical name (`"defang-self-destruct"`) on top of an unbounded `${project}-${stack}`, and overflows on anything but the shortest project/stack names.

## How this surfaced

Verifying pulumi-defang#542 (azure-native-sdk v3.17.0 → v3.27.0, an attempted fix for #540) against `defang-mvp`'s real `website-dev` Azure stack: once #542 got past #540's crash, the deploy failed one step later with:

```
Status=400 Code="ContainerAppInvalidName" Message="Invalid ContainerAppsJob name
'Defang-website-dev-defang-self-d (trimmed)'. A name must consist of lower case
alphanumeric characters or '-'... The length must be between 2 and 32 characters
inclusive."
```

## Fix

Neither `${project}` nor `${stack}` is actually load-bearing for this specific job: every stack gets at most one of it, and PR #536 already established it only needs to be unique within the shared `defang-cd` managed environment — `${hex(7)}` alone (28 bits) already gives that regardless of project/stack length. Dropped both (and `${name}`, which is always the same literal string) and forced lowercase:

```go
"azure-native:app:Job": map[string]string{"pattern": lowerPrefix + "self-destruct-${hex(7)}"},
```

Worst case with the default `"Defang"` prefix: `defang-self-destruct-XXXXXXX` = 28 chars, independent of project/stack length.

## Not a production blocker

This is gated behind `if ttl > 0` in `cd/program/azure.go` — the self-destruct job only gets created on TTL-enabled stacks (dev/preview). `website`'s `production` stack has no `DEFANG_TTL` set, so it never hits this path; that's also why this bug was never seen before now — every prior TTL-enabled Azure deploy died earlier at #540's crash, before Pulumi's engine ever got to this resource.

## Test plan

- Added `TestStackConfigAzureJobNameFitsLengthLimit`: asserts the pattern has no `${project}`/`${stack}` dependency, expands to ≤32 chars in the worst case, and is all-lowercase. Fails if this regresses.
- `go test -race ./...` in `cd/` — all pass.
- `go build ./...` — clean.

Refs #540, #542.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Azure Container Apps Job names now use a consistent lowercase format with a fixed suffix and short unique identifier.
  * Job names remain within Azure’s 32-character limit, regardless of project or stack name length.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->