### PR TITLE
fix: stop pinning our own build's version on self-registered resources

### DIFF
--- a/provider/common/plugin.go
+++ b/provider/common/plugin.go
@@ -14,7 +14,8 @@ import (
 const PluginDownloadURL = "github://api.github.com/DefangLabs/pulumi-defang"
 
 // PluginIdentity says which plugin serves our own resource types: where to
-// fetch it from, and which version of it to use.
+// fetch it from, and — only when a caller explicitly pinned one — which
+// version of it.
 //
 // The engine hands both to Construct — the Pulumi Go SDK copies them out of
 // the ConstructRequest onto the component's resource options — but they stop
@@ -22,50 +23,91 @@ const PluginDownloadURL = "github://api.github.com/DefangLabs/pulumi-defang"
 // package that we register from inside the provider process has to be given
 // them explicitly.
 //
-// Omitting them is not visible at deploy time. Without the URL the engine
-// synthesises a bare default provider and falls back to the conventional
-// plugin location github.com/pulumi/pulumi-<name>, which does not exist for
-// any of our packages. Without the version the checkpoint does not record
-// which plugin built the resource, so later operations resolve whatever is
-// newest and pay an unauthenticated GitHub API call to ask what "latest" is —
-// a call that is rate-limited per source IP. Neither costs anything during an
-// up, because resolving the SDK-registered provider has already put the plugin
-// binary in the local cache. Both strand the stack on destroy, from a fresh
-// workspace whose cache is empty, where nothing populates it.
+// Omitting the URL is not visible at deploy time: the engine synthesises a
+// bare default provider and falls back to the conventional plugin location
+// github.com/pulumi/pulumi-<name>, which does not exist for any of our
+// packages. Nothing fails while the plugin binary is still in the local cache,
+// so the stack strands later, on an operation run from a workspace whose cache
+// is empty and which therefore has to fetch the plugin.
+//
+// The version is a different matter, and PluginIdentityFrom deliberately does
+// not supply one — see the reasoning there.
 type PluginIdentity struct {
 	// DownloadURL is the plugin's pluginDownloadURL. Never empty after
 	// PluginIdentityFrom: it falls back to the PluginDownloadURL constant.
 	DownloadURL string
-	// Version is the plugin's semver, or "" for a build that carries none
-	// (a dev build has no -ldflags -X, and the generated SDKs omit the
-	// option in that case too).
+	// Version is the plugin's semver, or "" — the normal case — to let the
+	// engine accept whichever build of our plugin is at hand.
 	Version string
 }
 
 // PluginIdentityFrom determines the plugin identity to use for our own child
-// resources, preferring what the caller asked for and falling back to what
-// this build knows about itself.
+// resources: our PluginDownloadURL, plus a version only if the caller pinned
+// one.
 //
-// fallbackVersion is the provider package's linker-initialized Version. Pass
-// it from Construct, where that variable is in scope. It may be "": a dev
-// build has no -ldflags -X, and the generated SDKs omit the version option in
-// that case too.
+// It deliberately does NOT fall back to the provider package's linker-stamped
+// Version, even though that variable is in scope at every call site.
+//
+// A version in a registration is recorded in the checkpoint, as part of the
+// default provider's own URN — pulumi:providers:defang-azure::default_2_7_2_…
+// — and every later operation on those resources (up, refresh, destroy) has to
+// re-resolve that exact provider. Pulumi resolves a *versioned* request by
+// exact match (workspace.SelectCompatiblePlugin), so it is satisfied only by a
+// locally installed plugin of precisely that version, or by a GitHub release
+// tagged with it. Our CD image bakes exactly one version of the plugin: its
+// own. A pinned version is therefore resolvable by the image that wrote it,
+// and by no other image, unless the version happens to name a published
+// release. It usually does not:
+//
+//   - Only release.yml passes a real PROVIDER_VERSION. Every other build — the
+//     per-commit "alpha" CD images that test.yml publishes, a local `make
+//     image`, a bare `go build` — carries the Dockerfile's placeholder default
+//     (0.0.1) or a pulumictl pre-release string. Neither is ever tagged on
+//     GitHub, so a stack whose Build resources were first registered by such
+//     an image can never be operated on by any other image again: the engine
+//     404s on .../releases/tags/v0.0.1 and there is nothing anywhere to
+//     install. This is not hypothetical — it stranded a production stack whose
+//     first deploy used an alpha image and whose next deploy used a released
+//     one.
+//   - Even between two published releases the pin costs a download of the
+//     superseded plugin on every upgrade, because the new image does not have
+//     it, and it makes the recorded provider URN churn on every version bump.
+//
+// A registration with no version resolves through the legacy path
+// (workspace.LegacySelectCompatiblePlugin), which accepts any locally
+// installed plugin of that name — so every CD image can serve the resources it
+// did not create — and falls back to "latest" from PluginDownloadURL when the
+// cache really is empty. That is also what the generated SDKs already do: their
+// SdkVersion is the zero value, so PkgResourceDefaultOpts emits the URL and no
+// version. Leaving the version out makes our self-registered resources agree
+// with every other resource in the same stack instead of being the one
+// exception.
+//
+// The versionless path does pay one extra unauthenticated GitHub API call on a
+// genuinely cold cache: releases/latest to learn the version, then
+// releases/tags/vX to find the asset. Pinning buys nothing back there. For an
+// organisation other than "pulumi", the download itself goes through the same
+// rate-limited api.github.com endpoint either way (see githubSource.Download),
+// so a pin saves one request out of two and costs the stack its ability to be
+// served by any other build.
 //
 // Reading the options first mirrors GetChildOptions in pulumi-kubernetes' yaml
 // SDK, which propagates the caller's Version and PluginDownloadURL to the
 // children it registers. Today that read always comes back empty for us:
 // pulumi-go-provider's own ConstructRequest carries neither field, so its RPC
 // builder cannot populate them and the Go SDK has nothing to copy onto the
-// options it hands to Construct. Only Providers survives that trip. The read
-// is kept because it costs nothing, it is the behaviour we want the moment the
-// framework forwards them, and it lets a caller override.
+// options it hands to Construct. Only Providers survives that trip. The read is
+// kept because it costs nothing, it is the behaviour we want the moment the
+// framework forwards them, and it lets a caller pin a version deliberately —
+// which, coming from a program that resolved a published SDK, names a version
+// that really can be fetched.
 //
 // Thread the result down to the registration that needs it. It must not travel
 // as a ResourceOption: Version is per-package, so applying ours to a
-// neighbouring aws:/gcp:/azure: resource would send the engine looking for
-// that provider at our version.
-func PluginIdentityFrom(fallbackVersion string, opts ...pulumi.ResourceOption) PluginIdentity {
-	id := PluginIdentity{DownloadURL: PluginDownloadURL, Version: pulumiPluginVersion(fallbackVersion)}
+// neighbouring aws:/gcp:/azure: resource would send the engine looking for that
+// provider at our version.
+func PluginIdentityFrom(opts ...pulumi.ResourceOption) PluginIdentity {
+	id := PluginIdentity{DownloadURL: PluginDownloadURL}
 	snapshot, err := pulumi.NewResourceOptions(opts...)
 	if err != nil {
 		// Malformed options are the caller's problem and will resurface at
@@ -82,10 +124,10 @@ func PluginIdentityFrom(fallbackVersion string, opts ...pulumi.ResourceOption) P
 }
 
 // pulumiPluginVersion converts a Git tag-shaped version to the semver string
-// expected by pulumi.Version. Release builds inject tags such as "v2.7.1";
-// passing that prefix through makes the engine's strict parser reject the
-// child resource registration with "Invalid character(s) found in major
-// number \"v2\"".
+// expected by pulumi.Version. Callers may pin a tag such as "v2.7.1"; passing
+// that prefix through makes the engine's strict parser reject the child
+// resource registration with "Invalid character(s) found in major number
+// \"v2\"".
 func pulumiPluginVersion(version string) string {
 	return strings.TrimPrefix(version, "v")
 }

--- a/provider/common/plugin_test.go
+++ b/provider/common/plugin_test.go
@@ -5,33 +5,80 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestPluginIdentityFromNormalizesVersion(t *testing.T) {
+func TestPluginIdentityFrom(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name            string
-		fallbackVersion string
-		opts            []pulumi.ResourceOption
-		want            string
+		name        string
+		opts        []pulumi.ResourceOption
+		wantVersion string
+		wantURL     string
 	}{
-		{name: "release tag", fallbackVersion: "v2.7.1", want: "2.7.1"},
-		{name: "semver", fallbackVersion: "2.7.1", want: "2.7.1"},
-		{name: "empty development build", want: ""},
 		{
-			name:            "option overrides fallback",
-			fallbackVersion: "v2.7.1",
-			opts:            []pulumi.ResourceOption{pulumi.Version("v2.8.0-beta.1")},
-			want:            "2.8.0-beta.1",
+			// The regression this guards: an unpinned identity must stay
+			// unpinned. Whatever this build's linker-stamped Version happens to
+			// be — a release tag, the Dockerfile's 0.0.1 placeholder, a
+			// pulumictl pre-release string — it must not reach the checkpoint,
+			// because only a version that names a published GitHub release can
+			// ever be resolved again by a different CD image.
+			name:        "no options pins no version",
+			wantVersion: "",
+			wantURL:     PluginDownloadURL,
+		},
+		{
+			name:        "caller may pin a version",
+			opts:        []pulumi.ResourceOption{pulumi.Version("2.7.1")},
+			wantVersion: "2.7.1",
+			wantURL:     PluginDownloadURL,
+		},
+		{
+			// pulumi.Version's parser rejects a leading "v".
+			name:        "a pinned tag is normalized to semver",
+			opts:        []pulumi.ResourceOption{pulumi.Version("v2.8.0-beta.1")},
+			wantVersion: "2.8.0-beta.1",
+			wantURL:     PluginDownloadURL,
+		},
+		{
+			name:        "caller may override the download URL",
+			opts:        []pulumi.ResourceOption{pulumi.PluginDownloadURL("github://api.github.com/acme/fork")},
+			wantVersion: "",
+			wantURL:     "github://api.github.com/acme/fork",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			identity := PluginIdentityFrom(tt.fallbackVersion, tt.opts...)
-			assert.Equal(t, tt.want, identity.Version)
+			identity := PluginIdentityFrom(tt.opts...)
+			assert.Equal(t, tt.wantVersion, identity.Version)
+			assert.Equal(t, tt.wantURL, identity.DownloadURL)
 		})
 	}
+}
+
+func TestPluginIdentityResourceOptions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unpinned identity emits a URL and no version", func(t *testing.T) {
+		t.Parallel()
+
+		snapshot, err := pulumi.NewResourceOptions(PluginIdentityFrom().ResourceOptions()...)
+		require.NoError(t, err)
+		assert.Equal(t, PluginDownloadURL, snapshot.PluginDownloadURL)
+		assert.Empty(t, snapshot.Version,
+			"a versioned registration is resolvable only by the exact build that wrote it")
+	})
+
+	t.Run("a pinned identity emits both", func(t *testing.T) {
+		t.Parallel()
+
+		id := PluginIdentityFrom(pulumi.Version("v2.7.1"))
+		snapshot, err := pulumi.NewResourceOptions(id.ResourceOptions()...)
+		require.NoError(t, err)
+		assert.Equal(t, PluginDownloadURL, snapshot.PluginDownloadURL)
+		assert.Equal(t, "2.7.1", snapshot.Version)
+	})
 }

--- a/provider/defangaws/project.go
+++ b/provider/defangaws/project.go
@@ -130,8 +130,9 @@ func (*Project) Construct(
 	}
 
 	// The engine gives Construct the plugin identity for our own package;
-	// children do not inherit it, so carry it to the Build registration.
-	pluginID := common.PluginIdentityFrom(Version, opts)
+	// children do not inherit it, so carry it to the Build registration. No
+	// version is pinned on purpose — see common.PluginIdentityFrom.
+	pluginID := common.PluginIdentityFrom(opts)
 
 	result, err := buildProject(ctx, name, inputs, pluginID, pulumi.Parent(comp))
 

--- a/provider/defangazure/project.go
+++ b/provider/defangazure/project.go
@@ -525,8 +525,9 @@ func (*Project) Construct(
 	childOpts := []pulumi.ResourceOption{parentOpt}
 
 	// The engine gives Construct the plugin identity for our own package;
-	// children do not inherit it, so carry it to the Build registration.
-	pluginID := common.PluginIdentityFrom(Version, opts)
+	// children do not inherit it, so carry it to the Build registration. No
+	// version is pinned on purpose — see common.PluginIdentityFrom.
+	pluginID := common.PluginIdentityFrom(opts)
 
 	infra, llmModels, err := setupSharedInfra(ctx, name, inputs, parentOpt)
 	if err != nil {

--- a/provider/defanggcp/project.go
+++ b/provider/defanggcp/project.go
@@ -66,8 +66,9 @@ func (*Project) Construct(
 	childOpt := pulumi.Parent(comp)
 
 	// The engine gives Construct the plugin identity for our own package;
-	// children do not inherit it, so carry it to the Build registration.
-	pluginID := common.PluginIdentityFrom(Version, opts)
+	// children do not inherit it, so carry it to the Build registration. No
+	// version is pinned on purpose — see common.PluginIdentityFrom.
+	pluginID := common.PluginIdentityFrom(opts)
 
 	result, err := buildProject(ctx, name, inputs, pluginID, childOpt)
 	if err != nil {

--- a/tests/aws/project_test.go
+++ b/tests/aws/project_test.go
@@ -322,14 +322,20 @@ func TestConstructAwsProjectDuplicatePoliciesDeduped(t *testing.T) {
 }
 
 // TestConstructAwsProjectBuildCarriesPluginIdentity asserts that the Build
-// resource the provider registers for itself tells the engine both where to
-// fetch the plugin from and which version of it to use. Registrations that go
-// through a generated SDK get both for free; the ones we make with a raw
-// ctx.RegisterResource do not, and omitting them strands the stack on destroy.
-// See common.PluginIdentityFrom.
+// resource the provider registers for itself tells the engine where to fetch
+// the plugin from, and that it pins no version. Registrations that go through a
+// generated SDK get the URL for free; the ones we make with a raw
+// ctx.RegisterResource do not, and omitting it strands the stack on any
+// operation run from a workspace whose plugin cache is empty.
+//
+// The version has to stay empty even when this build carries one. A pinned
+// version is recorded in the checkpoint and can afterwards only be resolved by
+// a plugin of exactly that version — which, for every build except a tagged
+// release, names a GitHub release that does not exist. See
+// common.PluginIdentityFrom.
 func TestConstructAwsProjectBuildCarriesPluginIdentity(t *testing.T) {
-	// Pin a version the way the linker does for a release build, so the
-	// assertion covers the version as well as the URL.
+	// Stamp a version the way the linker does, to prove it does not leak into
+	// the registration.
 	prev := defangaws.Version
 	defangaws.Version = "9.9.9"
 	t.Cleanup(func() { defangaws.Version = prev })
@@ -352,7 +358,7 @@ func TestConstructAwsProjectBuildCarriesPluginIdentity(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	tracker.AssertOwnCustomResourcesCarryPluginIdentity(t, common.PluginDownloadURL, "9.9.9")
+	tracker.AssertOwnCustomResourcesCarryPluginIdentity(t, common.PluginDownloadURL, "")
 }
 
 // TestConstructAwsProjectPrivateZoneForcesDestroy pins forceDestroy on the

--- a/tests/azure/project_test.go
+++ b/tests/azure/project_test.go
@@ -183,14 +183,20 @@ func TestConstructAzureProjectServiceWithPoliciesGrantsRoles(t *testing.T) {
 }
 
 // TestConstructAzureProjectBuildCarriesPluginIdentity asserts that the Build
-// resource the provider registers for itself tells the engine both where to
-// fetch the plugin from and which version of it to use. Registrations that go
-// through a generated SDK get both for free; the ones we make with a raw
-// ctx.RegisterResource do not, and omitting them strands the stack on destroy.
-// See common.PluginIdentityFrom.
+// resource the provider registers for itself tells the engine where to fetch
+// the plugin from, and that it pins no version. Registrations that go through a
+// generated SDK get the URL for free; the ones we make with a raw
+// ctx.RegisterResource do not, and omitting it strands the stack on any
+// operation run from a workspace whose plugin cache is empty.
+//
+// The version has to stay empty even when this build carries one. A pinned
+// version is recorded in the checkpoint and can afterwards only be resolved by
+// a plugin of exactly that version — which, for every build except a tagged
+// release, names a GitHub release that does not exist. See
+// common.PluginIdentityFrom.
 func TestConstructAzureProjectBuildCarriesPluginIdentity(t *testing.T) {
-	// Pin a version the way the linker does for a release build, so the
-	// assertion covers the version as well as the URL.
+	// Stamp a version the way the linker does, to prove it does not leak into
+	// the registration.
 	prev := defangazure.Version
 	defangazure.Version = "9.9.9"
 	t.Cleanup(func() { defangazure.Version = prev })
@@ -210,5 +216,5 @@ func TestConstructAzureProjectBuildCarriesPluginIdentity(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	tracker.AssertOwnCustomResourcesCarryPluginIdentity(t, common.PluginDownloadURL, "9.9.9")
+	tracker.AssertOwnCustomResourcesCarryPluginIdentity(t, common.PluginDownloadURL, "")
 }

--- a/tests/gcp/project_test.go
+++ b/tests/gcp/project_test.go
@@ -1314,14 +1314,20 @@ func TestConstructGcpProjectDuplicatePoliciesDeduped(t *testing.T) {
 }
 
 // TestConstructGcpProjectBuildCarriesPluginIdentity asserts that the Build
-// resource the provider registers for itself tells the engine both where to
-// fetch the plugin from and which version of it to use. Registrations that go
-// through a generated SDK get both for free; the ones we make with a raw
-// ctx.RegisterResource do not, and omitting them strands the stack on destroy.
-// See common.PluginIdentityFrom.
+// resource the provider registers for itself tells the engine where to fetch
+// the plugin from, and that it pins no version. Registrations that go through a
+// generated SDK get the URL for free; the ones we make with a raw
+// ctx.RegisterResource do not, and omitting it strands the stack on any
+// operation run from a workspace whose plugin cache is empty.
+//
+// The version has to stay empty even when this build carries one. A pinned
+// version is recorded in the checkpoint and can afterwards only be resolved by
+// a plugin of exactly that version — which, for every build except a tagged
+// release, names a GitHub release that does not exist. See
+// common.PluginIdentityFrom.
 func TestConstructGcpProjectBuildCarriesPluginIdentity(t *testing.T) {
-	// Pin a version the way the linker does for a release build, so the
-	// assertion covers the version as well as the URL.
+	// Stamp a version the way the linker does, to prove it does not leak into
+	// the registration.
 	prev := defanggcp.Version
 	defanggcp.Version = "9.9.9"
 	t.Cleanup(func() { defanggcp.Version = prev })
@@ -1345,5 +1351,5 @@ func TestConstructGcpProjectBuildCarriesPluginIdentity(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	tracker.AssertOwnCustomResourcesCarryPluginIdentity(t, common.PluginDownloadURL, "9.9.9")
+	tracker.AssertOwnCustomResourcesCarryPluginIdentity(t, common.PluginDownloadURL, "")
 }

--- a/tests/testutil/plugin_check.go
+++ b/tests/testutil/plugin_check.go
@@ -65,16 +65,22 @@ func (pt *PluginTracker) Records() []PluginRecord {
 }
 
 // AssertOwnCustomResourcesCarryPluginIdentity asserts that every CUSTOM
-// resource we register from one of our own packages tells the engine both
-// where to fetch the plugin from and which version of it to use.
+// resource we register from one of our own packages tells the engine where to
+// fetch the plugin from, and pins the version wantVersion — which for our own
+// registrations is "".
 //
 // Without the URL the engine synthesises a bare default provider and falls
 // back to github.com/pulumi/pulumi-<name>, which does not exist for our
-// packages. Without the version the checkpoint does not record which plugin
-// built the resource, so later operations resolve whatever is newest and pay
-// an unauthenticated GitHub API call to ask what "latest" is. Both faults are
-// invisible during an up and strand the stack on destroy. See
-// common.PluginIdentityFrom.
+// packages: invisible during an up, and it strands the stack on the first
+// operation that has to fetch the plugin.
+//
+// A version is the opposite problem. Pulumi resolves a versioned request by
+// exact match, so a pinned version is written into the checkpoint and can
+// afterwards only be served by a plugin of precisely that version — the build
+// that wrote it, or a GitHub release tagged with it. Every build except a
+// tagged release stamps a version that was never published (the Dockerfile's
+// 0.0.1 placeholder, a pulumictl pre-release string), so pinning one strands
+// the stack permanently. See common.PluginIdentityFrom.
 //
 // Component resources are exempt: the engine deletes them without loading a
 // plugin, so they never trigger the lookup.


### PR DESCRIPTION
## The bug

A stack whose **first** deploy used an unreleased ("alpha") per-commit CD image can never be deployed again — by that image, by a later official image, by anything:

```
error: Could not automatically download and install resource plugin
'pulumi-resource-defang-azure' at version v0.0.1, install the plugin using
`pulumi plugin install resource defang-azure v0.0.1 --server github://api.github.com/DefangLabs/pulumi-defang`:
error downloading provider defang-azure to file: failed to download plugin:
defang-azure-0.0.1: 404 HTTP error fetching plugin from
https://api.github.com/repos/DefangLabs/pulumi-defang/releases/tags/v0.0.1
```

There is no `v0.0.1` and there never will be. `0.0.1` is the Dockerfile's `ARG PROVIDER_VERSION` default. Only `release.yml` overrides it (`PROVIDER_VERSION=${{ github.ref_name }}`); the per-commit "Build Docker Image" job in `test.yml` does not, and neither does a local `make image` (pulumictl pre-release string) or a bare `go build` (empty).

Alpha images are a supported workflow — they are how we validate unreleased provider changes against real projects before cutting a release. Using one should not brick the stack.

## Why it strands the stack

`common.PluginIdentityFrom` fed this build's linker-stamped `Version` to `pulumi.Version` on the `Build` resources each `Project.Construct` registers for itself. A version in a registration is recorded in the checkpoint, in the synthesised default provider's own URN:

```
pulumi:providers:defang-azure::default_0_0_1_github_/api.github.com/DefangLabs/pulumi-defang
```

Every later operation on the resources under it — `up`, `refresh`, `destroy` — has to resolve that provider again (`Deployment.EnsureProvider`; a refresh does it for every resource in the previous state). Pulumi resolves a **versioned** request by *exact* match — `workspace.SelectCompatiblePlugin` is `spec.Version.EQ(*plugin.Version)`, not a range — so it is satisfied only by a locally installed plugin of precisely that version, or by a GitHub release tagged with it.

A CD image bakes exactly one version of the plugin: its own (`pulumi plugin install resource defang-azure ${PROVIDER_VERSION}`). So a pinned version is resolvable by the image that wrote it and **by no other image** — and when the version was never published, by nothing at all, forever.

Note this is a stranding case on **`up`**, not only on `destroy`, which is what the old doc comment reasoned about. Its premise — "resolving the SDK-registered provider has already put the plugin binary in the local cache" — does not hold for a pin: the SDK-registered provider is *versionless* (`SdkVersion` is the zero value, so `PkgResourceDefaultOpts` emits the URL and no version), so it can never warm a specific version. The `Build` resource was the only versioned defang provider reference in the whole checkpoint.

## The fix

`PluginIdentityFrom` now supplies only the download URL, plus a version if a caller *explicitly* pinned one. It no longer falls back to this build's own stamp.

An unversioned registration resolves through `workspace.LegacySelectCompatiblePlugin`, which accepts any locally installed plugin of that name — so every CD image can serve resources it did not create — and falls back to "latest" from the recorded URL when the cache really is empty. The recorded provider URN also stops churning on every version bump. This is exactly what the generated SDKs already do, so the self-registered `Build` resource now agrees with every other resource in the same stack instead of being the one exception.

The URL half of #479 stays. Without it the engine falls back to `github.com/pulumi/pulumi-<name>`, which does not exist for our packages.

## Why the pin's stated benefit does not survive the arithmetic

#479 added the version to save an unauthenticated `api.github.com` call asking what "latest" is, after a cold-cache destroy hit `rate limit exceeded: 403`. But for an organisation other than `pulumi`, the download itself goes through the same rate-limited API endpoint either way — `githubSource.Download` only tries the direct `github.com/.../releases/download/...` URL when `source.organization == "pulumi"`, and otherwise falls through to `downloadViaAPI` → `.../releases/tags/vX`. So a pin saves one request out of two on a cold cache, and between two *released* versions it **adds** a download of the superseded plugin on every upgrade, because the new image does not have it.

Weighed against a permanently unrecoverable stack whenever the stamped version was never published, that is not a trade worth keeping.

## Alternative considered

Keep the pin but skip it for a "placeholder" version (`0.0.1`). Rejected: `0.0.1` is a perfectly well-formed semver, so the test has to be a hard-coded string, and it would still leave `make image` (pulumictl pre-release) and any hand-passed `--build-arg PROVIDER_VERSION=2.9.0` stranding stacks the same way. A provider binary fundamentally cannot know whether its own version was ever published; only `release.yml` knows that. Never pinning is the version of that rule that cannot rot.

## Tests

- `provider/common/plugin_test.go` — rewritten around the new signature: no options pins no version; a caller may still pin one; a pinned `vX.Y.Z` tag is still normalised (#553); `ResourceOptions` emits `pulumi.Version` only when pinned.
- `tests/{aws,gcp,azure}/project_test.go` — the existing per-cloud `PluginIdentity` tests still stamp `Version = "9.9.9"` the way the linker does, and now assert it does **not** reach the registration. Verified they fail if it leaks.
- `make test_unit` and `cd tests && go test -short ./...` green; `golangci-lint run --config=.golangci.yaml ./provider/...` reports nothing in the changed files.

No schema change, so no SDK regeneration.

## Scope notes

- **Already-affected stacks are not repaired by this.** The unresolvable provider entry is in their state; the next operation still tries to load it. Those need state surgery (or, if we ever want it to be automatic, the CD image could additionally cache-install its plugin under `0.0.1` — deliberately not done here, since it is a permanent workaround for a bug fixed at the source).
- Stacks pinned to a **released** version self-heal: the first `up` on a fixed image downloads that real tag once to move the `Build` resources onto the versionless provider, then drops the old provider entry.
- Related but distinct: DefangLabs/defang-mvp#3204 — an AWS stack stuck via the *opposite* shape (a fully bare provider, no URL, resolving to `github.com/pulumi/pulumi-defang-aws`), on `defang cd down`. Same lesson about how state gets permanently wedged; a different code path, still open.
- Concrete repro: a production Azure stack first deployed with a `2.7.0-alpha-<sha>` CD image, then re-deployed by its CI with `allow-upgrade: true` (which picked a newer, official image). Every subsequent deploy failed with the 404 above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QStH89k76yAXefjtzkvTYs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Plugin Resolution**
  - Plugin identities can now remain versionless when no version is explicitly supplied.
  - Caller-provided versions continue to be honored and normalized.
  - Download URLs remain supported and can be customized.
  - Project builds no longer automatically pin provider plugin versions, improving compatibility with dynamically resolved plugins.

- **Documentation**
  - Clarified versionless plugin resolution, caching and API behavior.
  - Documented handling of caller-pinned, `v`-prefixed versions.

- **Tests**
  - Updated coverage to verify versionless identities, custom URLs, and explicit version handling across AWS, Azure, and GCP.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->