### PR TITLE
feat(azure): implement x-defang-policies via per-service managed identity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.23.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers/v3 v3.1.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices v1.8.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6Xu
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers/v3 v3.1.0 h1:ilMZ576u8sm975EqV+AKEtD4u9TLwqEo2XY9csPXBRo=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers/v3 v3.1.0/go.mod h1:LGhzy+pg9AKr1Z7ZRyTC1qr1xNyVqLsqydvLdY+2iQk=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0 h1:Hp+EScFOu9HeCbeW8WU2yQPJd4gGwhMgKxWe+G6jNzw=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0/go.mod h1:/pz8dyNQe+Ey3yBp/XuYz7oqX8YDNWVpPB0hH3XWfbc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices v1.8.0 h1:ZMGAqCZov8+7iFUPWKVcTaLgNXUeTlz20sIuWkQWNfg=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices v1.8.0/go.mod h1:BElPQ/GZtrdQ2i5uDZw3OKLE1we75W0AEWyeBR1TWQA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry v1.2.0 h1:DWlwvVV5r/Wy1561nZ3wrpI1/vDIBRY/Wd1HWaRBZWA=

--- a/provider/defangazure/azure/containerapp.go
+++ b/provider/defangazure/azure/containerapp.go
@@ -167,10 +167,14 @@ func buildEnvVars(
 			Value: pulumi.String(serviceName),
 		},
 	}
-	if policyIdentity != nil {
+	if _, userSet := svc.Environment["AZURE_CLIENT_ID"]; policyIdentity != nil && !userSet {
 		// DefaultAzureCredential can't disambiguate when the Container App
 		// carries more than one user-assigned identity (e.g. this one plus a
 		// Key Vault identity) — tell it which one is x-defang-policies's.
+		// Skipped when the compose file already sets AZURE_CLIENT_ID: two
+		// entries with the same name make Container Apps reject the spec (or
+		// pick one nondeterministically), and the compose author's choice of
+		// identity should win over ours either way.
 		envs = append(envs, app.EnvironmentVarArgs{
 			Name:  pulumi.String("AZURE_CLIENT_ID"),
 			Value: policyIdentity.ClientID,

--- a/provider/defangazure/azure/containerapp.go
+++ b/provider/defangazure/azure/containerapp.go
@@ -154,6 +154,11 @@ func buildEnvVars(
 	infra *SharedInfra,
 	serviceEndpoints map[string]pulumi.StringOutput,
 	serviceHosts map[string]pulumi.StringOutput,
+	policyIdentity *PolicyIdentity,
+	//nolint:unparam // no current caller supplies invoke options, but the
+	// param mirrors ConfigProvider.GetSecretRef's own signature (compose.ConfigProvider),
+	// which buildEnvVars forwards it to — kept for interface parity with the
+	// AWS worker, which does pass a real option (parentOpt) here.
 	opts ...pulumi.InvokeOption,
 ) envResult {
 	envs := app.EnvironmentVarArray{
@@ -161,6 +166,15 @@ func buildEnvVars(
 			Name:  pulumi.String("DEFANG_SERVICE"),
 			Value: pulumi.String(serviceName),
 		},
+	}
+	if policyIdentity != nil {
+		// DefaultAzureCredential can't disambiguate when the Container App
+		// carries more than one user-assigned identity (e.g. this one plus a
+		// Key Vault identity) — tell it which one is x-defang-policies's.
+		envs = append(envs, app.EnvironmentVarArgs{
+			Name:  pulumi.String("AZURE_CLIENT_ID"),
+			Value: policyIdentity.ClientID,
+		})
 	}
 	if infra.Etag != "" {
 		envs = append(envs, app.EnvironmentVarArgs{
@@ -261,9 +275,10 @@ func CreateContainerApp(
 	serviceEndpoints map[string]pulumi.StringOutput,
 	serviceHosts map[string]pulumi.StringOutput,
 	dnsZones map[string]string,
+	policyIdentity *PolicyIdentity,
 	opts ...pulumi.ResourceOption,
 ) (*containerAppResult, error) {
-	result := buildEnvVars(ctx, serviceName, svc, infra, serviceEndpoints, serviceHosts)
+	result := buildEnvVars(ctx, serviceName, svc, infra, serviceEndpoints, serviceHosts, policyIdentity)
 
 	// Resource limits
 	cpu, mem := containerAppCpuMemory(svc.GetCPUs(), svc.GetMemoryMiB())
@@ -304,6 +319,9 @@ func CreateContainerApp(
 	}
 	if len(result.Secrets) > 0 && infra.KeyVaultIdentityID != nil {
 		userIdentities = append(userIdentities, infra.KeyVaultIdentityID.ToStringPtrOutput().Elem())
+	}
+	if policyIdentity != nil {
+		userIdentities = append(userIdentities, policyIdentity.ID)
 	}
 	var identity *app.ManagedServiceIdentityArgs
 	if len(userIdentities) > 0 {

--- a/provider/defangazure/azure/containerapp_test.go
+++ b/provider/defangazure/azure/containerapp_test.go
@@ -139,9 +139,46 @@ func TestBuildEnvVarsInjectsPolicyIdentityClientID(t *testing.T) {
 		require.True(t, ok, "AZURE_CLIENT_ID env var not found with a policy identity present")
 		assert.Equal(t, policyIdentity.ClientID, clientID.Value,
 			"AZURE_CLIENT_ID should carry the policy identity's client ID")
+
+		// A compose-declared AZURE_CLIENT_ID must win: two env entries with the
+		// same name make Container Apps reject the spec (or pick one
+		// nondeterministically).
+		svcWithOwnClientID := compose.ServiceConfig{
+			Environment: compose.Environment{"AZURE_CLIENT_ID": pulumi.String("user-supplied")},
+		}
+		result = buildEnvVars(ctx, "svc", svcWithOwnClientID, &SharedInfra{}, nil, nil, policyIdentity)
+		require.Equal(t, 1, countEnvVarsByName(result, "AZURE_CLIENT_ID"),
+			"exactly one AZURE_CLIENT_ID entry, not one from the compose file plus ours")
+		// The compose-loop path wraps even a literal value in a StringOutput
+		// (via compose.InterpolateEnvironmentVariable) — assert inside ApplyT
+		// so it runs after that (mock-synchronous) resolution completes.
+		userValue, ok := envVarsByName(result)["AZURE_CLIENT_ID"].Value.(pulumi.StringOutput)
+		require.True(t, ok)
+		userValue.ApplyT(func(v string) string {
+			assert.Equal(t, "user-supplied", v,
+				"the compose file's own AZURE_CLIENT_ID must not be overridden by the policy identity's")
+			return v
+		})
 		return nil
 	}, pulumi.WithMocks("proj", "stack", azureNoopMocks{}))
 	require.NoError(t, err)
+}
+
+// countEnvVarsByName counts raw env entries in result.Envs carrying name —
+// envVarsByName collapses duplicates into a map, hiding exactly the
+// double-entry bug this guards against, so this walks the slice directly.
+func countEnvVarsByName(result envResult, name string) int {
+	count := 0
+	for _, e := range result.Envs {
+		args, ok := e.(app.EnvironmentVarArgs)
+		if !ok {
+			continue
+		}
+		if n, ok := args.Name.(pulumi.String); ok && string(n) == name {
+			count++
+		}
+	}
+	return count
 }
 
 // TestBuildProbesClampsInitialDelay covers the Azure ceiling on a probe's

--- a/provider/defangazure/azure/containerapp_test.go
+++ b/provider/defangazure/azure/containerapp_test.go
@@ -57,7 +57,7 @@ func TestBuildEnvVarsEmitsSecretRefs(t *testing.T) {
 			},
 		}
 
-		result := buildEnvVars(ctx, "svc", svc, infra, nil, nil)
+		result := buildEnvVars(ctx, "svc", svc, infra, nil, nil, nil)
 
 		// Exactly one Secret entry — deduped even though two env vars reference CONFIG.
 		require.Len(t, result.Secrets, 1,
@@ -106,7 +106,7 @@ func TestBuildEnvVarsEmitsSecretRefs(t *testing.T) {
 func TestBuildEnvVarsInjectsDefangServiceEnv(t *testing.T) {
 	const serviceName = "my-service"
 	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
-		result := buildEnvVars(ctx, serviceName, compose.ServiceConfig{}, &SharedInfra{}, nil, nil)
+		result := buildEnvVars(ctx, serviceName, compose.ServiceConfig{}, &SharedInfra{}, nil, nil, nil)
 
 		defang, ok := envVarsByName(result)["DEFANG_SERVICE"]
 		require.True(t, ok, "DEFANG_SERVICE env var not found on Container App")
@@ -114,6 +114,31 @@ func TestBuildEnvVarsInjectsDefangServiceEnv(t *testing.T) {
 		require.True(t, ok, "DEFANG_SERVICE should have a concrete string value")
 		assert.Equal(t, serviceName, string(value),
 			"DEFANG_SERVICE value should match the service name")
+		return nil
+	}, pulumi.WithMocks("proj", "stack", azureNoopMocks{}))
+	require.NoError(t, err)
+}
+
+// TestBuildEnvVarsInjectsPolicyIdentityClientID verifies that AZURE_CLIENT_ID
+// is set to the x-defang-policies identity's client ID when one is present —
+// with more than one user-assigned identity on the Container App,
+// DefaultAzureCredential can't otherwise tell which one a self-redeploying
+// service should authenticate as (DefangLabs/pulumi-defang#326) — and is
+// absent for the (common) case of a service with no policies.
+func TestBuildEnvVarsInjectsPolicyIdentityClientID(t *testing.T) {
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		result := buildEnvVars(ctx, "svc", compose.ServiceConfig{}, &SharedInfra{}, nil, nil, nil)
+		_, ok := envVarsByName(result)["AZURE_CLIENT_ID"]
+		assert.False(t, ok, "AZURE_CLIENT_ID should be absent without a policy identity")
+
+		policyIdentity := &PolicyIdentity{
+			ClientID: pulumi.String("11111111-1111-1111-1111-111111111111").ToStringOutput(),
+		}
+		result = buildEnvVars(ctx, "svc", compose.ServiceConfig{}, &SharedInfra{}, nil, nil, policyIdentity)
+		clientID, ok := envVarsByName(result)["AZURE_CLIENT_ID"]
+		require.True(t, ok, "AZURE_CLIENT_ID env var not found with a policy identity present")
+		assert.Equal(t, policyIdentity.ClientID, clientID.Value,
+			"AZURE_CLIENT_ID should carry the policy identity's client ID")
 		return nil
 	}, pulumi.WithMocks("proj", "stack", azureNoopMocks{}))
 	require.NoError(t, err)

--- a/provider/defangazure/azure/policies.go
+++ b/provider/defangazure/azure/policies.go
@@ -35,6 +35,14 @@ func isAzureRoleDefinitionID(policy string) bool {
 	return strings.HasPrefix(policy, "/")
 }
 
+// roleNameFilter builds the ARM $filter value for looking up a role
+// definition by name. OData escapes a single quote by doubling it; without
+// this, a role name containing "'" either breaks the filter or (crafted as
+// `foo' or roleName eq 'Owner`) widens the match to an unintended role.
+func roleNameFilter(policy string) string {
+	return fmt.Sprintf("roleName eq '%s'", strings.ReplaceAll(policy, "'", "''"))
+}
+
 // resolveRoleDefinitionID turns an x-defang-policies entry into a full
 // role-definition resource ID at scope. A full resource ID passes through
 // unchanged; a bare name (a built-in like "Contributor", or a custom role
@@ -59,7 +67,7 @@ func resolveRoleDefinitionID(ctx context.Context, scope, policy string) (string,
 		return "", fmt.Errorf("building role definitions client: %w", err)
 	}
 
-	filter := fmt.Sprintf("roleName eq '%s'", policy)
+	filter := roleNameFilter(policy)
 	pager := client.NewListPager(scope, &armauthorization.RoleDefinitionsClientListOptions{Filter: &filter})
 	for pager.More() {
 		page, err := pager.NextPage(ctx)

--- a/provider/defangazure/azure/policies.go
+++ b/provider/defangazure/azure/policies.go
@@ -1,0 +1,144 @@
+package azure
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
+	"github.com/pulumi/pulumi-azure-native-sdk/authorization/v3"
+	"github.com/pulumi/pulumi-azure-native-sdk/managedidentity/v3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// PolicyIdentity is the per-service user-assigned managed identity created
+// for a service's x-defang-policies role assignments (see CreatePolicyIdentity).
+type PolicyIdentity struct {
+	// ID is the identity's ARM resource ID, for the Container App's
+	// ManagedServiceIdentity.UserAssignedIdentities map.
+	ID pulumi.StringOutput
+	// ClientID is the identity's AAD application (client) ID. With more than
+	// one user-assigned identity attached to a Container App,
+	// DefaultAzureCredential cannot pick one on its own — the defang CLI
+	// (which is what a self-redeploying service runs) needs AZURE_CLIENT_ID
+	// in its environment to authenticate as this identity specifically.
+	ClientID pulumi.StringOutput
+}
+
+// isAzureRoleDefinitionID reports whether policy is already a fully-qualified
+// role-definition resource ID (as opposed to a bare role name to resolve).
+// Mirrors compose.ClassifyPolicy's own Azure test ("/subscriptions/…" or
+// "/providers/…"), so a value that reaches here already passed
+// compose.ValidatePolicies against PolicyCloudAzure.
+func isAzureRoleDefinitionID(policy string) bool {
+	return strings.HasPrefix(policy, "/")
+}
+
+// resolveRoleDefinitionID turns an x-defang-policies entry into a full
+// role-definition resource ID at scope. A full resource ID passes through
+// unchanged; a bare name (a built-in like "Contributor", or a custom role
+// already visible at scope) is looked up by roleName via the ARM list API —
+// the one mechanism that covers both role kinds, since built-ins have no
+// per-subscription GUID a caller could reasonably hardcode. Mirrors
+// resolvePolicyArn (AWS) / ResolvePolicyRole (GCP), except Azure has no
+// invoke-style lookup for this (see LookupRoleDefinition, which needs the
+// GUID already known) so this calls the raw ARM SDK directly — the same
+// approach readLiveCustomDomains uses for a live, out-of-band Azure read.
+func resolveRoleDefinitionID(ctx context.Context, scope, policy string) (string, error) {
+	if isAzureRoleDefinitionID(policy) {
+		return policy, nil
+	}
+
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		return "", fmt.Errorf("building credential: %w", err)
+	}
+	client, err := armauthorization.NewRoleDefinitionsClient(cred, nil)
+	if err != nil {
+		return "", fmt.Errorf("building role definitions client: %w", err)
+	}
+
+	filter := fmt.Sprintf("roleName eq '%s'", policy)
+	pager := client.NewListPager(scope, &armauthorization.RoleDefinitionsClientListOptions{Filter: &filter})
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return "", fmt.Errorf("listing role definitions at %s: %w", scope, err)
+		}
+		for _, rd := range page.Value {
+			if rd != nil && rd.ID != nil {
+				return *rd.ID, nil
+			}
+		}
+	}
+	//nolint:err113 // the role name and scope are caller-supplied compose data, not a fixed sentinel case
+	return "", fmt.Errorf("no role definition named %q found at %s", policy, scope)
+}
+
+// CreatePolicyIdentity creates a per-service user-assigned managed identity
+// and grants it the x-defang-policies roles (already normalized and
+// validated against PolicyCloudAzure by the caller). Roles are capability
+// lists only on Azure — the scope decides what they apply to — so the grant
+// is made at the project's resource group, where every Defang-managed
+// resource for the project lives (see DefangLabs/pulumi-defang#326).
+//
+// Returns (nil, nil) when policies is empty: no identity, no role
+// assignments, nothing for the caller to attach — the common case, since
+// most services don't use x-defang-policies.
+//
+// Azure gotcha (documented, not worked around here): a fresh role assignment
+// can take up to ~5 minutes to propagate, so the very first deploy of a
+// self-redeploying service may need a retry before its own redeploy trigger
+// succeeds.
+func CreatePolicyIdentity(
+	ctx *pulumi.Context,
+	serviceName string,
+	policies []string,
+	infra *SharedInfra,
+	opts ...pulumi.ResourceOption,
+) (*PolicyIdentity, error) {
+	if len(policies) == 0 {
+		return nil, nil //nolint:nilnil // no policies; the caller treats nil as "nothing to attach"
+	}
+
+	identity, err := managedidentity.NewUserAssignedIdentity(
+		ctx, serviceName+"-policy", &managedidentity.UserAssignedIdentityArgs{
+			ResourceGroupName: infra.ResourceGroup.Name,
+		}, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("creating policy managed identity: %w", err)
+	}
+
+	scopeID := infra.ResourceGroup.ID().ToStringOutput()
+	var lastAssignmentID pulumi.IDOutput
+	for i, policy := range policies {
+		roleDefID := scopeID.ApplyT(func(scope string) (string, error) {
+			return resolveRoleDefinitionID(ctx.Context(), scope, policy)
+		}).(pulumi.StringOutput)
+
+		assignment, err := authorization.NewRoleAssignment(
+			ctx, fmt.Sprintf("%s-policy-%d", serviceName, i), &authorization.RoleAssignmentArgs{
+				Scope:            scopeID,
+				RoleDefinitionId: roleDefID,
+				PrincipalId:      identity.PrincipalId,
+				PrincipalType:    pulumi.String("ServicePrincipal"),
+			}, opts...)
+		if err != nil {
+			return nil, fmt.Errorf("granting policy %q: %w", policy, err)
+		}
+		lastAssignmentID = assignment.ID()
+	}
+
+	// Depend both outputs on the last role assignment so a caller using the
+	// identity (attaching it to a Container App, reading its client ID into
+	// an env var) implicitly waits for every grant to be created first.
+	id := pulumi.All(identity.ID(), lastAssignmentID).ApplyT(
+		func(args []interface{}) string { return string(args[0].(pulumi.ID)) },
+	).(pulumi.StringOutput)
+	clientID := pulumi.All(identity.ClientId, lastAssignmentID).ApplyT(
+		func(args []interface{}) string { return args[0].(string) },
+	).(pulumi.StringOutput)
+
+	return &PolicyIdentity{ID: id, ClientID: clientID}, nil
+}

--- a/provider/defangazure/azure/policies_test.go
+++ b/provider/defangazure/azure/policies_test.go
@@ -30,6 +30,27 @@ func TestIsAzureRoleDefinitionID(t *testing.T) {
 	}
 }
 
+// TestRoleNameFilterEscapesQuotes verifies OData single-quote escaping in the
+// role-definition list filter. Without it, a role name containing "'" either
+// breaks the filter or (crafted as `foo' or roleName eq 'Owner`) widens the
+// match to a role the compose file never asked for.
+func TestRoleNameFilterEscapesQuotes(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy string
+		want   string
+	}{
+		{"plain name", "deployer", "roleName eq 'deployer'"},
+		{"single quote", "O'Brien", "roleName eq 'O''Brien'"},
+		{"injection attempt", "foo' or roleName eq 'Owner", "roleName eq 'foo'' or roleName eq ''Owner'"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, roleNameFilter(tt.policy))
+		})
+	}
+}
+
 // TestCreatePolicyIdentity_NoPolicies verifies the fast path: no policies
 // means no identity is created and no error — the common case, since most
 // services don't use x-defang-policies at all.

--- a/provider/defangazure/azure/policies_test.go
+++ b/provider/defangazure/azure/policies_test.go
@@ -1,0 +1,45 @@
+package azure
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsAzureRoleDefinitionID(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy string
+		want   bool
+	}{
+		{"built-in role name", "Contributor", false},
+		{"custom role name", "deployer", false},
+		{"full role definition id", "/subscriptions/sub/providers/Microsoft.Authorization/roleDefinitions/guid", true},
+		{
+			"resource-group-scoped id",
+			"/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Authorization/roleDefinitions/guid",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isAzureRoleDefinitionID(tt.policy))
+		})
+	}
+}
+
+// TestCreatePolicyIdentity_NoPolicies verifies the fast path: no policies
+// means no identity is created and no error — the common case, since most
+// services don't use x-defang-policies at all.
+func TestCreatePolicyIdentity_NoPolicies(t *testing.T) {
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		infra := &SharedInfra{}
+		identity, err := CreatePolicyIdentity(ctx, "svc", nil, infra)
+		require.NoError(t, err)
+		assert.Nil(t, identity)
+		return nil
+	}, pulumi.WithMocks("proj", "stack", azureNoopMocks{}))
+	require.NoError(t, err)
+}

--- a/provider/defangazure/service.go
+++ b/provider/defangazure/service.go
@@ -1,7 +1,6 @@
 package defangazure
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/DefangLabs/pulumi-defang/provider/common"
@@ -11,8 +10,6 @@ import (
 	"github.com/pulumi/pulumi-azure-native-sdk/resources/v3"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
-
-var errPoliciesUnsupported = errors.New("x-defang-policies is not supported on Azure")
 
 // Service is the controller struct for the defang-azure:index:Service component.
 type Service struct{}
@@ -146,19 +143,20 @@ func createContainerApp(
 	serviceHosts map[string]pulumi.StringOutput,
 	dnsZones map[string]string,
 ) error {
-	// Policies aren't supported on Azure yet. Entries a stack leaves empty
-	// ("${EXTRA:-}") normalize away, so a compose file parameterized per
-	// stack still deploys here; a foreign-cloud literal gets the validation
-	// error (with the ${VAR} hint), any other entry the unsupported error.
+	// Entries a stack leaves empty ("${EXTRA:-}") normalize away, so a compose
+	// file parameterized per stack still deploys here; a foreign-cloud
+	// literal gets the validation error (with the ${VAR} hint).
 	policies := compose.NormalizePolicies(svc.Policies)
 	if err := compose.ValidatePolicies(compose.PolicyCloudAzure, policies); err != nil {
 		return fmt.Errorf("service %s: %w", serviceName, err)
 	}
-	if len(policies) > 0 {
-		return fmt.Errorf("service %s: %w", serviceName, errPoliciesUnsupported)
+	policyIdentity, err := azure.CreatePolicyIdentity(ctx, serviceName, policies, infra, pulumi.Parent(comp))
+	if err != nil {
+		return fmt.Errorf("granting policies for service %s: %w", serviceName, err)
 	}
 	caResult, err := azure.CreateContainerApp(
-		ctx, serviceName, svc, infra, imageURI, managedEndpoints, serviceHosts, dnsZones, pulumi.Parent(comp),
+		ctx, serviceName, svc, infra, imageURI, managedEndpoints, serviceHosts, dnsZones, policyIdentity,
+		pulumi.Parent(comp),
 	)
 	if err != nil {
 		return fmt.Errorf("creating Container App %s: %w", serviceName, err)

--- a/tests/azure/project_test.go
+++ b/tests/azure/project_test.go
@@ -6,6 +6,7 @@ package azure
 // App, Postgres, etc.) lives in their own dedicated test files.
 
 import (
+	"sync"
 	"testing"
 
 	p "github.com/pulumi/pulumi-go-provider"
@@ -17,6 +18,41 @@ import (
 	defangazure "github.com/DefangLabs/pulumi-defang/provider/defangazure"
 	"github.com/DefangLabs/pulumi-defang/tests/testutil"
 )
+
+type resourceRecord struct {
+	typ    string
+	name   string
+	inputs property.Map
+}
+
+// collectResources returns a mock and a pointer to the slice it populates.
+func collectResources() (*integration.MockResourceMonitor, *[]resourceRecord) {
+	var mu sync.Mutex
+	var records []resourceRecord
+	mock := &integration.MockResourceMonitor{
+		NewResourceF: func(args integration.MockResourceArgs) (string, property.Map, error) {
+			mu.Lock()
+			records = append(records, resourceRecord{
+				typ:    string(args.TypeToken),
+				name:   args.Name,
+				inputs: args.Inputs,
+			})
+			mu.Unlock()
+			return args.Name, args.Inputs, nil
+		},
+	}
+	return mock, &records
+}
+
+// findTypeWhere returns the first record matching the given type token and predicate, or nil.
+func findTypeWhere(records []resourceRecord, typ string, pred func(property.Map) bool) *resourceRecord {
+	for i := range records {
+		if records[i].typ == typ && pred(records[i].inputs) {
+			return &records[i]
+		}
+	}
+	return nil
+}
 
 func TestConstructAzureProject(t *testing.T) {
 	server := testutil.MakeAzureTestServer()
@@ -112,25 +148,38 @@ func TestConstructAzureProjectEmptyPoliciesDeploy(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestConstructAzureProjectRejectsApplicablePolicies(t *testing.T) {
-	server := testutil.MakeAzureTestServer()
+// TestConstructAzureProjectServiceWithPoliciesGrantsRoles covers the
+// full-role-definition-ID form of an x-defang-policies entry: a
+// RoleAssignment is registered at the project's resource group scope,
+// granting the service's own managed identity. The bare-name form (resolved
+// by listing role definitions against live Azure — see
+// resolveRoleDefinitionID) isn't exercised here: unlike GCP's ResolvePolicyRole,
+// it needs a real ARM credential and can't run against the mock resource
+// monitor alone (see roleNameFilter's unit test for the pure escaping logic).
+func TestConstructAzureProjectServiceWithPoliciesGrantsRoles(t *testing.T) {
+	mock, records := collectResources()
+	server := testutil.MakeAzureTestServer(integration.WithMocks(mock))
 
-	// A bare name applies on the current cloud, and Azure doesn't support
-	// policies yet.
+	const roleDefID = "/subscriptions/sub/providers/Microsoft.Authorization/roleDefinitions/deployer-guid"
+
 	_, err := server.Construct(p.ConstructRequest{
 		Urn: testutil.AzureURN("Project"),
 		Inputs: testutil.ServicesMap(map[string]property.Value{
-			"app": property.New(property.NewMap(map[string]property.Value{
-				"image": property.New("myapp:latest"),
-				"ports": property.New(property.NewArray([]property.Value{testutil.IngressPort(8080)})),
+			"redeployer": property.New(property.NewMap(map[string]property.Value{
+				"image": property.New("defangio/cli:latest"),
 				"policies": property.New(property.NewArray([]property.Value{
-					property.New("Contributor"),
+					property.New(roleDefID),
 				})),
 			})),
 		}),
 	})
 
-	require.ErrorContains(t, err, "x-defang-policies is not supported on Azure")
+	require.NoError(t, err)
+
+	found := findTypeWhere(*records, "azure-native:authorization:RoleAssignment", func(m property.Map) bool {
+		return m.Get("roleDefinitionId").AsString() == roleDefID
+	})
+	require.NotNil(t, found, "expected a RoleAssignment for the x-defang-policies entry")
 }
 
 // TestConstructAzureProjectBuildCarriesPluginIdentity asserts that the Build


### PR DESCRIPTION
## Summary

Implements the Azure half of #326: `x-defang-policies` on a service now grants a per-service **user-assigned managed identity** the requested role assignments, instead of rejecting with `errPoliciesUnsupported`.

- `provider/defangazure/azure/policies.go` (new): `CreatePolicyIdentity` creates the identity and, for each policy entry, a `authorization.RoleAssignment` at the project's resource group scope. Bare role names (built-in like `Contributor`, or a custom role already visible at scope) resolve to a full role-definition ID via the ARM `RoleDefinitions.NewListPager` `roleName eq '<name>'` filter — the one mechanism that covers both role kinds, since Azure has no invoke-style lookup that works from a name alone. A value that's already a full role-definition resource ID (`/subscriptions/…`) passes through unchanged, mirroring `resolvePolicyArn` (AWS) / `ResolvePolicyRole` (GCP).
- `provider/defangazure/azure/containerapp.go`: the policy identity is attached to the Container App's `UserAssignedIdentities` alongside any ACR-pull / Key-Vault identities, and `AZURE_CLIENT_ID` is injected into the container env — with more than one user-assigned identity attached, `DefaultAzureCredential` can't otherwise tell which one to use.
- `provider/defangazure/service.go`: replaces the `errPoliciesUnsupported` guard with the above.

**Motivating use case** (station#41): a Compose service that redeploys itself by running the `defang` CLI in-container. `DefaultAzureCredential` already works in-cluster via a managed identity; the only missing piece was a way to grant that identity permission to trigger a CD run — which is exactly what `x-defang-policies` is for. Once this is released, station's own provisioner service can move off `AZURE_CLIENT_SECRET`/`AZURE_TENANT_ID` service-principal keys onto this (RBAC instead of keys — station#41's actual ask).

**Documented, not worked around**: a fresh role assignment can take up to ~5 minutes to propagate, so the very first deploy of a self-redeploying service may need a retry before its own redeploy trigger succeeds (same caveat #326 calls out).

**Deferred** (not needed by the motivating use case, no current consumer): a guard rejecting `Policies` combined with a caller-supplied identity — Azure's `ServiceInputs` doesn't have such a field yet (unlike AWS's `taskRoleArn`), so there's nothing to conflict with today.

## Test plan
- [x] `go test ./provider/...` — new `policies_test.go` (bare-name-vs-full-ID classification, empty-policies no-op) and extended `containerapp_test.go` (`AZURE_CLIENT_ID` present/absent) pass, along with the full existing suite.
- [x] `golangci-lint run --config=.golangci.yaml ./provider/...` (pinned v2.11.4, matching CI) — 0 issues.
- [ ] Real Azure deploy of a self-redeploying service (can't be exercised in this sandbox — no Azure credentials here); station#41 will be the first real consumer once this is released.

Closes the Azure portion of #326.

https://claude.ai/code/session_01Uhdan1SdLnsBjktcTtS2N1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Azure deployments can use validated role-based policies through automatically managed, service-specific identities.
  * Policies may be specified using an Azure role name or full role-definition ID.
  * Container Apps receive the configured identity for authenticated Azure resource access.
  * The identity’s client ID is added automatically when not already configured.
* **Bug Fixes**
  * Policy configuration errors are reported before Container App creation.
  * Deployments without policies continue without creating an additional identity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->