### PR TITLE
fix: build all example providers before generating any examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,8 +168,15 @@ pre-push: provider test image_all
 EXAMPLE_PROVIDERS  := aws gcp azure
 EXAMPLE_LANGUAGES  := go nodejs python dotnet
 
+# Install every provider before generating any example. pulumictl bakes a
+# "+dirty" suffix into a provider's version if the git tree isn't clean at
+# build time, and generating one provider's examples writes real diffs into
+# the tracked examples/ tree — so building providers one-at-a-time,
+# interleaved with generation, dirties the tree for every provider after the
+# first (see the aws-then-gcp-then-azure order below: aws always came out
+# clean, gcp and azure always came out "+dirty").
 .PHONY: examples
-examples: $(foreach p,$(EXAMPLE_PROVIDERS),gen_examples_$(p)) ## Generate language examples from YAML
+examples: $(foreach p,$(EXAMPLE_PROVIDERS),install_defang-$(p)) $(foreach p,$(EXAMPLE_PROVIDERS),gen_examples_$(p)) ## Generate language examples from YAML
 	$(MAKE) README.md
 
 define example_target

--- a/Makefile
+++ b/Makefile
@@ -173,15 +173,20 @@ EXAMPLE_LANGUAGES  := go nodejs python dotnet
 # build time, and generating one provider's examples writes real diffs into
 # the tracked examples/ tree — so building providers one-at-a-time,
 # interleaved with generation, dirties the tree for every provider after the
-# first (see the aws-then-gcp-then-azure order below: aws always came out
-# clean, gcp and azure always came out "+dirty").
+# first (aws-then-gcp-then-azure: aws always came out clean, gcp and azure
+# always came out "+dirty"). This barrier must be a real prerequisite of
+# every generation target, not just a sibling of `examples`, so it also
+# holds under `make -j`.
+.PHONY: install_example_providers
+install_example_providers: $(foreach p,$(EXAMPLE_PROVIDERS),install_defang-$(p))
+
 .PHONY: examples
-examples: $(foreach p,$(EXAMPLE_PROVIDERS),install_defang-$(p)) $(foreach p,$(EXAMPLE_PROVIDERS),gen_examples_$(p)) ## Generate language examples from YAML
+examples: $(foreach p,$(EXAMPLE_PROVIDERS),gen_examples_$(p)) ## Generate language examples from YAML
 	$(MAKE) README.md
 
 define example_target
 .PHONY: example_$(1)_$(2)
-example_$(1)_$(2): install_defang-$(1)
+example_$(1)_$(2): install_example_providers
 	cd examples/$(1)-yaml && pulumi convert --language $(2) --generate-only --out ../$(1)-$(2)
 endef
 

--- a/examples/azure-dotnet/defang-azure.csproj
+++ b/examples/azure-dotnet/defang-azure.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="DefangLabs.DefangAzure" Version="2.7.1+dirty" />
+		<PackageReference Include="DefangLabs.DefangAzure" Version="2.7.1" />
 	</ItemGroup>
 
 </Project>

--- a/examples/azure-nodejs/package.json
+++ b/examples/azure-nodejs/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.7.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@defang-io/pulumi-defang-azure": "2.7.1+dirty"
+		"@defang-io/pulumi-defang-azure": "2.7.1"
 	}
 }

--- a/examples/azure-python/requirements.txt
+++ b/examples/azure-python/requirements.txt
@@ -1,2 +1,2 @@
-pulumi-defang-azure==2.7.1+dirty
+pulumi-defang-azure==2.7.1
 pulumi>=3.0.0,<4.0.0

--- a/examples/gcp-dotnet/defang-gcp.csproj
+++ b/examples/gcp-dotnet/defang-gcp.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="DefangLabs.DefangGcp" Version="2.7.1+dirty" />
+		<PackageReference Include="DefangLabs.DefangGcp" Version="2.7.1" />
 	</ItemGroup>
 
 </Project>

--- a/examples/gcp-nodejs/package.json
+++ b/examples/gcp-nodejs/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"typescript": "^4.7.0",
 		"@pulumi/pulumi": "^3.0.0",
-		"@defang-io/pulumi-defang-gcp": "2.7.1+dirty"
+		"@defang-io/pulumi-defang-gcp": "2.7.1"
 	}
 }

--- a/examples/gcp-python/requirements.txt
+++ b/examples/gcp-python/requirements.txt
@@ -1,2 +1,2 @@
-pulumi-defang-gcp==2.7.1+dirty
+pulumi-defang-gcp==2.7.1
 pulumi>=3.0.0,<4.0.0


### PR DESCRIPTION
## Summary
- Answers @lionello's question on PR #546: why `examples/azure-dotnet/defang-azure.csproj` (and, quietly, several other GCP/Azure example files) got `Version="2.7.1+dirty"`.
- Root cause: `pulumictl get version` appends `+dirty` when the git tree isn't clean at the moment a provider binary is built. `make examples` builds+generates one provider at a time in order `aws gcp azure`. Generating aws's examples writes real, legitimate diffs into the tracked `examples/` tree — so by the time gcp and then azure are built, the tree is already dirty, and pulumictl tags their embedded version `+dirty`. aws is always first, so it's always clean; gcp and azure always aren't. Verified against this release (PR #546) and the previous one (PR #539) — same pattern both times, all the way back to v2.0.0.
- Fix: build (`install_defang-*`) every provider before generating any example, so all three read the git-dirty state at the same point in time. Verified locally that after this change all three providers produce the *same* version string regardless of order.
- Also strips the stale `+dirty` that's currently committed in the gcp/azure dotnet/nodejs/python examples on `main`.

## Test plan
- [x] `make examples` run locally end-to-end; confirmed aws/gcp/azure examples now all embed the same version instead of gcp/azure trailing with `+dirty`
- [x] `grep -r '+dirty' examples/` is empty after the fix
- [ ] Next `regenerate_examples` release run (or a manual `make examples` on a clean `main` checkout) should produce a plain version with no `+dirty` for all three providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_hook-DefangLabs-pulumi-defang-9862

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated Azure and Google Cloud example projects to use the stable 2.7.1 provider packages.
  - Ensured all configured providers are installed before generating provider examples, including when examples are generated in parallel.
  - Preserved existing README regeneration behavior.
  - Improved consistency and reliability when setting up and generating cloud provider examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->