### PR TITLE
fix(tests): synchronize provider mock NewResource state (#544)

### DIFF
--- a/provider/defangaws/aws/legacy_aliases_test.go
+++ b/provider/defangaws/aws/legacy_aliases_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
@@ -76,6 +77,7 @@ func (noopAWSMocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error)
 // are all registered as "postgres"), so name alone can't tell them apart.
 type legacyAliasSpy struct {
 	noopAWSMocks
+	mu      sync.Mutex
 	aliases map[legacyResourceKey][]legacyAliasSpec
 }
 
@@ -90,7 +92,11 @@ type legacyAliasSpec struct {
 	noParent bool
 }
 
+// NewResource runs concurrently (one goroutine per resource registration), so
+// the map init and writes below must be synchronized.
 func (m *legacyAliasSpy) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.aliases == nil {
 		m.aliases = map[legacyResourceKey][]legacyAliasSpec{}
 	}
@@ -109,6 +115,8 @@ func (m *legacyAliasSpy) NewResource(args pulumi.MockResourceArgs) (string, reso
 
 // specs returns the legacy identities one registered resource declared.
 func (m *legacyAliasSpy) specs(typeToken, name string) []legacyAliasSpec {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return m.aliases[legacyResourceKey{typeToken: typeToken, name: name}]
 }
 

--- a/provider/defangazure/azure/dns_test.go
+++ b/provider/defangazure/azure/dns_test.go
@@ -2,6 +2,7 @@ package azure
 
 import (
 	"sort"
+	"sync"
 	"testing"
 
 	"github.com/pulumi/pulumi-azure-native-sdk/network/v3"
@@ -17,13 +18,17 @@ type dnsResource struct {
 }
 
 type dnsNameMocks struct {
+	mu        sync.Mutex
 	resources []dnsResource
 	aliases   []dnsResource
 }
 
+// NewResource runs concurrently (one goroutine per resource registration), so
+// the slice appends below must be synchronized.
 func (m *dnsNameMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
 	switch args.TypeToken {
 	case "azure-native:privatedns:PrivateZone", "azure-native:privatedns:VirtualNetworkLink":
+		m.mu.Lock()
 		m.resources = append(m.resources, dnsResource{typeToken: args.TypeToken, name: args.Name})
 		for _, alias := range args.RegisterRPC.GetAliases() {
 			// The azure-native SDK attaches an alias per historical API version
@@ -33,6 +38,7 @@ func (m *dnsNameMocks) NewResource(args pulumi.MockResourceArgs) (string, resour
 				m.aliases = append(m.aliases, dnsResource{typeToken: args.TypeToken, name: spec.GetName()})
 			}
 		}
+		m.mu.Unlock()
 	}
 	return args.Name + "_id", args.Inputs, nil
 }

--- a/provider/defanggcp/gcp/alb_test.go
+++ b/provider/defanggcp/gcp/alb_test.go
@@ -1,6 +1,7 @@
 package gcp
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
@@ -19,17 +20,22 @@ type albResource struct {
 }
 
 type albMocks struct {
+	mu        sync.Mutex
 	resources []albResource
 }
 
+// NewResource runs concurrently (one goroutine per resource registration), so
+// the append to resources below must be synchronized.
 func (m *albMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
 	var parent string
 	if args.RegisterRPC != nil {
 		parent = args.RegisterRPC.GetParent()
 	}
+	m.mu.Lock()
 	m.resources = append(m.resources, albResource{
 		name: args.Name, typeof: args.TypeToken, inputs: args.Inputs, parent: parent,
 	})
+	m.mu.Unlock()
 	return args.Name + "_id", args.Inputs, nil
 }
 

--- a/provider/defanggcp/gcp/cloudsql_test.go
+++ b/provider/defanggcp/gcp/cloudsql_test.go
@@ -1,6 +1,7 @@
 package gcp
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
@@ -86,10 +87,15 @@ func TestCloudSQLResolvesConfigPasswordWithExplicitProvider(t *testing.T) {
 // aliasSpy records the legacy names each registered resource declared.
 type aliasSpy struct {
 	noopMocks
+	mu      sync.Mutex
 	aliases map[string][]string
 }
 
+// NewResource runs concurrently (one goroutine per resource registration), so
+// the map init and writes below must be synchronized.
 func (m *aliasSpy) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.aliases == nil {
 		m.aliases = map[string][]string{}
 	}


### PR DESCRIPTION
## Summary

Pulumi's mock engine invokes `NewResource` concurrently (one goroutine per resource registration). Four provider-level mocks mutated shared state — a slice append or a lazily-initialized map — with no lock, which is a genuine data race that surfaced as intermittent CI flakes:

- `provider/defangazure/azure/dns_test.go` — `dnsNameMocks.NewResource` appended to `m.resources`/`m.aliases`. This is the one that flaked as `TestCreateDNSZonesNamesAreIndependentOfTheService` on #542's CI run.
- `provider/defanggcp/gcp/alb_test.go` — `albMocks.NewResource` appended to `m.resources`. This is the one that flaked as `TestCreateLoadBalancersTwoPrivateCloudRunServices` on #543's CI run.
- `provider/defangaws/aws/legacy_aliases_test.go` — `legacyAliasSpy.NewResource` lazily initialized and wrote to a map with no lock (same race class — worse, concurrent map writes can panic outright). Found while auditing `defangaws` per the issue's suggestion.
- `provider/defanggcp/gcp/cloudsql_test.go` — `aliasSpy.NewResource` had the identical lazy-init/map-write race.

Fix mirrors #424: add a `sync.Mutex` to each mock struct and lock around the write inside `NewResource`. All reads of the accumulated state happen after `pulumi.RunErr` returns — i.e. after every goroutine has joined — so no lock is needed there, same as #424.

Closes #544.

## Test plan

- [x] `go build ./...`
- [x] `go test -race -run TestCreateDNSZonesNamesAreIndependentOfTheService ./provider/defangazure/... -count=20` — clean
- [x] `go test -race -run TestCreateLoadBalancersTwoPrivateCloudRunServices ./provider/defanggcp/... -count=20` — clean
- [x] `go test -race ./provider/... -count=3` — clean
- [x] `golangci-lint run` on the touched packages — no new findings (all flagged issues are pre-existing, in files this PR doesn't touch)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>