### PR TITLE
fix(azure): give host-mode ports an internal ingress, not none

### DIFF
--- a/provider/defangazure/azure/containerapp.go
+++ b/provider/defangazure/azure/containerapp.go
@@ -524,26 +524,54 @@ func llmURLEndpoint(v string, serviceEndpoints map[string]pulumi.StringOutput) (
 	return pulumi.StringOutput{}, false
 }
 
+// buildIngress returns the Container Apps ingress for a service, or nil when the
+// service publishes no port at all.
+//
+// Container Apps has no equivalent of a direct host port: an app is reachable by
+// name — even from a sibling app in the same environment — only if it has an
+// ingress block. So a host-mode port must map to an INTERNAL ingress rather than
+// to no ingress, or the service gets no resolvable name and a sibling that
+// addresses it by service name fails DNS resolution outright.
+//
+// Port mode therefore selects the exposure type and networks decide visibility:
+//   - an ingress port is externally exposed when the service is in a public
+//     network, internal otherwise;
+//   - a host port is always internal. Host is treated as private transitionally,
+//     the same choice common.ServiceFQDN documents, so a default-network host
+//     service keeps an internal-only name until public host exposure is
+//     implemented (pulumi-defang#253). This deliberately does not give a
+//     default-network host service a public hostname.
 func buildIngress(svc compose.ServiceConfig, networks compose.Networks) *app.IngressArgs {
-	if !svc.HasIngressPorts() {
+	publishedPort, ok := azureIngressPort(svc)
+	if !ok {
 		return nil
 	}
-	var ingressPort compose.ServicePortConfig
-	for _, p := range svc.Ports {
-		if p.IsIngress() {
-			ingressPort = p
-			break // TODO: support more than one ingress port
-		}
-	}
 	ingress := &app.IngressArgs{
-		External:   pulumi.Bool(common.InPublicNetwork(networks, svc)),
-		TargetPort: pulumi.Int(ingressPort.Target),
+		External:   pulumi.Bool(svc.HasIngressPorts() && common.InPublicNetwork(networks, svc)),
+		TargetPort: pulumi.Int(publishedPort.Target),
 	}
-	if ingressPort.AppProtocol == compose.PortAppProtocolGRPC ||
-		ingressPort.AppProtocol == compose.PortAppProtocolHTTP2 {
+	if publishedPort.AppProtocol == compose.PortAppProtocolGRPC ||
+		publishedPort.AppProtocol == compose.PortAppProtocolHTTP2 {
 		ingress.Transport = pulumi.StringPtr(string(app.IngressTransportMethodHttp2))
 	}
 	return ingress
+}
+
+// azureIngressPort picks the single port a Container App publishes. Ingress ports
+// win over host ports: a service with both is asking to be load-balanced, and
+// only ingress can be external. Returns false when the service publishes nothing.
+func azureIngressPort(svc compose.ServiceConfig) (compose.ServicePortConfig, bool) {
+	for _, p := range svc.Ports {
+		if p.IsIngress() {
+			return p, true // TODO: support more than one ingress port
+		}
+	}
+	for _, p := range svc.Ports {
+		if p.IsHost() {
+			return p, true
+		}
+	}
+	return compose.ServicePortConfig{}, false
 }
 
 // buildProbes returns the liveness probe(s) for a Container App.

--- a/provider/defangazure/azure/ingress_test.go
+++ b/provider/defangazure/azure/ingress_test.go
@@ -1,0 +1,119 @@
+package azure
+
+import (
+	"testing"
+
+	"github.com/DefangLabs/pulumi-defang/provider/compose"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	internalNet = map[compose.NetworkID]compose.ServiceNetworkConfig{"internal": {}}
+	defaultNet  = map[compose.NetworkID]compose.ServiceNetworkConfig{compose.DefaultNetwork: {}}
+	// topLevelNets is the shape a project like DefangLabs/station declares: a
+	// public default network alongside a private one.
+	topLevelNets = compose.Networks{compose.DefaultNetwork: {}, "internal": {}}
+)
+
+// TestBuildIngressHostPortGetsInternalIngress is the case that motivated this
+// change: on Container Apps a service is resolvable by name only if it has an
+// ingress block, so a host-mode port must produce an internal ingress rather
+// than none at all. Without it a sibling app addressing the service by name
+// fails DNS resolution and the caller 502s.
+func TestBuildIngressHostPortGetsInternalIngress(t *testing.T) {
+	ingress := buildIngress(compose.ServiceConfig{
+		Ports:    []compose.ServicePortConfig{{Target: 8080, Mode: compose.PortModeHost}},
+		Networks: internalNet,
+	}, topLevelNets)
+
+	require.NotNil(t, ingress, "a host port must still get an ingress, or the service has no resolvable name")
+	assert.Equal(t, false, boolInputValue(t, ingress.External))
+	assert.Equal(t, 8080, intInputValue(t, ingress.TargetPort))
+}
+
+// TestBuildIngressHostPortStaysInternalInPublicNetwork pins the transitional
+// boundary: host mode is treated as private even on the public default network,
+// matching common.ServiceFQDN, so this does not hand a host service a public
+// hostname (pulumi-defang#253).
+func TestBuildIngressHostPortStaysInternalInPublicNetwork(t *testing.T) {
+	ingress := buildIngress(compose.ServiceConfig{
+		Ports:    []compose.ServicePortConfig{{Target: 5432, Mode: compose.PortModeHost}},
+		Networks: defaultNet,
+	}, topLevelNets)
+
+	require.NotNil(t, ingress)
+	assert.Equal(t, false, boolInputValue(t, ingress.External),
+		"host mode must not be externally exposed until public host exposure exists")
+}
+
+// TestBuildIngressExternalFollowsNetworks covers the ingress-mode matrix: the
+// port mode asks for load-balanced exposure, the networks decide whether that
+// exposure is public.
+func TestBuildIngressExternalFollowsNetworks(t *testing.T) {
+	tests := []struct {
+		name         string
+		networks     compose.Networks
+		svcNetworks  map[compose.NetworkID]compose.ServiceNetworkConfig
+		wantExternal bool
+	}{
+		{"default network is public", topLevelNets, defaultNet, true},
+		{"private network is not public", topLevelNets, internalNet, false},
+		{
+			"internal default network is not public",
+			compose.Networks{compose.DefaultNetwork: {Internal: true}}, defaultNet, false,
+		},
+		{"no networks declared anywhere is public", nil, nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ingress := buildIngress(compose.ServiceConfig{
+				Ports:    []compose.ServicePortConfig{{Target: 80, Mode: compose.PortModeIngress}},
+				Networks: tt.svcNetworks,
+			}, tt.networks)
+
+			require.NotNil(t, ingress)
+			assert.Equal(t, tt.wantExternal, boolInputValue(t, ingress.External))
+		})
+	}
+}
+
+// TestBuildIngressNoPortsGetsNoIngress keeps the one case that must stay nil: a
+// worker with no published port is not reachable by anything.
+func TestBuildIngressNoPortsGetsNoIngress(t *testing.T) {
+	assert.Nil(t, buildIngress(compose.ServiceConfig{Networks: internalNet}, topLevelNets))
+}
+
+// TestBuildIngressPrefersIngressPortOverHostPort: a service asking for both is
+// asking to be load-balanced, and only an ingress port can be external.
+func TestBuildIngressPrefersIngressPortOverHostPort(t *testing.T) {
+	ingress := buildIngress(compose.ServiceConfig{
+		Ports: []compose.ServicePortConfig{
+			{Target: 5432, Mode: compose.PortModeHost},
+			{Target: 80, Mode: compose.PortModeIngress},
+		},
+		Networks: defaultNet,
+	}, topLevelNets)
+
+	require.NotNil(t, ingress)
+	assert.Equal(t, 80, intInputValue(t, ingress.TargetPort))
+	assert.Equal(t, true, boolInputValue(t, ingress.External))
+}
+
+// buildIngress builds its args from plain literals, so the inputs are the
+// concrete pulumi.Bool / pulumi.Int types rather than Outputs and can be read
+// back directly.
+func boolInputValue(t *testing.T, input pulumi.BoolPtrInput) bool {
+	t.Helper()
+	b, ok := input.(pulumi.Bool)
+	require.True(t, ok, "expected a pulumi.Bool, got %T", input)
+	return bool(b)
+}
+
+func intInputValue(t *testing.T, input pulumi.IntPtrInput) int {
+	t.Helper()
+	i, ok := input.(pulumi.Int)
+	require.True(t, ok, "expected a pulumi.Int, got %T", input)
+	return int(i)
+}

--- a/provider/defangazure/azure/ingress_test.go
+++ b/provider/defangazure/azure/ingress_test.go
@@ -29,7 +29,7 @@ func TestBuildIngressHostPortGetsInternalIngress(t *testing.T) {
 	}, topLevelNets)
 
 	require.NotNil(t, ingress, "a host port must still get an ingress, or the service has no resolvable name")
-	assert.Equal(t, false, boolInputValue(t, ingress.External))
+	assert.False(t, boolInputValue(t, ingress.External))
 	assert.Equal(t, 8080, intInputValue(t, ingress.TargetPort))
 }
 
@@ -44,7 +44,7 @@ func TestBuildIngressHostPortStaysInternalInPublicNetwork(t *testing.T) {
 	}, topLevelNets)
 
 	require.NotNil(t, ingress)
-	assert.Equal(t, false, boolInputValue(t, ingress.External),
+	assert.False(t, boolInputValue(t, ingress.External),
 		"host mode must not be externally exposed until public host exposure exists")
 }
 
@@ -98,7 +98,7 @@ func TestBuildIngressPrefersIngressPortOverHostPort(t *testing.T) {
 
 	require.NotNil(t, ingress)
 	assert.Equal(t, 80, intInputValue(t, ingress.TargetPort))
-	assert.Equal(t, true, boolInputValue(t, ingress.External))
+	assert.True(t, boolInputValue(t, ingress.External))
 }
 
 // buildIngress builds its args from plain literals, so the inputs are the


### PR DESCRIPTION
## The problem

On Container Apps an app is resolvable by name — even from a sibling app in the same managed environment — only if it has an `ingress` block. `buildIngress` returned `nil` unless the service had an **ingress**-mode port, so there was no way to express *"internal service, reachable by name"* on Azure at all:

| compose | result |
|---|---|
| `mode: host` | `HasIngressPorts()` false → no ingress → no DNS name. **Unreachable.** |
| `mode: ingress` | reachable, but the CLI's `serviceNameReplacer` buckets on port mode, so `svc:8080` is rewritten to a public `*.defang.app` FQDN that doesn't resolve for an `External: false` app. |

The two requirements were mutually exclusive, so the only workaround was to move the service into the public `default` network — the exact leak the networks model exists to prevent.

## Observed in production

`DefangLabs/station` deploys to Azure. Its compose has a Caddy `proxy` on `default` + `internal`, and `web` / `marketing` / `api` on `internal` only. All five Container Apps came up `Running`, but every request 502'd:

```
{"logger":"http.log.error","msg":"dial tcp: lookup marketing on 127.0.0.11:53: no such host",...,"status":502}
```

`127.0.0.11` is Docker Compose's embedded resolver, which doesn't exist on Container Apps. Only the proxy had ingress at all:

```
$ az containerapp list -g Defang-station-production \
    --query "[].{name:name,hasIngress:properties.configuration.ingress!=null}" -o table
Name       HasIngress
---------  ------------
web        False
marketing  False
proxy      True
migrate    False
api        False
```

No hostname existed for the proxy to resolve.

## The change

Port mode selects the **exposure type**; networks decide **visibility**:

- an **ingress** port is external when the service is in a public network, internal otherwise (unchanged behavior);
- a **host** port now gets an **internal** ingress instead of none.

Host stays private transitionally — the same choice `common.ServiceFQDN` already documents — so a *default-network* host service keeps an internal-only name rather than gaining a public one. That boundary is pulumi-defang#253 and this PR deliberately does not cross it.

A service with no published port still gets no ingress. `CreateCustomDomain` keeps gating on `HasIngressPorts`, so a host-mode service gets no public delegate-domain CNAME either.

## CLI compatibility

**This path needs no CLI change, which is why it was chosen.** The CLI already buckets host-mode services as private (`serviceNameReplacer.go:40`), and `ServicePrivateDNS` is the bare service name on Azure — so `marketing:8080` stays `marketing:8080` and now resolves.

Making the *ingress-in-a-private-network* path work is the case that **does** need a networks-aware replacer in the CLI, and it is not attempted here. That change is backwards-compat sensitive: `serviceNameReplacer` currently buckets purely on port mode (`// HACK: we only check the ports for "host" mode and don't care about the networks`), and any existing project whose env vars reference a ports-having service today gets a public FQDN substituted. Teaching it networks would silently change those substitutions, so it needs its own PR and its own compatibility story.

## Compatibility of this PR

The only behavior change is for a service with **host-mode ports on Azure**, which today gets no ingress and is therefore unreachable — so there is no working configuration to regress. Services with ingress ports, and services with no ports, are unaffected.

## Relationship to #380

Independent, but adjacent. #380 threads real top-level networks into `buildIngress` (the call site currently passes `nil` with a TODO); this PR changes what `buildIngress` does with them. They touch different lines and either can land first — with `nil` networks the station shape still classifies correctly, because `InPublicNetwork` falls back to the service's own networks.

Both are symptoms of the same half-finished migration: #380 moved the *classification* to networks, while the *gate* on whether ingress exists at all stayed on port mode. This PR moves the gate.

## Tests

New `provider/defangazure/azure/ingress_test.go`:
- host port in a private network → ingress exists, `External: false`, correct target port (the station case);
- host port in the **public** network → still `External: false` (pins the #253 boundary);
- the ingress-mode matrix: default network public, private network internal, `internal: true` default internal, no networks declared → public;
- no ports → still `nil`;
- both port modes present → ingress port wins.

Existing `ingress_transport_test.go` (gRPC/HTTP2 transport) passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rxct3jubVBBRu4ZPzuBTJt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Azure container apps now select ingress ports before host ports.
  - Host-mode ports use internal ingress and remain internal even on public networks.
  - External exposure is limited to explicitly configured ingress ports.
  - Services without published ports no longer receive ingress.

- **Bug Fixes**
  - Corrected ingress behavior across internal and public network configurations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->