### PR TITLE
feat(azure): optional scope on x-defang-policies role assignments

### DIFF
--- a/provider/compose/policies.go
+++ b/provider/compose/policies.go
@@ -20,7 +20,37 @@ var (
 	// different cloud: there is no cross-cloud filtering.
 	ErrPolicyForeignCloud = errors.New(
 		"use a ${VAR} entry whose per-stack value carries the identifier for the targeted cloud")
+	// ErrPolicyMalformedScope rejects a scoped entry with an empty half:
+	// "Contributor@" names no scope, "@subscription" names no role.
+	ErrPolicyMalformedScope = errors.New(
+		"a scoped policy is written ROLE@SCOPE, where SCOPE is `subscription` or a full Azure scope resource ID")
 )
+
+const (
+	// PolicyScopeSeparator separates an entry's role from the scope the role
+	// is granted at: "Contributor@subscription". Azure-only syntax, because
+	// Azure is the only one of the three clouds where a role is a capability
+	// list with no reach of its own — an AWS managed policy applies wherever
+	// it is attached, and a GCP role binds at the project.
+	PolicyScopeSeparator = "@"
+	// PolicyScopeSubscription grants at the whole subscription the deployment
+	// runs in, rather than at the project's own resource group. Needed by a
+	// service that manages resources outside its project: creating a resource
+	// group is a write at subscription scope, which a resource-group-scoped
+	// Contributor cannot do however broad the role is.
+	PolicyScopeSubscription = "subscription"
+)
+
+// SplitPolicyScope splits "ROLE@SCOPE" into the role and the scope. An entry
+// with no separator yields an empty scope, which the provider reads as its own
+// default (on Azure, the project's resource group). Splits at the LAST
+// separator, so a custom role whose own name contains one still parses.
+func SplitPolicyScope(entry string) (string, string) {
+	if i := strings.LastIndex(entry, PolicyScopeSeparator); i >= 0 {
+		return entry[:i], entry[i+len(PolicyScopeSeparator):]
+	}
+	return entry, ""
+}
 
 // PolicyCloud identifies which cloud an x-defang-policies entry targets.
 type PolicyCloud string
@@ -81,6 +111,10 @@ func NormalizePolicies(entries []string) []string {
 // current cloud.
 func ClassifyPolicy(entry string) PolicyCloud {
 	switch {
+	case strings.Contains(entry, PolicyScopeSeparator):
+		// Only Azure takes a scope, so the suffix identifies the cloud on its
+		// own — including for a bare role name that would otherwise be "any".
+		return PolicyCloudAzure
 	case strings.HasPrefix(entry, "arn:"):
 		return PolicyCloudAWS
 	case strings.HasPrefix(entry, "roles/"),
@@ -110,6 +144,14 @@ func ValidatePolicies(cloud PolicyCloud, policies []string) error {
 		if c := ClassifyPolicy(entry); c != cloud && c != PolicyCloudAny {
 			return fmt.Errorf("x-defang-policies entry %q is a %s identifier but this deployment targets %s: %w",
 				entry, c, cloud, ErrPolicyForeignCloud)
+		}
+		if strings.Contains(entry, PolicyScopeSeparator) {
+			// The scope keywords themselves are the provider's to know; only
+			// the shape is checked here. Which scope a role may be granted at
+			// is the cloud's own answer, reported when the grant is made.
+			if role, scope := SplitPolicyScope(entry); role == "" || scope == "" {
+				return fmt.Errorf("x-defang-policies entry %q: %w", entry, ErrPolicyMalformedScope)
+			}
 		}
 	}
 	return nil

--- a/provider/compose/policies.go
+++ b/provider/compose/policies.go
@@ -44,7 +44,10 @@ const (
 // SplitPolicyScope splits "ROLE@SCOPE" into the role and the scope. An entry
 // with no separator yields an empty scope, which the provider reads as its own
 // default (on Azure, the project's resource group). Splits at the LAST
-// separator, so a custom role whose own name contains one still parses.
+// separator, so a scoped custom role whose own name contains one still parses
+// ("team@corp reader@subscription"). An unscoped Azure role whose name
+// contains "@" cannot be written as a bare name — it would read as a scope —
+// so name it by its full role-definition ID instead.
 func SplitPolicyScope(entry string) (string, string) {
 	if i := strings.LastIndex(entry, PolicyScopeSeparator); i >= 0 {
 		return entry[:i], entry[i+len(PolicyScopeSeparator):]
@@ -111,16 +114,19 @@ func NormalizePolicies(entries []string) []string {
 // current cloud.
 func ClassifyPolicy(entry string) PolicyCloud {
 	switch {
-	case strings.Contains(entry, PolicyScopeSeparator):
-		// Only Azure takes a scope, so the suffix identifies the cloud on its
-		// own — including for a bare role name that would otherwise be "any".
-		return PolicyCloudAzure
 	case strings.HasPrefix(entry, "arn:"):
 		return PolicyCloudAWS
 	case strings.HasPrefix(entry, "roles/"),
 		strings.HasPrefix(entry, "projects/"),
 		strings.HasPrefix(entry, "organizations/"):
 		return PolicyCloudGCP
+	case strings.Contains(entry, PolicyScopeSeparator):
+		// Only Azure takes a scope, so the separator identifies the cloud on
+		// its own — including for a bare role name that would otherwise be
+		// "any". Checked after the qualified AWS and GCP forms, because an AWS
+		// policy name may itself contain "@" (IAM's PolicyName pattern is
+		// [\w+=,.@-]+), which would otherwise read as an Azure scope.
+		return PolicyCloudAzure
 	case strings.HasPrefix(entry, "/"):
 		// Azure role-definition resource IDs: /subscriptions/… or /providers/…
 		return PolicyCloudAzure
@@ -141,14 +147,17 @@ func ValidatePolicies(cloud PolicyCloud, policies []string) error {
 			return fmt.Errorf("x-defang-policies entry %q has an unresolved variable: %w",
 				entry, ErrPolicyUnresolvedVariable)
 		}
-		if c := ClassifyPolicy(entry); c != cloud && c != PolicyCloudAny {
+		c := ClassifyPolicy(entry)
+		if c != cloud && c != PolicyCloudAny {
 			return fmt.Errorf("x-defang-policies entry %q is a %s identifier but this deployment targets %s: %w",
 				entry, c, cloud, ErrPolicyForeignCloud)
 		}
-		if strings.Contains(entry, PolicyScopeSeparator) {
-			// The scope keywords themselves are the provider's to know; only
-			// the shape is checked here. Which scope a role may be granted at
-			// is the cloud's own answer, reported when the grant is made.
+		if c == PolicyCloudAzure && strings.Contains(entry, PolicyScopeSeparator) {
+			// Only an entry whose "@" is a scope separator — not an AWS policy
+			// name that happens to contain one. The scope keywords themselves
+			// are the provider's to know; only the shape is checked here.
+			// Which scope a role may be granted at is the cloud's own answer,
+			// reported when the grant is made.
 			if role, scope := SplitPolicyScope(entry); role == "" || scope == "" {
 				return fmt.Errorf("x-defang-policies entry %q: %w", entry, ErrPolicyMalformedScope)
 			}

--- a/provider/compose/policies.go
+++ b/provider/compose/policies.go
@@ -8,70 +8,26 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var (
-	// ErrPolicyUnresolvedVariable rejects entries still containing `${…}`:
-	// compose variables are interpolated before the project reaches the
-	// provider (a CLI concern, e.g. from the stack's env files), and `defang
-	// config` is deliberately not supported for policies.
-	ErrPolicyUnresolvedVariable = errors.New(
-		"policy variables must be resolved when the compose file is loaded; " +
-			"`defang config` is not supported for policies")
-	// ErrPolicyForeignCloud rejects an identifier whose syntax belongs to a
-	// different cloud: there is no cross-cloud filtering.
-	ErrPolicyForeignCloud = errors.New(
-		"use a ${VAR} entry whose per-stack value carries the identifier for the targeted cloud")
-	// ErrPolicyMalformedScope rejects a scoped entry with an empty half:
-	// "Contributor@" names no scope, "@subscription" names no role.
-	ErrPolicyMalformedScope = errors.New(
-		"a scoped policy is written ROLE@SCOPE, where SCOPE is `subscription` or a full Azure scope resource ID")
-)
-
-const (
-	// PolicyScopeSeparator separates an entry's role from the scope the role
-	// is granted at: "Contributor@subscription". Azure-only syntax, because
-	// Azure is the only one of the three clouds where a role is a capability
-	// list with no reach of its own — an AWS managed policy applies wherever
-	// it is attached, and a GCP role binds at the project.
-	PolicyScopeSeparator = "@"
-	// PolicyScopeSubscription grants at the whole subscription the deployment
-	// runs in, rather than at the project's own resource group. Needed by a
-	// service that manages resources outside its project: creating a resource
-	// group is a write at subscription scope, which a resource-group-scoped
-	// Contributor cannot do however broad the role is.
-	PolicyScopeSubscription = "subscription"
-)
-
-// SplitPolicyScope splits "ROLE@SCOPE" into the role and the scope. An entry
-// with no separator yields an empty scope, which the provider reads as its own
-// default (on Azure, the project's resource group). Splits at the LAST
-// separator, so a scoped custom role whose own name contains one still parses
-// ("team@corp reader@subscription"). An unscoped Azure role whose name
-// contains "@" cannot be written as a bare name — it would read as a scope —
-// so name it by its full role-definition ID instead.
-func SplitPolicyScope(entry string) (string, string) {
-	if i := strings.LastIndex(entry, PolicyScopeSeparator); i >= 0 {
-		return entry[:i], entry[i+len(PolicyScopeSeparator):]
-	}
-	return entry, ""
-}
-
-// PolicyCloud identifies which cloud an x-defang-policies entry targets.
-type PolicyCloud string
-
-const (
-	PolicyCloudAWS   PolicyCloud = "aws"
-	PolicyCloudGCP   PolicyCloud = "gcp"
-	PolicyCloudAzure PolicyCloud = "azure"
-	// PolicyCloudAny is a bare name: a custom policy/role in the current
-	// account/project, applicable on whichever cloud is being deployed.
-	PolicyCloudAny PolicyCloud = "any"
-)
+// ErrPolicyUnresolvedVariable rejects entries still containing `${…}`:
+// compose variables are interpolated before the project reaches the
+// provider (a CLI concern, e.g. from the stack's env files), and `defang
+// config` is deliberately not supported for policies.
+var ErrPolicyUnresolvedVariable = errors.New(
+	"policy variables must be resolved when the compose file is loaded; " +
+		"`defang config` is not supported for policies")
 
 // PolicyList holds x-defang-policies entries. In YAML it accepts a sequence
 // or a single scalar, and entries may hold several comma-separated
 // identifiers — so one `${VAR}` interpolated at compose-load time can carry
 // a variable-length list. Empty entries (a "${VAR:-}" the stack leaves
 // unset) are dropped.
+//
+// What an entry means is the target cloud's business: each provider parses
+// x-defang-policies in its own package (aws.ParsePolicies,
+// gcp.ParsePolicies, azure.ParsePolicies), because a policy identifier is
+// cloud-specific and nothing here can say which cloud a bare name belongs
+// to. This file holds only what is true of every cloud: the YAML shape, and
+// that an entry must be a literal by the time a provider sees it.
 type PolicyList []string
 
 // UnmarshalYAML accepts `x-defang-policies: ${POLICIES}` (scalar) in addition
@@ -108,60 +64,27 @@ func NormalizePolicies(entries []string) []string {
 	return out
 }
 
-// ClassifyPolicy determines the target cloud of an x-defang-policies entry
-// from its qualified form: AWS ARNs, GCP role names, and Azure resource IDs
-// are self-identifying; anything else is a bare name that resolves on the
-// current cloud.
-func ClassifyPolicy(entry string) PolicyCloud {
-	switch {
-	case strings.HasPrefix(entry, "arn:"):
-		return PolicyCloudAWS
-	case strings.HasPrefix(entry, "roles/"),
-		strings.HasPrefix(entry, "projects/"),
-		strings.HasPrefix(entry, "organizations/"):
-		return PolicyCloudGCP
-	case strings.Contains(entry, PolicyScopeSeparator):
-		// Only Azure takes a scope, so the separator identifies the cloud on
-		// its own — including for a bare role name that would otherwise be
-		// "any". Checked after the qualified AWS and GCP forms, because an AWS
-		// policy name may itself contain "@" (IAM's PolicyName pattern is
-		// [\w+=,.@-]+), which would otherwise read as an Azure scope.
-		return PolicyCloudAzure
-	case strings.HasPrefix(entry, "/"):
-		// Azure role-definition resource IDs: /subscriptions/… or /providers/…
-		return PolicyCloudAzure
-	}
-	return PolicyCloudAny
-}
-
-// ValidatePolicies rejects x-defang-policies entries that cannot apply on the
-// given cloud. Entries must be literals by the time they reach the provider:
-// compose variables are interpolated at compose-load time — by the CLI, not
-// by the CD/providers — and `defang config` is deliberately not supported
-// for policies, so an unresolved variable is an error, as is an identifier
-// whose syntax belongs to a different cloud (there is no cross-cloud
-// filtering; vary the variable's per-stack value instead).
-func ValidatePolicies(cloud PolicyCloud, policies []string) error {
+// NormalizeLiteralPolicies normalizes entries and rejects any that is not a
+// literal. Every provider's own ParsePolicies starts here, because compose
+// interpolation is a property of the compose file rather than of any cloud:
+// variables are substituted at compose-load time by the CLI, not by the
+// CD/providers, so a `${…}` still present means the stack had no value for
+// it and the deployment would otherwise attach a policy named after the
+// variable.
+func NormalizeLiteralPolicies(entries []string) ([]string, error) {
+	policies := NormalizePolicies(entries)
 	for _, entry := range policies {
 		if strings.Contains(entry, "${") {
-			return fmt.Errorf("x-defang-policies entry %q has an unresolved variable: %w",
+			return nil, fmt.Errorf("x-defang-policies entry %q has an unresolved variable: %w",
 				entry, ErrPolicyUnresolvedVariable)
 		}
-		c := ClassifyPolicy(entry)
-		if c != cloud && c != PolicyCloudAny {
-			return fmt.Errorf("x-defang-policies entry %q is a %s identifier but this deployment targets %s: %w",
-				entry, c, cloud, ErrPolicyForeignCloud)
-		}
-		if c == PolicyCloudAzure && strings.Contains(entry, PolicyScopeSeparator) {
-			// Only an entry whose "@" is a scope separator — not an AWS policy
-			// name that happens to contain one. The scope keywords themselves
-			// are the provider's to know; only the shape is checked here.
-			// Which scope a role may be granted at is the cloud's own answer,
-			// reported when the grant is made.
-			if role, scope := SplitPolicyScope(entry); role == "" || scope == "" {
-				return fmt.Errorf("x-defang-policies entry %q: %w", entry, ErrPolicyMalformedScope)
-			}
-		}
 	}
-	return nil
+	return policies, nil
 }
+
+// PolicyVarHint is the tail of a provider's "this is not one of mine" error.
+// A single compose file can target several clouds, and the entries that do
+// not apply to all of them belong in a variable whose per-stack value carries
+// the right identifier — there is no cross-cloud filtering of a literal list.
+const PolicyVarHint = "; a compose file deployed to more than one cloud should carry " +
+	"cloud-specific policies in a ${VAR} whose per-stack value is the identifier for that cloud"

--- a/provider/compose/policies_test.go
+++ b/provider/compose/policies_test.go
@@ -8,34 +8,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func TestClassifyPolicy(t *testing.T) {
-	tests := []struct {
-		entry string
-		want  PolicyCloud
-	}{
-		{"arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess", PolicyCloudAWS},
-		{"arn:aws:iam::123456789012:policy/deployer", PolicyCloudAWS},
-		{"roles/run.developer", PolicyCloudGCP},
-		{"projects/my-proj/roles/deployer", PolicyCloudGCP},
-		{"organizations/123/roles/auditor", PolicyCloudGCP},
-		{"/subscriptions/sub-id/providers/Microsoft.Authorization/roleDefinitions/x", PolicyCloudAzure},
-		{"/providers/Microsoft.Authorization/roleDefinitions/x", PolicyCloudAzure},
-		{"deployer", PolicyCloudAny},
-		{"AmazonS3ReadOnlyAccess", PolicyCloudAny},
-		// A scope suffix is Azure-only syntax, so it decides the cloud even
-		// for a role name that would otherwise be "any".
-		{"Contributor@subscription", PolicyCloudAzure},
-		{"deployer@/subscriptions/sub-id/resourceGroups/rg", PolicyCloudAzure},
-		// …but a qualified identifier wins over it: IAM's PolicyName pattern
-		// ([\w+=,.@-]+) allows "@", so an ARN carrying one is still AWS.
-		{"arn:aws:iam::123456789012:policy/team@corp", PolicyCloudAWS},
-		{"projects/my-proj/roles/team@corp", PolicyCloudGCP},
-	}
-	for _, tt := range tests {
-		assert.Equal(t, tt.want, ClassifyPolicy(tt.entry), "entry %q", tt.entry)
-	}
-}
-
 func TestNormalizePolicies(t *testing.T) {
 	// Comma-separated entries split (one interpolated ${VAR} can carry a list),
 	// whitespace trims, empties drop (a "${VAR:-}" the stack leaves unset).
@@ -55,85 +27,19 @@ func TestNormalizePolicies(t *testing.T) {
 	assert.Nil(t, NormalizePolicies([]string{"", " ", ","}))
 }
 
-func TestValidatePolicies(t *testing.T) {
-	// Current-cloud and bare entries pass.
-	require.NoError(t, ValidatePolicies(PolicyCloudAWS, []string{
-		"arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess", "deployer",
-	}))
-	require.NoError(t, ValidatePolicies(PolicyCloudGCP, []string{
-		"roles/run.developer", "deployer",
-	}))
-
-	// A foreign identifier is a hard error (no cross-cloud filtering).
-	err := ValidatePolicies(PolicyCloudAWS, []string{"roles/run.developer"})
-	require.ErrorContains(t, err, "gcp identifier")
-	require.ErrorContains(t, err, "targets aws")
-	require.ErrorContains(t, err, "${VAR}")
-
-	err = ValidatePolicies(PolicyCloudGCP, []string{"arn:aws:iam::aws:policy/A"})
-	require.ErrorContains(t, err, "aws identifier")
+func TestNormalizeLiteralPolicies(t *testing.T) {
+	// Normalizes like NormalizePolicies, and says nothing about what an entry
+	// means — that is each cloud's ParsePolicies.
+	got, err := NormalizeLiteralPolicies([]string{"roles/run.developer, deployer", ""})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"roles/run.developer", "deployer"}, got)
 
 	// An unresolved variable means compose-load interpolation had no value
 	// for it; defang config is deliberately unsupported for policies.
-	err = ValidatePolicies(PolicyCloudAWS, []string{"${POLICIES}"})
+	_, err = NormalizeLiteralPolicies([]string{"${POLICIES}"})
 	require.ErrorContains(t, err, "unresolved variable")
 	require.ErrorContains(t, err, "defang config")
-
-	// Scoped entries pass on Azure, in both the keyword and the full-ARM-scope
-	// spellings, and are a foreign identifier anywhere else.
-	require.NoError(t, ValidatePolicies(PolicyCloudAzure, []string{
-		"Contributor@subscription",
-		"Storage Blob Data Contributor@/subscriptions/sub/resourceGroups/other",
-		"/providers/Microsoft.Authorization/roleDefinitions/guid@subscription",
-		"Contributor",
-	}))
-	err = ValidatePolicies(PolicyCloudGCP, []string{"Contributor@subscription"})
-	require.ErrorContains(t, err, "azure identifier")
-
-	// A half-written scope is caught here rather than at deploy time.
-	err = ValidatePolicies(PolicyCloudAzure, []string{"Contributor@"})
-	require.ErrorContains(t, err, "ROLE@SCOPE")
-	err = ValidatePolicies(PolicyCloudAzure, []string{"@subscription"})
-	require.ErrorContains(t, err, "ROLE@SCOPE")
-
-	// An AWS policy name containing "@" is not a scoped entry: it must pass on
-	// AWS (in both spellings, including the one that looks half-written) and
-	// stay a foreign identifier on Azure.
-	require.NoError(t, ValidatePolicies(PolicyCloudAWS, []string{
-		"arn:aws:iam::123456789012:policy/team@corp",
-		"arn:aws:iam::123456789012:policy/team@",
-	}))
-	err = ValidatePolicies(PolicyCloudAzure, []string{"arn:aws:iam::123456789012:policy/team@corp"})
-	require.ErrorContains(t, err, "aws identifier")
-}
-
-func TestSplitPolicyScope(t *testing.T) {
-	tests := []struct {
-		entry     string
-		wantRole  string
-		wantScope string
-	}{
-		{"Contributor", "Contributor", ""},
-		{"Contributor@subscription", "Contributor", "subscription"},
-		{
-			"Reader@/subscriptions/sub/resourceGroups/rg",
-			"Reader",
-			"/subscriptions/sub/resourceGroups/rg",
-		},
-		{
-			"/providers/Microsoft.Authorization/roleDefinitions/guid@subscription",
-			"/providers/Microsoft.Authorization/roleDefinitions/guid",
-			"subscription",
-		},
-		// Split at the last separator, so a custom role whose own name
-		// contains one keeps it.
-		{"team@corp reader@subscription", "team@corp reader", "subscription"},
-	}
-	for _, tt := range tests {
-		role, scope := SplitPolicyScope(tt.entry)
-		assert.Equal(t, tt.wantRole, role, "role of %q", tt.entry)
-		assert.Equal(t, tt.wantScope, scope, "scope of %q", tt.entry)
-	}
+	require.ErrorIs(t, err, ErrPolicyUnresolvedVariable)
 }
 
 func TestPolicyListUnmarshalYAML(t *testing.T) {

--- a/provider/compose/policies_test.go
+++ b/provider/compose/policies_test.go
@@ -26,6 +26,10 @@ func TestClassifyPolicy(t *testing.T) {
 		// for a role name that would otherwise be "any".
 		{"Contributor@subscription", PolicyCloudAzure},
 		{"deployer@/subscriptions/sub-id/resourceGroups/rg", PolicyCloudAzure},
+		// …but a qualified identifier wins over it: IAM's PolicyName pattern
+		// ([\w+=,.@-]+) allows "@", so an ARN carrying one is still AWS.
+		{"arn:aws:iam::123456789012:policy/team@corp", PolicyCloudAWS},
+		{"projects/my-proj/roles/team@corp", PolicyCloudGCP},
 	}
 	for _, tt := range tests {
 		assert.Equal(t, tt.want, ClassifyPolicy(tt.entry), "entry %q", tt.entry)
@@ -91,6 +95,16 @@ func TestValidatePolicies(t *testing.T) {
 	require.ErrorContains(t, err, "ROLE@SCOPE")
 	err = ValidatePolicies(PolicyCloudAzure, []string{"@subscription"})
 	require.ErrorContains(t, err, "ROLE@SCOPE")
+
+	// An AWS policy name containing "@" is not a scoped entry: it must pass on
+	// AWS (in both spellings, including the one that looks half-written) and
+	// stay a foreign identifier on Azure.
+	require.NoError(t, ValidatePolicies(PolicyCloudAWS, []string{
+		"arn:aws:iam::123456789012:policy/team@corp",
+		"arn:aws:iam::123456789012:policy/team@",
+	}))
+	err = ValidatePolicies(PolicyCloudAzure, []string{"arn:aws:iam::123456789012:policy/team@corp"})
+	require.ErrorContains(t, err, "aws identifier")
 }
 
 func TestSplitPolicyScope(t *testing.T) {

--- a/provider/compose/policies_test.go
+++ b/provider/compose/policies_test.go
@@ -22,6 +22,10 @@ func TestClassifyPolicy(t *testing.T) {
 		{"/providers/Microsoft.Authorization/roleDefinitions/x", PolicyCloudAzure},
 		{"deployer", PolicyCloudAny},
 		{"AmazonS3ReadOnlyAccess", PolicyCloudAny},
+		// A scope suffix is Azure-only syntax, so it decides the cloud even
+		// for a role name that would otherwise be "any".
+		{"Contributor@subscription", PolicyCloudAzure},
+		{"deployer@/subscriptions/sub-id/resourceGroups/rg", PolicyCloudAzure},
 	}
 	for _, tt := range tests {
 		assert.Equal(t, tt.want, ClassifyPolicy(tt.entry), "entry %q", tt.entry)
@@ -70,6 +74,52 @@ func TestValidatePolicies(t *testing.T) {
 	err = ValidatePolicies(PolicyCloudAWS, []string{"${POLICIES}"})
 	require.ErrorContains(t, err, "unresolved variable")
 	require.ErrorContains(t, err, "defang config")
+
+	// Scoped entries pass on Azure, in both the keyword and the full-ARM-scope
+	// spellings, and are a foreign identifier anywhere else.
+	require.NoError(t, ValidatePolicies(PolicyCloudAzure, []string{
+		"Contributor@subscription",
+		"Storage Blob Data Contributor@/subscriptions/sub/resourceGroups/other",
+		"/providers/Microsoft.Authorization/roleDefinitions/guid@subscription",
+		"Contributor",
+	}))
+	err = ValidatePolicies(PolicyCloudGCP, []string{"Contributor@subscription"})
+	require.ErrorContains(t, err, "azure identifier")
+
+	// A half-written scope is caught here rather than at deploy time.
+	err = ValidatePolicies(PolicyCloudAzure, []string{"Contributor@"})
+	require.ErrorContains(t, err, "ROLE@SCOPE")
+	err = ValidatePolicies(PolicyCloudAzure, []string{"@subscription"})
+	require.ErrorContains(t, err, "ROLE@SCOPE")
+}
+
+func TestSplitPolicyScope(t *testing.T) {
+	tests := []struct {
+		entry     string
+		wantRole  string
+		wantScope string
+	}{
+		{"Contributor", "Contributor", ""},
+		{"Contributor@subscription", "Contributor", "subscription"},
+		{
+			"Reader@/subscriptions/sub/resourceGroups/rg",
+			"Reader",
+			"/subscriptions/sub/resourceGroups/rg",
+		},
+		{
+			"/providers/Microsoft.Authorization/roleDefinitions/guid@subscription",
+			"/providers/Microsoft.Authorization/roleDefinitions/guid",
+			"subscription",
+		},
+		// Split at the last separator, so a custom role whose own name
+		// contains one keeps it.
+		{"team@corp reader@subscription", "team@corp reader", "subscription"},
+	}
+	for _, tt := range tests {
+		role, scope := SplitPolicyScope(tt.entry)
+		assert.Equal(t, tt.wantRole, role, "role of %q", tt.entry)
+		assert.Equal(t, tt.wantScope, scope, "scope of %q", tt.entry)
+	}
 }
 
 func TestPolicyListUnmarshalYAML(t *testing.T) {

--- a/provider/defangaws/aws/ecs.go
+++ b/provider/defangaws/aws/ecs.go
@@ -537,8 +537,8 @@ func CreateECSService(
 		// literals by now — compose variables were interpolated before the
 		// project reached the provider — so anything unresolved or qualified
 		// for a different cloud is a hard error.
-		policies := compose.NormalizePolicies(svc.Policies)
-		if err := compose.ValidatePolicies(compose.PolicyCloudAWS, policies); err != nil {
+		policies, err := ParsePolicies(svc.Policies)
+		if err != nil {
 			return nil, fmt.Errorf("service %s: %w", serviceName, err)
 		}
 		// Dedup repeated entries: the attachment URN embeds policyName(policy),

--- a/provider/defangaws/aws/iam.go
+++ b/provider/defangaws/aws/iam.go
@@ -2,9 +2,11 @@ package aws
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/DefangLabs/pulumi-defang/provider/compose"
 	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/iam"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -207,6 +209,34 @@ func attachObjectStorePolicy(
 		Role:   taskRole.Name,
 		Policy: policyJson,
 	}, opts...)
+}
+
+// ErrPolicyNotAWS rejects an x-defang-policies entry that cannot be an AWS
+// policy identifier.
+var ErrPolicyNotAWS = errors.New(
+	"an AWS policy is a full ARN (arn:…) or the name of a customer-managed policy in this account")
+
+// ParsePolicies normalizes x-defang-policies for an AWS deployment and
+// rejects what AWS cannot name. Anything but a full ARN is a policy name, and
+// IAM policy names cannot contain "/" or ":" (PolicyName is [\w+=,.@-]+), so
+// an entry carrying either is not an AWS identifier at all — most often
+// another cloud's, in a compose file deployed to several. Whether a
+// well-formed name exists is IAM's answer, not this function's.
+func ParsePolicies(entries []string) ([]string, error) {
+	policies, err := compose.NormalizeLiteralPolicies(entries)
+	if err != nil {
+		return nil, err
+	}
+	for _, policy := range policies {
+		if strings.HasPrefix(policy, "arn:") {
+			continue
+		}
+		if strings.ContainsAny(policy, "/:") {
+			return nil, fmt.Errorf("x-defang-policies entry %q: %w%s",
+				policy, ErrPolicyNotAWS, compose.PolicyVarHint)
+		}
+	}
+	return policies, nil
 }
 
 // resolvePolicyArn turns an x-defang-policies entry into a policy ARN. Full

--- a/provider/defangaws/aws/policies_test.go
+++ b/provider/defangaws/aws/policies_test.go
@@ -1,0 +1,45 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/DefangLabs/pulumi-defang/provider/compose"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePolicies(t *testing.T) {
+	// ARNs and bare policy names pass, normalized and with empty entries (a
+	// "${VAR:-}" the stack leaves unset) dropped.
+	got, err := ParsePolicies([]string{
+		"arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess, arn:aws:iam::123456789012:policy/deployer",
+		"",
+		"deployer",
+		// IAM's PolicyName pattern is [\w+=,.@-]+, so "@" is legal in a name.
+		"team@corp",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
+		"arn:aws:iam::123456789012:policy/deployer",
+		"deployer",
+		"team@corp",
+	}, got)
+
+	// A name cannot hold "/" or ":", so an identifier belonging to another
+	// cloud is rejected here rather than sent to IAM as a name.
+	for _, entry := range []string{
+		"roles/run.developer",
+		"projects/my-proj/roles/deployer",
+		"/subscriptions/sub/providers/Microsoft.Authorization/roleDefinitions/x",
+		"Contributor@/subscriptions/sub/resourceGroups/rg",
+	} {
+		_, err := ParsePolicies([]string{entry})
+		require.ErrorIs(t, err, ErrPolicyNotAWS, "entry %q", entry)
+		require.ErrorContains(t, err, "${VAR}", "entry %q", entry)
+	}
+
+	// The literal check is shared, and reported as the compose-level error.
+	_, err = ParsePolicies([]string{"${POLICIES}"})
+	require.ErrorIs(t, err, compose.ErrPolicyUnresolvedVariable)
+}

--- a/provider/defangazure/azure/policies.go
+++ b/provider/defangazure/azure/policies.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
+	"github.com/DefangLabs/pulumi-defang/provider/compose"
 	"github.com/pulumi/pulumi-azure-native-sdk/authorization/v3"
 	"github.com/pulumi/pulumi-azure-native-sdk/managedidentity/v3"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -41,6 +42,48 @@ func isAzureRoleDefinitionID(policy string) bool {
 // `foo' or roleName eq 'Owner`) widens the match to an unintended role.
 func roleNameFilter(policy string) string {
 	return fmt.Sprintf("roleName eq '%s'", strings.ReplaceAll(policy, "'", "''"))
+}
+
+// subscriptionScope reduces a resource group's own ARM ID
+// (/subscriptions/<sub>/resourceGroups/<rg>) to the subscription scope above
+// it. Reading the subscription off the group this deployment already owns
+// makes it right by construction, where azure-native's stack config has to
+// be set to be right (see readLiveCustomDomains, which has to cope with it
+// being unset).
+func subscriptionScope(resourceGroupID string) (string, error) {
+	// A leading "/" makes parts[0] empty: "", "subscriptions", "<sub>", …
+	parts := strings.Split(resourceGroupID, "/")
+	if len(parts) < 3 || !strings.EqualFold(parts[1], "subscriptions") || parts[2] == "" {
+		//nolint:err113 // reports the malformed ID itself, not a case a caller branches on
+		return "", fmt.Errorf("no subscription in resource group ID %q", resourceGroupID)
+	}
+	return "/subscriptions/" + parts[2], nil
+}
+
+// resolvePolicyScope turns the scope half of an x-defang-policies entry into
+// the ARM scope its role assignment is created at.
+//
+// An empty scope — an entry written without one, which is every entry
+// predating this — stays the project's resource group, where all of a
+// project's own Defang-managed resources live. `subscription` widens it to
+// the whole subscription, for a service that manages resources outside its
+// project: creating a resource group is a write at subscription scope, and no
+// role granted on the project's group can authorize it. Anything else must
+// already be a full ARM scope resource ID, which is how a specific group,
+// resource or management group is named.
+func resolvePolicyScope(resourceGroupID pulumi.StringOutput, scope string) (pulumi.StringOutput, error) {
+	switch {
+	case scope == "":
+		return resourceGroupID, nil
+	case scope == compose.PolicyScopeSubscription:
+		return resourceGroupID.ApplyT(subscriptionScope).(pulumi.StringOutput), nil
+	case strings.HasPrefix(scope, "/"):
+		return pulumi.String(scope).ToStringOutput(), nil
+	}
+	//nolint:err113 // the scope is caller-supplied compose data, not a fixed sentinel case
+	return pulumi.StringOutput{}, fmt.Errorf(
+		"unknown policy scope %q: use %q or a full Azure scope resource ID starting with %q",
+		scope, compose.PolicyScopeSubscription, "/")
 }
 
 // resolveRoleDefinitionID turns an x-defang-policies entry into a full
@@ -87,9 +130,11 @@ func resolveRoleDefinitionID(ctx context.Context, scope, policy string) (string,
 // CreatePolicyIdentity creates a per-service user-assigned managed identity
 // and grants it the x-defang-policies roles (already normalized and
 // validated against PolicyCloudAzure by the caller). Roles are capability
-// lists only on Azure — the scope decides what they apply to — so the grant
-// is made at the project's resource group, where every Defang-managed
-// resource for the project lives (see DefangLabs/pulumi-defang#326).
+// lists only on Azure — the scope decides what they apply to — so each entry
+// may name its own scope (`Contributor@subscription`, see
+// resolvePolicyScope), and one that doesn't is granted at the project's
+// resource group, where every Defang-managed resource for the project lives
+// (see DefangLabs/pulumi-defang#326).
 //
 // Returns (nil, nil) when policies is empty: no identity, no role
 // assignments, nothing for the caller to attach — the common case, since
@@ -118,11 +163,19 @@ func CreatePolicyIdentity(
 		return nil, fmt.Errorf("creating policy managed identity: %w", err)
 	}
 
-	scopeID := infra.ResourceGroup.ID().ToStringOutput()
+	resourceGroupID := infra.ResourceGroup.ID().ToStringOutput()
 	var lastAssignmentID pulumi.IDOutput
 	for i, policy := range policies {
+		role, scopeSpec := compose.SplitPolicyScope(policy)
+		scopeID, err := resolvePolicyScope(resourceGroupID, scopeSpec)
+		if err != nil {
+			return nil, fmt.Errorf("granting policy %q: %w", policy, err)
+		}
+		// The role is looked up at the scope it is granted at: a list there
+		// returns both the built-ins (which every scope inherits) and any
+		// custom role defined at or above it.
 		roleDefID := scopeID.ApplyT(func(scope string) (string, error) {
-			return resolveRoleDefinitionID(ctx.Context(), scope, policy)
+			return resolveRoleDefinitionID(ctx.Context(), scope, role)
 		}).(pulumi.StringOutput)
 
 		assignment, err := authorization.NewRoleAssignment(

--- a/provider/defangazure/azure/policies.go
+++ b/provider/defangazure/azure/policies.go
@@ -2,6 +2,7 @@ package azure
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -27,11 +28,62 @@ type PolicyIdentity struct {
 	ClientID pulumi.StringOutput
 }
 
+// ErrPolicyNotAzure rejects an x-defang-policies entry that cannot be an
+// Azure role identifier.
+var ErrPolicyNotAzure = errors.New(
+	"an Azure policy is a role name, or a full role-definition resource ID (/subscriptions/… or " +
+		"/providers/…), each optionally suffixed with @SCOPE where SCOPE is `subscription` or a " +
+		"full Azure scope resource ID")
+
+// policyScopeSubscription grants at the whole subscription the deployment
+// runs in, rather than at the project's own resource group. Needed by a
+// service that manages resources outside its project: creating a resource
+// group is a write at subscription scope, which a resource-group-scoped
+// Contributor cannot do however broad the role is.
+const policyScopeSubscription = "subscription"
+
+// PolicyGrant is one parsed x-defang-policies entry: the role to grant, and
+// the scope to grant it at. An empty Scope means the entry named none, which
+// is the project's own resource group — see resolvePolicyScope.
+type PolicyGrant struct {
+	Role  string
+	Scope string
+}
+
+// ParsePolicies normalizes x-defang-policies for an Azure deployment and
+// splits each entry into its role and scope halves.
+//
+// Azure is the only one of the clouds where a role carries no reach of its
+// own — it is a capability list, and the scope decides what it applies to —
+// so an entry may name one: "Contributor@subscription". The separator is cut
+// at its first occurrence, so an Azure role whose display name contains "@"
+// has to be named by its role-definition ID instead.
+//
+// A role that is not a resource ID is a name to look up, and a role name can
+// hold most characters, so almost the only shape ruled out is one that looks
+// like a path without being one — which is what another cloud's identifier
+// looks like here.
+func ParsePolicies(entries []string) ([]PolicyGrant, error) {
+	policies, err := compose.NormalizeLiteralPolicies(entries)
+	if err != nil {
+		return nil, err
+	}
+	grants := make([]PolicyGrant, 0, len(policies))
+	for _, policy := range policies {
+		role, scope, scoped := strings.Cut(policy, "@")
+		if role == "" || (scoped && scope == "") ||
+			(strings.Contains(role, "/") && !isAzureRoleDefinitionID(role)) {
+			return nil, fmt.Errorf("x-defang-policies entry %q: %w%s",
+				policy, ErrPolicyNotAzure, compose.PolicyVarHint)
+		}
+		grants = append(grants, PolicyGrant{Role: role, Scope: scope})
+	}
+	return grants, nil
+}
+
 // isAzureRoleDefinitionID reports whether policy is already a fully-qualified
-// role-definition resource ID (as opposed to a bare role name to resolve).
-// Mirrors compose.ClassifyPolicy's own Azure test ("/subscriptions/…" or
-// "/providers/…"), so a value that reaches here already passed
-// compose.ValidatePolicies against PolicyCloudAzure.
+// role-definition resource ID (as opposed to a bare role name to resolve):
+// "/subscriptions/…" or "/providers/…".
 func isAzureRoleDefinitionID(policy string) bool {
 	return strings.HasPrefix(policy, "/")
 }
@@ -75,7 +127,7 @@ func resolvePolicyScope(resourceGroupID pulumi.StringOutput, scope string) (pulu
 	switch {
 	case scope == "":
 		return resourceGroupID, nil
-	case scope == compose.PolicyScopeSubscription:
+	case scope == policyScopeSubscription:
 		return resourceGroupID.ApplyT(subscriptionScope).(pulumi.StringOutput), nil
 	case strings.HasPrefix(scope, "/"):
 		return pulumi.String(scope).ToStringOutput(), nil
@@ -83,7 +135,7 @@ func resolvePolicyScope(resourceGroupID pulumi.StringOutput, scope string) (pulu
 	//nolint:err113 // the scope is caller-supplied compose data, not a fixed sentinel case
 	return pulumi.StringOutput{}, fmt.Errorf(
 		"unknown policy scope %q: use %q or a full Azure scope resource ID starting with %q",
-		scope, compose.PolicyScopeSubscription, "/")
+		scope, policyScopeSubscription, "/")
 }
 
 // resolveRoleDefinitionID turns an x-defang-policies entry into a full
@@ -147,7 +199,7 @@ func resolveRoleDefinitionID(ctx context.Context, scope, policy string) (string,
 func CreatePolicyIdentity(
 	ctx *pulumi.Context,
 	serviceName string,
-	policies []string,
+	policies []PolicyGrant,
 	infra *SharedInfra,
 	opts ...pulumi.ResourceOption,
 ) (*PolicyIdentity, error) {
@@ -166,16 +218,15 @@ func CreatePolicyIdentity(
 	resourceGroupID := infra.ResourceGroup.ID().ToStringOutput()
 	var lastAssignmentID pulumi.IDOutput
 	for i, policy := range policies {
-		role, scopeSpec := compose.SplitPolicyScope(policy)
-		scopeID, err := resolvePolicyScope(resourceGroupID, scopeSpec)
+		scopeID, err := resolvePolicyScope(resourceGroupID, policy.Scope)
 		if err != nil {
-			return nil, fmt.Errorf("granting policy %q: %w", policy, err)
+			return nil, fmt.Errorf("granting policy %q: %w", policy.Role, err)
 		}
 		// The role is looked up at the scope it is granted at: a list there
 		// returns both the built-ins (which every scope inherits) and any
 		// custom role defined at or above it.
 		roleDefID := scopeID.ApplyT(func(scope string) (string, error) {
-			return resolveRoleDefinitionID(ctx.Context(), scope, role)
+			return resolveRoleDefinitionID(ctx.Context(), scope, policy.Role)
 		}).(pulumi.StringOutput)
 
 		assignment, err := authorization.NewRoleAssignment(

--- a/provider/defangazure/azure/policies.go
+++ b/provider/defangazure/azure/policies.go
@@ -50,6 +50,15 @@ type PolicyGrant struct {
 	Scope string
 }
 
+// String reconstructs the compose entry this grant was parsed from, so an
+// error names the value its author wrote rather than the struct.
+func (p PolicyGrant) String() string {
+	if p.Scope == "" {
+		return p.Role
+	}
+	return p.Role + "@" + p.Scope
+}
+
 // ParsePolicies normalizes x-defang-policies for an Azure deployment and
 // splits each entry into its role and scope halves.
 //
@@ -220,7 +229,7 @@ func CreatePolicyIdentity(
 	for i, policy := range policies {
 		scopeID, err := resolvePolicyScope(resourceGroupID, policy.Scope)
 		if err != nil {
-			return nil, fmt.Errorf("granting policy %q: %w", policy.Role, err)
+			return nil, fmt.Errorf("granting policy %q: %w", policy, err)
 		}
 		// The role is looked up at the scope it is granted at: a list there
 		// returns both the built-ins (which every scope inherits) and any

--- a/provider/defangazure/azure/policies_test.go
+++ b/provider/defangazure/azure/policies_test.go
@@ -2,6 +2,7 @@ package azure
 
 import (
 	"testing"
+	"time"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/assert"
@@ -48,6 +49,71 @@ func TestRoleNameFilterEscapesQuotes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, roleNameFilter(tt.policy))
 		})
+	}
+}
+
+// TestSubscriptionScope checks the reduction of a resource group's own ARM ID
+// to the subscription scope above it — the source of the `subscription`
+// keyword's scope, chosen so no stack config has to be set for it to be right.
+func TestSubscriptionScope(t *testing.T) {
+	got, err := subscriptionScope("/subscriptions/0000-1111/resourceGroups/rg")
+	require.NoError(t, err)
+	assert.Equal(t, "/subscriptions/0000-1111", got)
+
+	// ARM is inconsistent about the casing of this segment ("resourcegroups"
+	// in the CLI's own URLs), so the match is case-insensitive.
+	got, err = subscriptionScope("/Subscriptions/0000-1111/resourcegroups/rg")
+	require.NoError(t, err)
+	assert.Equal(t, "/subscriptions/0000-1111", got)
+
+	for _, bad := range []string{"", "/", "/subscriptions", "/subscriptions/", "/resourceGroups/rg"} {
+		_, err := subscriptionScope(bad)
+		require.ErrorContains(t, err, "no subscription", "input %q", bad)
+	}
+}
+
+// TestResolvePolicyScope covers the three spellings a scope half can take,
+// plus the rejection of a keyword that is neither.
+func TestResolvePolicyScope(t *testing.T) {
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		rgID := pulumi.String("/subscriptions/0000-1111/resourceGroups/rg").ToStringOutput()
+
+		// No scope: the project's resource group, unchanged from before
+		// scopes existed.
+		scope, err := resolvePolicyScope(rgID, "")
+		require.NoError(t, err)
+		assert.Equal(t, "/subscriptions/0000-1111/resourceGroups/rg", awaitString(t, scope))
+
+		scope, err = resolvePolicyScope(rgID, "subscription")
+		require.NoError(t, err)
+		assert.Equal(t, "/subscriptions/0000-1111", awaitString(t, scope))
+
+		scope, err = resolvePolicyScope(rgID, "/subscriptions/0000-1111/resourceGroups/other")
+		require.NoError(t, err)
+		assert.Equal(t, "/subscriptions/0000-1111/resourceGroups/other", awaitString(t, scope))
+
+		_, err = resolvePolicyScope(rgID, "subscriptions")
+		require.ErrorContains(t, err, "unknown policy scope")
+		return nil
+	}, pulumi.WithMocks("proj", "stack", azureNoopMocks{}))
+	require.NoError(t, err)
+}
+
+// awaitString resolves a StringOutput inside a pulumi.RunErr program, where
+// an ApplyT runs on the engine's own goroutine.
+func awaitString(t *testing.T, out pulumi.StringOutput) string {
+	t.Helper()
+	done := make(chan string, 1)
+	out.ApplyT(func(s string) string {
+		done <- s
+		return s
+	})
+	select {
+	case s := <-done:
+		return s
+	case <-time.After(10 * time.Second):
+		t.Fatal("output never resolved")
+		return ""
 	}
 }
 

--- a/provider/defangazure/azure/policies_test.go
+++ b/provider/defangazure/azure/policies_test.go
@@ -94,6 +94,23 @@ func TestParsePolicies(t *testing.T) {
 	require.ErrorIs(t, err, compose.ErrPolicyUnresolvedVariable)
 }
 
+// TestPolicyGrantString checks that a grant reconstructs the compose entry it
+// was parsed from: the errors raised while granting name it with %q, and the
+// value the author wrote is more useful there than the struct.
+func TestPolicyGrantString(t *testing.T) {
+	assert.Equal(t, "Contributor", PolicyGrant{Role: "Contributor"}.String())
+	assert.Equal(t, "Contributor@subscription",
+		PolicyGrant{Role: "Contributor", Scope: "subscription"}.String())
+	assert.Equal(t, "Reader@/subscriptions/sub/resourceGroups/rg",
+		PolicyGrant{Role: "Reader", Scope: "/subscriptions/sub/resourceGroups/rg"}.String())
+
+	// Round-trips through the parser, which is what makes the reconstruction
+	// worth trusting in an error message.
+	grants, err := ParsePolicies([]string{"Contributor@subscription"})
+	require.NoError(t, err)
+	assert.Equal(t, "Contributor@subscription", grants[0].String())
+}
+
 // TestSubscriptionScope checks the reduction of a resource group's own ARM ID
 // to the subscription scope above it — the source of the `subscription`
 // keyword's scope, chosen so no stack config has to be set for it to be right.

--- a/provider/defangazure/azure/policies_test.go
+++ b/provider/defangazure/azure/policies_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DefangLabs/pulumi-defang/provider/compose"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -50,6 +52,46 @@ func TestRoleNameFilterEscapesQuotes(t *testing.T) {
 			assert.Equal(t, tt.want, roleNameFilter(tt.policy))
 		})
 	}
+}
+
+func TestParsePolicies(t *testing.T) {
+	// Role names, role-definition IDs, and either with a scope; normalized,
+	// with empty entries (a "${VAR:-}" the stack leaves unset) dropped.
+	const roleDefID = "/subscriptions/sub/providers/Microsoft.Authorization/roleDefinitions/guid"
+	got, err := ParsePolicies([]string{
+		"Contributor@subscription, Storage Blob Data Contributor",
+		"",
+		roleDefID,
+		roleDefID + "@subscription",
+		"Reader@/subscriptions/sub/resourceGroups/other",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []PolicyGrant{
+		{Role: "Contributor", Scope: "subscription"},
+		{Role: "Storage Blob Data Contributor"},
+		{Role: roleDefID},
+		{Role: roleDefID, Scope: "subscription"},
+		{Role: "Reader", Scope: "/subscriptions/sub/resourceGroups/other"},
+	}, got)
+
+	// A role name is free-form, so the shapes ruled out are the ones that
+	// look like a path without being a role-definition ID — which is what
+	// another cloud's identifier looks like here — plus a half-written scope.
+	for _, entry := range []string{
+		"arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
+		"roles/run.developer",
+		"projects/my-proj/roles/deployer",
+		"Contributor@",
+		"@subscription",
+	} {
+		_, err := ParsePolicies([]string{entry})
+		require.ErrorIs(t, err, ErrPolicyNotAzure, "entry %q", entry)
+		require.ErrorContains(t, err, "@SCOPE", "entry %q", entry)
+	}
+
+	// The literal check is shared, and reported as the compose-level error.
+	_, err = ParsePolicies([]string{"${POLICIES}"})
+	require.ErrorIs(t, err, compose.ErrPolicyUnresolvedVariable)
 }
 
 // TestSubscriptionScope checks the reduction of a resource group's own ARM ID

--- a/provider/defangazure/service.go
+++ b/provider/defangazure/service.go
@@ -144,10 +144,10 @@ func createContainerApp(
 	dnsZones map[string]string,
 ) error {
 	// Entries a stack leaves empty ("${EXTRA:-}") normalize away, so a compose
-	// file parameterized per stack still deploys here; a foreign-cloud
-	// literal gets the validation error (with the ${VAR} hint).
-	policies := compose.NormalizePolicies(svc.Policies)
-	if err := compose.ValidatePolicies(compose.PolicyCloudAzure, policies); err != nil {
+	// file parameterized per stack still deploys here; one that is not an
+	// Azure identifier gets the parse error (with the ${VAR} hint).
+	policies, err := azure.ParsePolicies(svc.Policies)
+	if err != nil {
 		return fmt.Errorf("service %s: %w", serviceName, err)
 	}
 	policyIdentity, err := azure.CreatePolicyIdentity(ctx, serviceName, policies, infra, pulumi.Parent(comp))

--- a/provider/defanggcp/gcp/iam.go
+++ b/provider/defanggcp/gcp/iam.go
@@ -3,6 +3,7 @@ package gcp
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/DefangLabs/pulumi-defang/provider/compose"
@@ -16,25 +17,41 @@ var ErrPolicyNotGCP = errors.New(
 	"a GCP role is `roles/…`, `projects/…/roles/…`, `organizations/…/roles/…`, " +
 		"or the bare ID of a custom role in this project")
 
+// gcpRoleID matches the ID half of a role name: a GCP role ID holds letters,
+// digits, "_" and "." and nothing else, which is what makes another cloud's
+// identifier recognizable as not-a-role here.
+var gcpRoleID = regexp.MustCompile(`^[A-Za-z0-9_.]+$`)
+
+// isGCPRole reports whether policy is a role this deployment could bind:
+// a predefined `roles/<id>`, a custom `projects/<project>/roles/<id>` or
+// `organizations/<org>/roles/<id>`, or the bare `<id>` of a custom role in
+// the deployment's own project. Whether the role exists is IAM's answer, not
+// this function's; the shape is ours, because a value that is not a role
+// name at all would otherwise be bound as one.
+func isGCPRole(policy string) bool {
+	parts := strings.Split(policy, "/")
+	switch {
+	case len(parts) == 1: // bare custom-role ID
+		return gcpRoleID.MatchString(parts[0])
+	case len(parts) == 2: // roles/<id>
+		return parts[0] == "roles" && gcpRoleID.MatchString(parts[1])
+	case len(parts) == 4: // projects|organizations/<parent>/roles/<id>
+		return (parts[0] == "projects" || parts[0] == "organizations") &&
+			parts[1] != "" && parts[2] == "roles" && gcpRoleID.MatchString(parts[3])
+	}
+	return false
+}
+
 // ParsePolicies normalizes x-defang-policies for a GCP deployment and rejects
-// what GCP cannot name. A qualified role has one of the three known prefixes;
-// anything else is a bare custom-role ID, whose character set (letters,
-// digits, "_" and ".") admits neither "/" nor ":" — so an entry carrying
-// either is not a GCP identifier at all, most often another cloud's in a
-// compose file deployed to several. Whether the role exists is IAM's answer,
-// not this function's.
+// what GCP cannot name — most often another cloud's identifier, in a compose
+// file deployed to several.
 func ParsePolicies(entries []string) ([]string, error) {
 	policies, err := compose.NormalizeLiteralPolicies(entries)
 	if err != nil {
 		return nil, err
 	}
 	for _, policy := range policies {
-		if strings.HasPrefix(policy, "roles/") ||
-			strings.HasPrefix(policy, "projects/") ||
-			strings.HasPrefix(policy, "organizations/") {
-			continue
-		}
-		if strings.ContainsAny(policy, "/:") {
+		if !isGCPRole(policy) {
 			return nil, fmt.Errorf("x-defang-policies entry %q: %w%s",
 				policy, ErrPolicyNotGCP, compose.PolicyVarHint)
 		}

--- a/provider/defanggcp/gcp/iam.go
+++ b/provider/defanggcp/gcp/iam.go
@@ -1,11 +1,46 @@
 package gcp
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 
+	"github.com/DefangLabs/pulumi-defang/provider/compose"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/projects"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
+
+// ErrPolicyNotGCP rejects an x-defang-policies entry that cannot be a GCP
+// role name.
+var ErrPolicyNotGCP = errors.New(
+	"a GCP role is `roles/…`, `projects/…/roles/…`, `organizations/…/roles/…`, " +
+		"or the bare ID of a custom role in this project")
+
+// ParsePolicies normalizes x-defang-policies for a GCP deployment and rejects
+// what GCP cannot name. A qualified role has one of the three known prefixes;
+// anything else is a bare custom-role ID, whose character set (letters,
+// digits, "_" and ".") admits neither "/" nor ":" — so an entry carrying
+// either is not a GCP identifier at all, most often another cloud's in a
+// compose file deployed to several. Whether the role exists is IAM's answer,
+// not this function's.
+func ParsePolicies(entries []string) ([]string, error) {
+	policies, err := compose.NormalizeLiteralPolicies(entries)
+	if err != nil {
+		return nil, err
+	}
+	for _, policy := range policies {
+		if strings.HasPrefix(policy, "roles/") ||
+			strings.HasPrefix(policy, "projects/") ||
+			strings.HasPrefix(policy, "organizations/") {
+			continue
+		}
+		if strings.ContainsAny(policy, "/:") {
+			return nil, fmt.Errorf("x-defang-policies entry %q: %w%s",
+				policy, ErrPolicyNotGCP, compose.PolicyVarHint)
+		}
+	}
+	return policies, nil
+}
 
 // ResolvePolicyRole turns an x-defang-policies entry into an IAM role name for
 // a project-level binding. Qualified names (`roles/…`, `projects/…/roles/…`,

--- a/provider/defanggcp/gcp/policies_test.go
+++ b/provider/defanggcp/gcp/policies_test.go
@@ -25,13 +25,22 @@ func TestParsePolicies(t *testing.T) {
 		"deployer",
 	}, got)
 
-	// A bare role ID holds letters, digits, "_" and "." only, so an
-	// identifier belonging to another cloud is rejected here rather than
-	// resolved into "projects/<proj>/roles/<other cloud's ARN>".
+	// A role ID holds letters, digits, "_" and "." only, and a qualified
+	// name is one of exactly three shapes — so anything else is rejected
+	// here rather than resolved into "projects/<proj>/roles/<not a role>".
 	for _, entry := range []string{
 		"arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
 		"/subscriptions/sub/providers/Microsoft.Authorization/roleDefinitions/x",
 		"Contributor@/subscriptions/sub/resourceGroups/rg",
+		// An Azure scope suffix holds no "/" or ":", so the shape of the ID
+		// itself is what rules it out rather than a stray character.
+		"Contributor@subscription",
+		// Prefix-only values that are not role paths: a bare prefix match
+		// would have let these through to be bound as roles.
+		"projects/my-proj",
+		"roles/",
+		"organizations/123/roles/",
+		"projects/my-proj/deployer",
 	} {
 		_, err := ParsePolicies([]string{entry})
 		require.ErrorIs(t, err, ErrPolicyNotGCP, "entry %q", entry)

--- a/provider/defanggcp/gcp/policies_test.go
+++ b/provider/defanggcp/gcp/policies_test.go
@@ -1,0 +1,44 @@
+package gcp
+
+import (
+	"testing"
+
+	"github.com/DefangLabs/pulumi-defang/provider/compose"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePolicies(t *testing.T) {
+	// The three qualified forms and a bare custom-role ID pass, normalized
+	// and with empty entries (a "${VAR:-}" the stack leaves unset) dropped.
+	got, err := ParsePolicies([]string{
+		"roles/run.developer, projects/my-proj/roles/deployer",
+		"",
+		"organizations/123/roles/auditor",
+		"deployer",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"roles/run.developer",
+		"projects/my-proj/roles/deployer",
+		"organizations/123/roles/auditor",
+		"deployer",
+	}, got)
+
+	// A bare role ID holds letters, digits, "_" and "." only, so an
+	// identifier belonging to another cloud is rejected here rather than
+	// resolved into "projects/<proj>/roles/<other cloud's ARN>".
+	for _, entry := range []string{
+		"arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
+		"/subscriptions/sub/providers/Microsoft.Authorization/roleDefinitions/x",
+		"Contributor@/subscriptions/sub/resourceGroups/rg",
+	} {
+		_, err := ParsePolicies([]string{entry})
+		require.ErrorIs(t, err, ErrPolicyNotGCP, "entry %q", entry)
+		require.ErrorContains(t, err, "${VAR}", "entry %q", entry)
+	}
+
+	// The literal check is shared, and reported as the compose-level error.
+	_, err = ParsePolicies([]string{"${POLICIES}"})
+	require.ErrorIs(t, err, compose.ErrPolicyUnresolvedVariable)
+}

--- a/provider/defanggcp/service.go
+++ b/provider/defanggcp/service.go
@@ -201,8 +201,8 @@ func grantPolicies(
 	infra *providergcp.SharedInfra,
 	opts []pulumi.ResourceOption,
 ) ([]pulumi.Resource, error) {
-	policies = compose.NormalizePolicies(policies)
-	if err := compose.ValidatePolicies(compose.PolicyCloudGCP, policies); err != nil {
+	policies, err := providergcp.ParsePolicies(policies)
+	if err != nil {
 		return nil, fmt.Errorf("service %s: %w", serviceName, err)
 	}
 	if len(policies) == 0 {

--- a/tests/aws/project_test.go
+++ b/tests/aws/project_test.go
@@ -232,8 +232,8 @@ func TestConstructAwsProjectRejectsForeignPolicies(t *testing.T) {
 			})),
 		}),
 	})
-	require.ErrorContains(t, err, "gcp identifier")
-	require.ErrorContains(t, err, "targets aws")
+	require.ErrorContains(t, err, "is a full ARN")
+	require.ErrorContains(t, err, "${VAR}")
 }
 
 func TestConstructAwsProjectPoliciesNormalized(t *testing.T) {

--- a/tests/azure/project_test.go
+++ b/tests/azure/project_test.go
@@ -124,8 +124,8 @@ func TestConstructAzureProjectRejectsForeignPolicies(t *testing.T) {
 		}),
 	})
 
-	require.ErrorContains(t, err, "aws identifier")
-	require.ErrorContains(t, err, "targets azure")
+	require.ErrorContains(t, err, "an Azure policy is")
+	require.ErrorContains(t, err, "${VAR}")
 }
 
 func TestConstructAzureProjectEmptyPoliciesDeploy(t *testing.T) {

--- a/tests/azure/project_test.go
+++ b/tests/azure/project_test.go
@@ -234,14 +234,18 @@ func TestConstructAzureProjectServicePoliciesHonorScope(t *testing.T) {
 
 	mu.Lock()
 	defer mu.Unlock()
+	// Both predicates also match on the role, so an unrelated grant made by
+	// the shared infra (Key Vault, ACR) cannot stand in for either entry.
 	wide := findTypeWhere(records, "azure-native:authorization:RoleAssignment", func(m property.Map) bool {
-		return m.Get("scope").AsString() == "/subscriptions/"+subID
+		return m.Get("roleDefinitionId").AsString() == roleDefID &&
+			m.Get("scope").AsString() == "/subscriptions/"+subID
 	})
 	require.NotNil(t, wide, "expected a subscription-scoped RoleAssignment for the @subscription entry")
 
 	narrow := findTypeWhere(records, "azure-native:authorization:RoleAssignment", func(m property.Map) bool {
 		scope := m.Get("scope").AsString()
-		return scope != "/subscriptions/"+subID && strings.Contains(scope, "/resourceGroups/")
+		return m.Get("roleDefinitionId").AsString() == roleDefID &&
+			scope != "/subscriptions/"+subID && strings.Contains(scope, "/resourceGroups/")
 	})
 	require.NotNil(t, narrow, "expected the unscoped entry to stay on the project resource group")
 

--- a/tests/azure/project_test.go
+++ b/tests/azure/project_test.go
@@ -6,6 +6,7 @@ package azure
 // App, Postgres, etc.) lives in their own dedicated test files.
 
 import (
+	"strings"
 	"sync"
 	"testing"
 
@@ -180,6 +181,73 @@ func TestConstructAzureProjectServiceWithPoliciesGrantsRoles(t *testing.T) {
 		return m.Get("roleDefinitionId").AsString() == roleDefID
 	})
 	require.NotNil(t, found, "expected a RoleAssignment for the x-defang-policies entry")
+}
+
+// TestConstructAzureProjectServicePoliciesHonorScope covers the scope half of
+// an x-defang-policies entry: `ROLE@subscription` is granted at the whole
+// subscription, an entry with no scope keeps landing on the project's resource
+// group, and both grants go to the same service identity. This is what a
+// service that manages resources outside its own project needs — creating a
+// resource group is a write at subscription scope (DefangLabs/station#41).
+func TestConstructAzureProjectServicePoliciesHonorScope(t *testing.T) {
+	const (
+		roleDefID = "/subscriptions/sub/providers/Microsoft.Authorization/roleDefinitions/deployer-guid"
+		subID     = "0000-1111-2222"
+	)
+
+	var mu sync.Mutex
+	var records []resourceRecord
+	mock := &integration.MockResourceMonitor{
+		NewResourceF: func(args integration.MockResourceArgs) (string, property.Map, error) {
+			mu.Lock()
+			records = append(records, resourceRecord{
+				typ:    string(args.TypeToken),
+				name:   args.Name,
+				inputs: args.Inputs,
+			})
+			mu.Unlock()
+			// The subscription is read off the project resource group's own
+			// ARM ID, so this mock has to answer with one — collectResources
+			// returns the resource's name as its ID, which has no
+			// subscription in it.
+			if string(args.TypeToken) == "azure-native:resources:ResourceGroup" {
+				return "/subscriptions/" + subID + "/resourceGroups/" + args.Name, args.Inputs, nil
+			}
+			return args.Name, args.Inputs, nil
+		},
+	}
+	server := testutil.MakeAzureTestServer(integration.WithMocks(mock))
+
+	_, err := server.Construct(p.ConstructRequest{
+		Urn: testutil.AzureURN("Project"),
+		Inputs: testutil.ServicesMap(map[string]property.Value{
+			"redeployer": property.New(property.NewMap(map[string]property.Value{
+				"image": property.New("defangio/cli:latest"),
+				"policies": property.New(property.NewArray([]property.Value{
+					property.New(roleDefID + "@subscription"),
+					property.New(roleDefID),
+				})),
+			})),
+		}),
+	})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	wide := findTypeWhere(records, "azure-native:authorization:RoleAssignment", func(m property.Map) bool {
+		return m.Get("scope").AsString() == "/subscriptions/"+subID
+	})
+	require.NotNil(t, wide, "expected a subscription-scoped RoleAssignment for the @subscription entry")
+
+	narrow := findTypeWhere(records, "azure-native:authorization:RoleAssignment", func(m property.Map) bool {
+		scope := m.Get("scope").AsString()
+		return scope != "/subscriptions/"+subID && strings.Contains(scope, "/resourceGroups/")
+	})
+	require.NotNil(t, narrow, "expected the unscoped entry to stay on the project resource group")
+
+	// One identity, both grants: the scope widens the reach of a role, it does
+	// not split the service into two principals.
+	require.Equal(t, wide.inputs.Get("principalId").AsString(), narrow.inputs.Get("principalId").AsString())
 }
 
 // TestConstructAzureProjectBuildCarriesPluginIdentity asserts that the Build

--- a/tests/gcp/project_test.go
+++ b/tests/gcp/project_test.go
@@ -1253,8 +1253,8 @@ func TestConstructGcpProjectRejectsForeignPolicies(t *testing.T) {
 			})),
 		}),
 	})
-	require.ErrorContains(t, err, "aws identifier")
-	require.ErrorContains(t, err, "targets gcp")
+	require.ErrorContains(t, err, "a GCP role is")
+	require.ErrorContains(t, err, "${VAR}")
 }
 
 func TestConstructGcpProjectPolicyRepeatingPlatformRoleDoesNotCollide(t *testing.T) {


### PR DESCRIPTION
## Why

An Azure role is a capability list with no reach of its own — the scope decides what it applies to. #552 therefore granted every `x-defang-policies` role at the project's resource group, where a project's own Defang-managed resources live. That is right for a service reaching its own project's resources, and insufficient for one that manages resources elsewhere in the subscription.

The motivating case is DefangLabs/station#41: its provisioner creates one resource group per Station (`PUT /subscriptions/{sub}/resourcegroups/station-<uuid>`). That is a write at *subscription* scope, and no role granted on the project's own group can authorize it, however broad the role. Without this, station keeps a Contributor service principal and a client secret in config purely because the managed identity cannot be granted wide enough.

This is also where the AWS analogy stops: an AWS managed policy applies wherever it is attached, so `x-defang-policies` on AWS needs no scope at all.

## What

An entry may now carry an optional scope:

```yaml
services:
  provisioner:
    x-defang-policies:
      - Contributor@subscription                                   # the whole subscription
      - Storage Blob Data Contributor                              # the project's resource group (unchanged)
      - Reader@/subscriptions/<sub>/resourceGroups/shared          # a specific existing scope
```

`SCOPE` is either the keyword `subscription` or a full ARM scope resource ID. **An entry without a scope keeps today's behaviour exactly**, so no existing compose file changes meaning.

- The role is resolved at the scope it is granted at, so a custom role defined at or above that scope resolves the same way a built-in does.
- The subscription is read off the project resource group's own ARM ID, not from azure-native's stack config, so it is right by construction and needs nothing configured (`readLiveCustomDomains` has to cope with that config being unset).
- Entries stay plain strings — **no schema or SDK regeneration**.

## Policy parsing moved into each cloud (review feedback)

Per @lionello on this PR: a policy identifier is inherently cloud-specific, so classifying an entry centrally and then checking the answer against the target cloud was the wrong shape — it collected every cloud's syntax into one shared switch that each new cloud has to be added to, and a fourth is on the way (#234).

Each provider now parses its own entries, next to the resolver it already had:

| package | function | beside |
|---|---|---|
| `defangaws/aws` | `ParsePolicies` | `resolvePolicyArn` |
| `defanggcp/gcp` | `ParsePolicies` | `ResolvePolicyRole` |
| `defangazure/azure` | `ParsePolicies` → `[]PolicyGrant{Role, Scope}` | `resolveRoleDefinitionID` |

`PolicyCloud`, `ClassifyPolicy`, `ValidatePolicies` and `SplitPolicyScope` are deleted. `provider/compose` keeps only what is true of every cloud: the YAML shape (`PolicyList`, `NormalizePolicies`) and that an entry must be a literal by the time a provider sees it (`NormalizeLiteralPolicies`) — compose interpolation is a property of the compose file, not of a cloud.

The early, specific error for a compose file deployed to several clouds survives without a cross-cloud table, because it now falls out of each grammar on its own terms: an IAM policy name cannot contain `/` or `:`, a GCP bare role ID cannot either, and an Azure role that is not a role-definition ID cannot look like a path. The `${VAR}` hint is shared as `compose.PolicyVarHint`, which is advice about compose files rather than about any cloud. Adding a cloud is now adding one function in that cloud's package.

Which scopes a role may actually be granted at stays the cloud's answer, reported when the grant is made — per AGENTS.md, no mirrored validation here.

## Testing

- `provider/compose`: normalization, the literal check, and the YAML shapes.
- `provider/defangaws/aws`, `provider/defanggcp/gcp`, `provider/defangazure/azure`: a `ParsePolicies` table each — the forms that pass, the other clouds' identifiers rejected with the `${VAR}` hint, and the shared unresolved-variable error. Azure additionally covers scope splitting, `subscriptionScope` (including ARM's inconsistent casing of `resourceGroups`), and `resolvePolicyScope` across all three spellings plus an unknown keyword.
- `tests/azure`: a Project construct with both a `@subscription` entry and an unscoped one asserts two `RoleAssignment`s — one at `/subscriptions/<sub>`, one on the project resource group — matching on role as well as scope, and sharing one principal. The mock returns an ARM-shaped ID for the resource group, which the shared `collectResources` mock does not.
- The three integration tests that asserted the old cross-cloud message now assert the owning cloud's own error.

`make test_unit`, `cd tests && go test -short ./...` and `golangci-lint` at CI's pinned v2.11.4 are all clean.

## Operator note

Creating a role assignment at subscription scope needs `Microsoft.Authorization/roleAssignments/write` there — Owner or User Access Administrator. A deploy identity that is only Contributor on the subscription will get an ARM authorization error on the grant, not on the role lookup.

Follows #552 and closes out the design in #326.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Azure policy assignments support individual scopes using `ROLE@SCOPE` syntax.
  - Policies can target the resource group, subscription, or a specific Azure resource.
  - Role assignments retain the project’s service identity across scopes.
  - AWS and Google Cloud policies now accept provider-specific formats and normalization.

- **Validation**
  - Invalid policy identifiers, scopes, and unresolved variables are rejected with provider-specific guidance.
  - Unsupported cross-cloud policy formats continue to be rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->