### PR TITLE
fix: normalize provider plugin versions

### DIFF
--- a/provider/common/plugin.go
+++ b/provider/common/plugin.go
@@ -1,6 +1,10 @@
 package common
 
-import "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+import (
+	"strings"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
 
 // PluginDownloadURL is where Pulumi fetches this plugin from when it is not
 // already in the local plugin cache. Each provider's schema metadata publishes
@@ -61,7 +65,7 @@ type PluginIdentity struct {
 // neighbouring aws:/gcp:/azure: resource would send the engine looking for
 // that provider at our version.
 func PluginIdentityFrom(fallbackVersion string, opts ...pulumi.ResourceOption) PluginIdentity {
-	id := PluginIdentity{DownloadURL: PluginDownloadURL, Version: fallbackVersion}
+	id := PluginIdentity{DownloadURL: PluginDownloadURL, Version: pulumiPluginVersion(fallbackVersion)}
 	snapshot, err := pulumi.NewResourceOptions(opts...)
 	if err != nil {
 		// Malformed options are the caller's problem and will resurface at
@@ -72,9 +76,18 @@ func PluginIdentityFrom(fallbackVersion string, opts ...pulumi.ResourceOption) P
 		id.DownloadURL = snapshot.PluginDownloadURL
 	}
 	if snapshot.Version != "" {
-		id.Version = snapshot.Version
+		id.Version = pulumiPluginVersion(snapshot.Version)
 	}
 	return id
+}
+
+// pulumiPluginVersion converts a Git tag-shaped version to the semver string
+// expected by pulumi.Version. Release builds inject tags such as "v2.7.1";
+// passing that prefix through makes the engine's strict parser reject the
+// child resource registration with "Invalid character(s) found in major
+// number \"v2\"".
+func pulumiPluginVersion(version string) string {
+	return strings.TrimPrefix(version, "v")
 }
 
 // ResourceOptions prefixes opts with this identity, for registering one of our

--- a/provider/common/plugin_test.go
+++ b/provider/common/plugin_test.go
@@ -1,0 +1,37 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPluginIdentityFromNormalizesVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		fallbackVersion string
+		opts            []pulumi.ResourceOption
+		want            string
+	}{
+		{name: "release tag", fallbackVersion: "v2.7.1", want: "2.7.1"},
+		{name: "semver", fallbackVersion: "2.7.1", want: "2.7.1"},
+		{name: "empty development build", want: ""},
+		{
+			name:            "option overrides fallback",
+			fallbackVersion: "v2.7.1",
+			opts:            []pulumi.ResourceOption{pulumi.Version("v2.8.0-beta.1")},
+			want:            "2.8.0-beta.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			identity := PluginIdentityFrom(tt.fallbackVersion, tt.opts...)
+			assert.Equal(t, tt.want, identity.Version)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- strip the Git tag `v` prefix before passing provider versions to `pulumi.Version`
- normalize both the linker-injected fallback and a caller-supplied resource option
- add regression coverage for release, prerelease, plain-semver, and development versions

## Root cause

Release builds set `PROVIDER_VERSION=${{ github.ref_name }}`, so v2.7.0/v2.7.1 providers receive values such as `v2.7.1`. The child-resource identity added in #479 passed that value directly to `pulumi.Version`. Pulumi strictly parses that resource option and fails with `Invalid character(s) found in major number "v2"`.

PR images did not reproduce this because their provider version is not a `v`-prefixed release tag. That explains why the Azure Native 3.27 test image appeared to fix #540 while both released v2.7.0 and v2.7.1 continued failing DefangLabs/defang-mvp run 34248917002.

Fixes #540.

## Validation

- `go test ./provider/common/...`
- `go test ./provider/...`
- inspected the v2.7.1 Azure image used by the failing execution and confirmed it contains `pulumi-resource-azure-native` v3.27.0, ruling out a stale promoted image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved plugin version handling by consistently removing a leading `v` from release versions.
  - Preserved plain semantic versions and empty development-build versions.
  - Ensured explicitly provided resource versions take precedence over fallback versions.

- **Tests**
  - Added coverage for release, semantic-version, development-build, and override scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->